### PR TITLE
Revert software version pattern

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ smaht-portal
 Change Log
 ----------
 
+0.11.2
+======
+
+* Broaden software version pattern pending further discussion with bioinformatics.
+
+
 0.11.1
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.11.1"
+version = "0.11.2"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/software.json
+++ b/src/encoded/schemas/software.json
@@ -112,6 +112,10 @@
                 ]
             }
         },
+        "version": {
+            "pattern": ".+",
+            "comment": "TODO: Replace with a proper version pattern"
+        },
         "binary_url": {
             "$merge": "encoded_core:schemas/software.json#/properties/binary_url"
         },

--- a/src/encoded/tests/test_types_software.py
+++ b/src/encoded/tests/test_types_software.py
@@ -1,0 +1,43 @@
+from typing import Any, Dict
+
+import pytest
+from webtest.app import TestApp
+
+from .utils import patch_item, post_item
+
+
+@pytest.fixture
+def software(
+    testapp: TestApp, test_submission_center: Dict[str, Any]
+) -> Dict[str, Any]:
+    item = {
+        "aliases": ["test:software"],
+        "category": ["Alignment"],
+        "version": "1.0.0",
+        "title": "test software",
+        "name": "test_software",
+        "submission_centers": [test_submission_center["uuid"]],
+    }
+    return post_item(testapp, item, "Software")
+
+
+@pytest.mark.parametrize(
+    "version,expected_status",
+    [
+        ("", 422),
+        ("w", 200),
+        ("1.0.0", 200),
+        ("1.0.0-alpha", 200),
+        ("v2.2.2", 200),
+        ("abcdefg", 200),
+    ],
+)
+def test_version_pattern(
+    version: str,
+    expected_status: int,
+    testapp: TestApp,
+    software: Dict[str, Any],
+) -> None:
+    """Test that the version field is validated by the pattern regex."""
+    patch_body = {"version": version}
+    patch_item(testapp, patch_body, software["uuid"], status=expected_status)


### PR DESCRIPTION
Apply a broader regex for the software version for now. Will need to rethink the strategy here with bioinformatics and apply a more restrictive regex later on.