### PR TITLE
Bm nav edits

### DIFF
--- a/src/encoded/static/components/navigation/components/BigDropdown/BigDropdownPageTreeMenu.js
+++ b/src/encoded/static/components/navigation/components/BigDropdown/BigDropdownPageTreeMenu.js
@@ -171,6 +171,7 @@ export function BigDropdownPageTreeMenu(props) {
     return (
         <div className={cls}>
             {topLeftMenuCol}
+            <CustomStaticLinks {...{ pathName, href }} />
             {childItems}
         </div>
     );
@@ -191,4 +192,96 @@ function Level1Title({ childPageItem, active }) {
             </a>
         </div>
     );
+}
+
+function CustomStaticLinks({ pathName, href }) {
+    console.log('href, pathName', href, pathName, href.includes(pathName));
+    switch (pathName) {
+        case 'data':
+            return (
+                <div className="help-menu-tree level-1 col-12 col-md-6 col-lg-8 has-children">
+                    <div
+                        className={`level-1-title-container ${
+                            href.includes(pathName + '/benchmarking')
+                                ? ' active'
+                                : ''
+                        }`}>
+                        <div className="level-1-title text-medium">
+                            Benchmarking Data
+                        </div>
+                    </div>
+                    <div className="row">
+                        <div className="level-2 col-12 col-md-6">
+                            <div className="level-2-title-container my-1">
+                                <div className="level-2-title text-medium text-600">
+                                    Cell Lines
+                                </div>
+                            </div>
+
+                            <div className="level-3">
+                                <a
+                                    className="level-3-title text-small d-block"
+                                    href="/data/benchmarking/COLO829"
+                                    id="menutree-linkto-colo829_page">
+                                    <span>COLO829</span>
+                                </a>
+                                <a
+                                    className="level-3-title text-small d-block"
+                                    href="/data/benchmarking/HapMap#main"
+                                    id="menutree-linkto-hapmap_page">
+                                    <span>HapMap</span>
+                                </a>
+                                <a
+                                    className="level-3-title text-small d-block"
+                                    href="/data/benchmarking/iPSC-fibroblasts#main"
+                                    id="menutree-linkto-ipscfirbro_page">
+                                    <span>iPSc and Fibroblasts</span>
+                                </a>
+                            </div>
+                        </div>
+                        <div className="level-2 col-12 col-md-6 mt-md-0 mt-1">
+                            <div className="level-2-title-container my-1">
+                                <div className="level-2-title text-medium text-600">
+                                    Primary Tissues
+                                </div>
+                            </div>
+                            <div className="level-3">
+                                <a
+                                    className="level-3-title text-small d-block"
+                                    href="/data/benchmarking/brain"
+                                    id="menutree-linkto-brain_page">
+                                    <span>Brain</span>
+                                </a>
+                                <a
+                                    className="level-3-title text-small d-block"
+                                    href="/data/benchmarking/skin"
+                                    id="menutree-linkto-skin_page">
+                                    <span>Skin</span>
+                                </a>
+                                <a
+                                    className="level-3-title text-small d-block"
+                                    href="/data/benchmarking/lung"
+                                    id="menutree-linkto-lung_page">
+                                    <span>Lung</span>
+                                </a>
+                                <a
+                                    className="level-3-title text-small d-block"
+                                    href="/data/benchmarking/colon"
+                                    id="menutree-linkto-colon_page">
+                                    <span>Colon</span>
+                                </a>
+                                <a
+                                    className="level-3-title text-small d-block"
+                                    href="/data/benchmarking/heart"
+                                    id="menutree-linkto-heart_page">
+                                    <span>Heart</span>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            );
+        default:
+            return null;
+    }
 }

--- a/src/encoded/static/components/navigation/components/BigDropdown/BigDropdownPageTreeMenu.js
+++ b/src/encoded/static/components/navigation/components/BigDropdown/BigDropdownPageTreeMenu.js
@@ -13,6 +13,7 @@ import { BigDropdownIntroductionWrapper } from './BigDropdownIntroductionWrapper
 
 export function BigDropdownPageTreeMenuIntroduction(props) {
     const {
+        linkToTopLevelDirPage = true,
         menuTree,
         windowHeight,
         windowWidth,
@@ -32,7 +33,11 @@ export function BigDropdownPageTreeMenuIntroduction(props) {
         <BigDropdownIntroductionWrapper
             {...{ windowHeight, windowWidth, titleIcon, isActive }}>
             <h4 className="mt-0 mb-0">
-                <a href={'/' + pathName}>{display_title}</a>
+                {linkToTopLevelDirPage ? (
+                    <a href={'/' + pathName}>{display_title}</a>
+                ) : (
+                    display_title
+                )}
             </h4>
             {description ? (
                 <div className="description">{description}</div>
@@ -43,7 +48,11 @@ export function BigDropdownPageTreeMenuIntroduction(props) {
 
 export function BigDropdownPageTreeMenu(props) {
     const { menuTree, href } = props;
-    const { display_title, identifier: pathName, children = [] } = menuTree || {};
+    const {
+        display_title,
+        identifier: pathName,
+        children = [],
+    } = menuTree || {};
 
     if (!pathName || !display_title) return null;
 
@@ -90,7 +99,8 @@ export function BigDropdownPageTreeMenu(props) {
                     (!hasLevel2Children ? ' col-lg-8' : ' col-lg-4')
                 }>
                 {level1ChildrenWithoutSubChildren.map(function (child) {
-                    const active = urlParts.pathname.indexOf(child.identifier) > -1;
+                    const active =
+                        urlParts.pathname.indexOf(child.identifier) > -1;
                     return (
                         <Level1Title
                             childPageItem={child}

--- a/src/encoded/static/components/navigation/components/CollapsedNav.js
+++ b/src/encoded/static/components/navigation/components/CollapsedNav.js
@@ -82,7 +82,10 @@ function AboutNavItem(props) {
                 id="about-menu-item"
                 navItemHref="/about"
                 navItemContent="About">
-                <BigDropdownPageTreeMenuIntroduction titleIcon="info-circle fas" />
+                <BigDropdownPageTreeMenuIntroduction
+                    titleIcon="info-circle fas"
+                    linkToTopLevelDirPage={false}
+                />
                 <BigDropdownPageTreeMenu />
             </BigDropdownNavItem>
         </BigDropdownPageLoader>
@@ -99,7 +102,10 @@ function DocsNavItem(props) {
                 id="docs-menu-item"
                 navItemHref="/docs"
                 navItemContent="Documentation">
-                <BigDropdownPageTreeMenuIntroduction titleIcon="book fas" />
+                <BigDropdownPageTreeMenuIntroduction
+                    titleIcon="book fas"
+                    linkToTopLevelDirPage={false}
+                />
                 <BigDropdownPageTreeMenu />
             </BigDropdownNavItem>
         </BigDropdownPageLoader>
@@ -116,7 +122,10 @@ function DataNavItem(props) {
                 id="data-menu-item"
                 navItemHref="/data"
                 navItemContent="Data">
-                <BigDropdownPageTreeMenuIntroduction titleIcon="database fas" />
+                <BigDropdownPageTreeMenuIntroduction
+                    titleIcon="database fas"
+                    linkToTopLevelDirPage={false}
+                />
                 <BigDropdownPageTreeMenu />
             </BigDropdownNavItem>
         </BigDropdownPageLoader>

--- a/src/encoded/static/scss/encoded/modules/_navbar.scss
+++ b/src/encoded/static/scss/encoded/modules/_navbar.scss
@@ -1014,20 +1014,14 @@ body[data-current-action="multiselect"] {
                             margin-top: 0;
                             margin-bottom: 4px;
                             > .level-1-title {
-                                //border: 1px solid transparent;
                                 display: inline-block;
                                 color: #333;
                                 color: #fff;
                                 font-weight: 500;
                                 padding: 8px 0 6px 0;
-                                //margin-left: -12px;
-                                //margin-right: -11px;
                                 border-radius: 2px;
-                                //margin-bottom: -1px;
-                                &:hover {
-                                    border-color: #5d8a8e; 
-                                    //background-color: #e7e7e7;
-                                    //color: #fff;
+                                &:not(div):hover {
+                                    border-color: #5d8a8e;
                                     text-decoration: none;
                                     color: #2DB3FF; 
                                     text-shadow: 0 0 0;
@@ -1102,31 +1096,34 @@ body[data-current-action="multiselect"] {
                                 background-color: #2db3ff87;
                             }
                         }
-    
-                    }
-
-                    /*
-                    &.no-level-2-children {
-                        > .help-menu-tree.level-1-no-child-links {
-
-                            > .level-1-title-container {
+                        
+                        // Really only used for Data nav item ATM
+                        // TODO: make more specific in case styles are needed elsewhere
+                        .level-2 {
+                            .level-2-title-container {
+                                margin-top: 0;
                                 margin-bottom: 0;
-                                border-top-color: #5d5d5d;
-                                border-bottom: none;
-                                &:not(:first-child) {
-                                    border-top-width: 1px;
-                                    border-top-style: solid;
-                                }
-                                > a.level-1-title {
-                                    padding-top: 7px;
-                                    padding-bottom: 7px;
+                            }
+                            .level-3 {
+                                .level-3-title {
+                                    display: inline-block;
+                                    color: #333;
+                                    color: #fff;
+                                    padding: 4px 0 4px 10px;
+                                    border-radius: 2px;
+                                    &:hover {
+                                        background-color: #2db3ff91;
+                                        color: #fff;
+                                        text-decoration: none;
+                                    }
+                                    > * {
+                                        vertical-align: middle;
+                                    }
                                 }
                             }
-
                         }
+    
                     }
-                    */
-
                 }
 
                 @media screen and (min-width: 1600px) {

--- a/src/encoded/tests/data/master-inserts/page.json
+++ b/src/encoded/tests/data/master-inserts/page.json
@@ -344,9 +344,7 @@
         "identifier": "data",
         "title": "Data",
         "status": "public",
-        "children": [
-            "39deafe0-34ae-4ab8-8261-3661b0c79a38"
-        ],
+        "children": [],
         "table-of-contents": {
             "enabled": true,
             "header-depth": 4


### PR DESCRIPTION
### Changelog:
- Disabled links to top-level navigation/directory pages
- Added a new static, custom menu for benchmarking data to Data navbar
  - Removed benchmarking data page as child insert of data page
  - To add other data groups (like "Other Data" in screenshots below), add those as children to data page

### Screenshots:
Desktop
[![Image from Gyazo](https://i.gyazo.com/48382239c9f10365085c88c4e4562fac.gif)](https://gyazo.com/48382239c9f10365085c88c4e4562fac)
Tablet
[![Image from Gyazo](https://i.gyazo.com/8593f2bb8cbcb698cfde0b024f90b8ef.png)](https://gyazo.com/8593f2bb8cbcb698cfde0b024f90b8ef)
Mobile
[![Image from Gyazo](https://i.gyazo.com/6a0c58b6fb81f4fca06ad56b15c7343d.png)](https://gyazo.com/6a0c58b6fb81f4fca06ad56b15c7343d)