### PR TITLE
More QC value types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ smaht-portal
 Change Log
 ----------
 
+0.11.5
+======
+
+`PR 48: More QC value types <https://github.com/smaht-dac/smaht-portal/pull/48>`_
+* Allow any non-object JSON type for QC values instead of just strings
+
+
 0.11.4
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.11.4"
+version = "0.11.5"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/quality_metric.json
+++ b/src/encoded/schemas/quality_metric.json
@@ -101,7 +101,14 @@
                         "$merge": "encoded_core:schemas/quality_metric_generic.json#/properties/qc_values/items/properties/key"
                     },
                     "value": {
-                        "$merge": "encoded_core:schemas/quality_metric_generic.json#/properties/qc_values/items/properties/value"
+                        "$merge": "encoded_core:schemas/quality_metric_generic.json#/properties/qc_values/items/properties/value",
+                        "type": [
+                            "array",
+                            "boolean",
+                            "float",
+                            "number",
+                            "string"
+                        ]
                     },
                     "visible": {
                         "$merge": "encoded_core:schemas/quality_metric_generic.json#/properties/qc_values/items/properties/visible"

--- a/src/encoded/schemas/quality_metric.json
+++ b/src/encoded/schemas/quality_metric.json
@@ -105,7 +105,7 @@
                         "type": [
                             "array",
                             "boolean",
-                            "float",
+                            "integer",
                             "number",
                             "string"
                         ]

--- a/src/encoded/tests/data/workbook-inserts/quality_metric.json
+++ b/src/encoded/tests/data/workbook-inserts/quality_metric.json
@@ -14,6 +14,27 @@
                 "value": "bar",
                 "flag": "Pass",
                 "tooltip": "Description of how foo was derived"
+            },
+            {
+                "key": "bar",
+                "value": 25
+            },
+            {
+                "key": "fu",
+                "value": 252.4
+            },
+            {
+                "key": "bur",
+                "value": false
+            },
+            {
+                "key": "baz",
+                "value": [
+                    "foo",
+                    5,
+                    true,
+                    -3.5
+                ]
             }
         ]
     }


### PR DESCRIPTION
Allow any non-object JSON type for QC values instead of just strings.