### PR TITLE
Add lifecycle properties to File schema

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ smaht-portal
 Change Log
 ----------
 
+0.21.2
+======
+
+* Add lifecycle properties to File schema
+
 0.21.1
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.21.0"
+version = "0.21.1b0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.21.1"
+version = "0.21.2"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -153,6 +153,26 @@
             "type": "string",
             "linkTo": "SubmissionCenter",
             "permission": "restricted_fields"
+        },
+        "s3_lifecycle_category": {
+            "$merge": "encoded_core:schemas/file.json#/properties/s3_lifecycle_category",
+            "suggested_enum": [],
+            "enum": [
+                "ignore",
+                "long_term_access",
+                "long_term_access_long_term_archive",
+                "long_term_archive",
+                "no_storage",
+                "short_term_access",
+                "short_term_access_long_term_archive",
+                "short_term_archive"
+            ]
+        },
+        "s3_lifecycle_last_checked": {
+            "$merge": "encoded_core:schemas/file.json#/properties/s3_lifecycle_last_checked"
+        },
+        "s3_lifecycle_status": {
+            "$merge": "encoded_core:schemas/file.json#/properties/s3_lifecycle_status"
         }
     },
     "facets": {

--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -155,8 +155,8 @@
             "permission": "restricted_fields"
         },
         "s3_lifecycle_category": {
-            "$merge": "encoded_core:schemas/file.json#/properties/s3_lifecycle_category",
-            "suggested_enum": [],
+            "description": "The lifecycle category determines how long a file remains in a certain storage class.  If set to ignore, lifecycle management will have no effect on this file",
+            "permission": "restricted_fields",
             "enum": [
                 "ignore",
                 "long_term_access",
@@ -166,7 +166,9 @@
                 "short_term_access",
                 "short_term_access_long_term_archive",
                 "short_term_archive"
-            ]
+            ],
+            "title": "S3 Lifecycle Category",
+            "type": "string"
         },
         "s3_lifecycle_last_checked": {
             "$merge": "encoded_core:schemas/file.json#/properties/s3_lifecycle_last_checked"


### PR DESCRIPTION
Taking `s3_lifecycle_category` from encoded_core and setting `suggested_enum=[]` messed up up the File edit UI. That's why I am just duplicating it here.