### PR TITLE
Derived From LinkTo

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ smaht-portal
 Change Log
 ----------
 
+0.21.3
+======
+
+* Update `derived_from` linkTo from File to SubmittedFile
+
+
 0.21.2
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.21.2"
+version = "0.21.3"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/mixins.json
+++ b/src/encoded/schemas/mixins.json
@@ -248,7 +248,7 @@
             "uniqueItems": true,
             "items": {
                 "type": "string",
-                "linkTo": "File"
+                "linkTo": "SubmittedFile"
             }
         },
         "file_sets": {


### PR DESCRIPTION
Here, we update the `derived_from` linkTo to point to SubmittedFiles instead of Files so a submitted file's `submitted_id` can be used as a reference.