### PR TITLE
Add peak-metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ smaht-portal
 Change Log
 ----------
 
+0.16.0
+======
+
+* Adds `/peak-metadata` support for retrieving facet information from the metadata.tsv
+
 
 0.15.0
 ======
@@ -35,7 +40,7 @@ Change Log
 
 `PR 56: Implement submittable item API <https://github.com/smaht-dac/smaht-portal/pull/56>`_
 * Add functionality and tests for submittable item api to smaht portal
-* update lockfile with latest snovault that contains the primitive for this 
+* update lockfile with latest snovault that contains the primitive for this
 
 
 0.12.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.15.0"
+version = "0.16.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/metadata.py
+++ b/src/encoded/metadata.py
@@ -158,7 +158,7 @@ def handle_metadata_arguments(context, request):
         return Response("Invalid parameters", status=400)
 
     if download_file_name is None:
-        download_file_name = 'metadata_' + datetime.utcnow().strftime('%Y-%m-%d-%Hh-%Mm') + '.tsv'
+        download_file_name = 'smaht_manifest_' + datetime.utcnow().strftime('%Y-%m-%d-%Hh-%Mm') + '.tsv'
 
     # Generate a header, resolve mapping
     # Note that this will become more complex as we add additional header types

--- a/src/encoded/metadata.py
+++ b/src/encoded/metadata.py
@@ -65,6 +65,8 @@ TSV_MAPPING = {
                                            field_name=['href']),
         'File Accession': TSVDescriptor(field_type=FILE,
                                         field_name=['accession']),
+        'File Name': TSVDescriptor(field_type=FILE,
+                                   field_name=['annotated_filename']),
         'Size (MB)': TSVDescriptor(field_type=FILE,
                                    field_name=['file_size']),
         'md5sum': TSVDescriptor(field_type=FILE,
@@ -79,10 +81,10 @@ TSV_MAPPING = {
 
 def generate_file_download_header(download_file_name: str):
     """ Helper function that generates a suitable header for the File download """
-    header1 = ['###', 'Metadata TSV Download', '', '', '', '']
+    header1 = ['###', 'Metadata TSV Download', '', '', '', '', '']
     header2 = ['Suggested command to download: ', '', '',
                'cut -f 1 ./{} | tail -n +3 | grep -v ^# | xargs -n 1 curl -O -L '
-               '--user <access_key_id>:<access_key_secret>'.format(download_file_name), '', '']
+               '--user <access_key_id>:<access_key_secret>'.format(download_file_name), '', '', '']
     header3 = list(TSV_MAPPING[FILE].keys())
     return header1, header2, header3
 
@@ -157,6 +159,7 @@ def handle_metadata_arguments(context, request):
 @view_config(route_name='peak_metadata', request_method=['GET', 'POST'])
 @debug_log
 def peak_metadata(context, request):
+    """ Helper for the UI that will retrieve faceting information about data retrieved from /metadata """
     # get arguments from helper
     (accessions, sort_param, type_param, include_extra_files, download_file_name,
      header, tsv_mapping) = handle_metadata_arguments(context, request)
@@ -172,6 +175,8 @@ def peak_metadata(context, request):
     if sort_param:
         search_param['sort'] = sort_param
     search_param['limit'] = [1]  # we don't care about results, just the facets
+    if include_extra_files:
+        search_param['additional_facet'] = 'extra_files.file_size'
     subreq = make_search_subreq(request, '{}?{}'.format('/search', urlencode(search_param, True)), inherit_user=True)
     result = search(context, subreq)
     return result['facets']

--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -142,6 +142,24 @@
             "type": "string"
         }
     },
-    "facets": {},
+    "facets": {
+        "file_size": {
+            "title": "File Size",
+            "description": "Filter using range of size of the file",
+            "aggregation_type": "stats",
+            "increments": [
+                1024,
+                10240,
+                1048576,
+                10485760,
+                104857600,
+                1073741824,
+                10737418240,
+                107374182400
+            ],
+            "disabled": false,
+            "comment": "disabled flag may be removed once we (a) can handle ?field=val1-to-val2 (ranges) in filters and (b) send ranges from FacetList to search URI."
+        }
+    },
     "columns": {}
 }

--- a/src/encoded/tests/data/workbook-inserts/aligned_reads.json
+++ b/src/encoded/tests/data/workbook-inserts/aligned_reads.json
@@ -16,6 +16,7 @@
         "file_sets": [
             "TEST_FILE-SET_LIVER"
         ],
-        "reference_genome": "GRCh38"
+        "reference_genome": "GRCh38",
+        "file_size": 1000
     }
 ]

--- a/src/encoded/tests/data/workbook-inserts/file_format.json
+++ b/src/encoded/tests/data/workbook-inserts/file_format.json
@@ -15,7 +15,8 @@
         "identifier": "BAM",
         "standard_file_extension": "bam",
 		"extra_file_formats": [
-			"BAI"
+			"BAI",
+            "VCF"
 		]
     },
     {

--- a/src/encoded/tests/data/workbook-inserts/output_file.json
+++ b/src/encoded/tests/data/workbook-inserts/output_file.json
@@ -15,6 +15,7 @@
         ],
         "consortia": [
             "smaht"
-        ]
+        ],
+        "file_size": 5000
     }
 ]

--- a/src/encoded/tests/data/workbook-inserts/output_file.json
+++ b/src/encoded/tests/data/workbook-inserts/output_file.json
@@ -10,12 +10,43 @@
         "file_format": "BAM",
         "extra_files": [
             {
+                "filename": "a_bam_bai.bai",
+                "file_size": 3000,
+                "status": "uploaded",
                 "file_format": "BAI"
+            },
+            {
+                "filename": "a_vcf.vcf",
+                "file_size": 5000,
+                "status": "uploaded",
+                "file_format": "VCF"
             }
         ],
         "consortia": [
             "smaht"
         ],
         "file_size": 5000
+    },
+    {
+        "uuid": "cca15caa-bc11-4a6a-8998-ea0c69df8b9e",
+        "data_category": [
+            "Sequencing Reads"
+        ],
+        "data_type": [
+            "Aligned Reads"
+        ],
+        "file_format": "BAM",
+        "extra_files": [
+            {
+                "filename": "a_second_bam_bai.bai",
+                "file_size": 6000,
+                "status": "uploaded",
+                "file_format": "BAI"
+            }
+        ],
+        "consortia": [
+            "smaht"
+        ],
+        "file_size": 10000
     }
 ]

--- a/src/encoded/tests/data/workbook-inserts/reference_file.json
+++ b/src/encoded/tests/data/workbook-inserts/reference_file.json
@@ -15,6 +15,7 @@
         ],
         "consortia": [
             "smaht"
-        ]
+        ],
+        "file_size": 8000
     }
 ]

--- a/src/encoded/tests/data/workbook-inserts/unaligned_reads.json
+++ b/src/encoded/tests/data/workbook-inserts/unaligned_reads.json
@@ -16,6 +16,7 @@
         "file_sets": [
             "TEST_FILE-SET_LIVER"
         ],
-        "read_pair_number": "R1"
+        "read_pair_number": "R1",
+        "file_size": 10000
     }
 ]

--- a/src/encoded/tests/data/workbook-inserts/variant_calls.json
+++ b/src/encoded/tests/data/workbook-inserts/variant_calls.json
@@ -19,6 +19,7 @@
         "reference_genome": "GRCh38",
         "variant_type": [
             "Single Nucleotide Variant"
-        ]
+        ],
+        "file_size": 100000
     }
 ]

--- a/src/encoded/tests/test_metadata_tsv_workbook.py
+++ b/src/encoded/tests/test_metadata_tsv_workbook.py
@@ -61,7 +61,7 @@ class TestMetadataTSVWorkbook:
         """ Tests we can peak at metadata for files and get facet information (just file size for now) """
         es_testapp.post_json('/index', {})  # index the files
         # check all types
-        res = es_testapp.post_json('/peak-metadata/',
+        res = es_testapp.post_json('/peek-metadata/',
                                    {'type': 'File', 'include_extra_files': False}).json
         for facet in res:
             if facet['field'] == 'file_size':
@@ -72,7 +72,7 @@ class TestMetadataTSVWorkbook:
             if facet['field'] == 'extra_files.file_size':
                 raise AssertionError('Extra files information present when not desired')
         # check an individual type (with extra files)
-        res = es_testapp.post_json('/peak-metadata/',
+        res = es_testapp.post_json('/peek-metadata/',
                                    {'type': 'OutputFile', 'include_extra_files': True}).json
         for facet in res:
             if facet['field'] == 'extra_files.file_size':

--- a/src/encoded/tests/test_metadata_tsv_workbook.py
+++ b/src/encoded/tests/test_metadata_tsv_workbook.py
@@ -5,7 +5,7 @@ import csv
 
 class TestMetadataTSVHelper:
 
-    TSV_WIDTH = 6
+    TSV_WIDTH = 7
 
     @staticmethod
     def read_tsv_from_bytestream(bytestream):
@@ -48,37 +48,40 @@ class TestMetadataTSVWorkbook:
         TestMetadataTSVHelper.check_key_and_length(header1, 'Metadata TSV Download')
         TestMetadataTSVHelper.check_key_and_length(header2, 'Suggested command to download: ')
         TestMetadataTSVHelper.check_key_and_length(header3, 'File Download URL')
-        assert len(parsed[3:]) == 7  # there are 7 entries in the workbook right now
+        assert len(parsed[3:]) == 10  # there are 10 entries in the workbook right now, including extra files
         # test for various types
         TestMetadataTSVHelper.check_type_length(es_testapp, 'AlignedReads', 1)
         TestMetadataTSVHelper.check_type_length(es_testapp, 'UnalignedReads', 1)
         TestMetadataTSVHelper.check_type_length(es_testapp, 'VariantCalls', 1)
         TestMetadataTSVHelper.check_type_length(es_testapp, 'ReferenceFile', 1)
         TestMetadataTSVHelper.check_type_length(es_testapp, 'UnalignedReads', 1)
-        TestMetadataTSVHelper.check_type_length(es_testapp, 'OutputFile', 1)
+        TestMetadataTSVHelper.check_type_length(es_testapp, 'OutputFile', 2)
 
     def test_peak_metadata_workbook(self, workbook, es_testapp):
         """ Tests we can peak at metadata for files and get facet information (just file size for now) """
         es_testapp.post_json('/index', {})  # index the files
         # check all types
         res = es_testapp.post_json('/peak-metadata/',
-                                   {'type': 'File', 'include_extra_files': True}).json
+                                   {'type': 'File', 'include_extra_files': False}).json
         for facet in res:
             if facet['field'] == 'file_size':
-                assert facet['count'] == 5
+                assert facet['count'] == 6
                 assert facet['min'] == 1000.0
                 assert facet['max'] == 100000.0
-                assert facet['avg'] == 24800.0
-                assert facet['sum'] == 124000.0
-            break
-        # check an individual type
+                assert facet['sum'] == 134000.0
+            if facet['field'] == 'extra_files.file_size':
+                raise AssertionError('Extra files information present when not desired')
+        # check an individual type (with extra files)
         res = es_testapp.post_json('/peak-metadata/',
-                                   {'type': 'AlignedReads', 'include_extra_files': True}).json
+                                   {'type': 'OutputFile', 'include_extra_files': True}).json
         for facet in res:
+            if facet['field'] == 'extra_files.file_size':
+                assert facet['count'] == 3  # 2 + 1 extra files
+                assert facet['min'] == 3000.0
+                assert facet['max'] == 6000.0
+                assert facet['sum'] == 14000.0
             if facet['field'] == 'file_size':
-                assert facet['count'] == 1
-                assert facet['min'] == 1000.0
-                assert facet['max'] == 1000.0
-                assert facet['avg'] == 1000.0
-                assert facet['sum'] == 1000.0
-            break
+                assert facet['count'] == 2
+                assert facet['min'] == 5000.0
+                assert facet['max'] == 10000.0
+                assert facet['sum'] == 15000.0

--- a/src/encoded/tests/test_metadata_tsv_workbook.py
+++ b/src/encoded/tests/test_metadata_tsv_workbook.py
@@ -56,3 +56,29 @@ class TestMetadataTSVWorkbook:
         TestMetadataTSVHelper.check_type_length(es_testapp, 'ReferenceFile', 1)
         TestMetadataTSVHelper.check_type_length(es_testapp, 'UnalignedReads', 1)
         TestMetadataTSVHelper.check_type_length(es_testapp, 'OutputFile', 1)
+
+    def test_peak_metadata_workbook(self, workbook, es_testapp):
+        """ Tests we can peak at metadata for files and get facet information (just file size for now) """
+        es_testapp.post_json('/index', {})  # index the files
+        # check all types
+        res = es_testapp.post_json('/peak-metadata/',
+                                   {'type': 'File', 'include_extra_files': True}).json
+        for facet in res:
+            if facet['field'] == 'file_size':
+                assert facet['count'] == 5
+                assert facet['min'] == 1000.0
+                assert facet['max'] == 100000.0
+                assert facet['avg'] == 24800.0
+                assert facet['sum'] == 124000.0
+            break
+        # check an individual type
+        res = es_testapp.post_json('/peak-metadata/',
+                                   {'type': 'AlignedReads', 'include_extra_files': True}).json
+        for facet in res:
+            if facet['field'] == 'file_size':
+                assert facet['count'] == 1
+                assert facet['min'] == 1000.0
+                assert facet['max'] == 1000.0
+                assert facet['avg'] == 1000.0
+                assert facet['sum'] == 1000.0
+            break


### PR DESCRIPTION
- Adds a new endpoint `/peek-metadata` that takes the same args as `/metadata` but returns the facet dictionary (currently just file size)