### PR TITLE
Culture Mixture Parent Types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Change Log
 0.13.1
 ======
 
+`PR 58: Culture mixture parent types <https://github.com/smaht-dac/smaht-portal/pull/58>`_
 * Include CellCulture as parent item of CellCultureMixture for resolving reference during submissions
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,12 @@ Change Log
 ----------
 
 
+0.13.1
+======
+
+* Include CellCulture as parent item of CellCultureMixture for resolving reference during submissions
+
+
 0.13.0
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.13.0"
+version = "0.13.1"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/tests/test_types_cell_culture.py
+++ b/src/encoded/tests/test_types_cell_culture.py
@@ -9,4 +9,6 @@ def test_submitted_id_resource_path(es_testapp: TestApp, workbook: None) -> None
     """Ensure submitted_id is resource path for cell culture within
     SampleSource collection.
     """
-    get_item(es_testapp, "TEST_CELL-CULTURE_HELA", collection="SampleSource", status=301)
+    get_item(
+        es_testapp, "TEST_CELL-CULTURE_HELA", collection="SampleSource", status=301
+    )

--- a/src/encoded/tests/test_types_cell_culture_mixture.py
+++ b/src/encoded/tests/test_types_cell_culture_mixture.py
@@ -1,0 +1,23 @@
+import pytest
+from webtest import TestApp
+
+from .utils import get_item
+
+
+@pytest.mark.workbook
+def test_submitted_id_resource_path(es_testapp: TestApp, workbook: None) -> None:
+    """Ensure submitted_id is resource path for cell culture within
+    SampleSource and CellCulture collections.
+    """
+    get_item(
+        es_testapp,
+        "TEST_CELL-CULTURE-MIX_HELA-HEK293",
+        collection="SampleSource",
+        status=301,
+    )
+    get_item(
+        es_testapp,
+        "TEST_CELL-CULTURE-MIX_HELA-HEK293",
+        collection="CellCulture",
+        status=301,
+    )

--- a/src/encoded/types/cell_culture_mixture.py
+++ b/src/encoded/types/cell_culture_mixture.py
@@ -14,4 +14,5 @@ from .cell_culture import CellCulture
 class CellCultureMixture(CellCulture):
     item_type = "cell_culture_mixture"
     schema = load_schema("encoded:schemas/cell_culture_mixture.json")
+    base_types = ["CellCulture"] + CellCulture.base_types
     embedded_list = []


### PR DESCRIPTION
Here, we explicitly add the CellCulture type as a parent type to the CellCultureMixture type to enable reference resolution during data submission.

Created a ticket to add tests for this generally across all item types to prevent future bugs, but need this fix to submit data in the meantime.