### PR TITLE
Repair test namespacing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ smaht-portal
 Change Log
 ----------
 
+0.21.6
+======
+
+* Repair test namespacing in unit tests
+
+
 0.21.5
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.21.5"
+version = "0.21.6"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/tests/conftest.py
+++ b/src/encoded/tests/conftest.py
@@ -410,10 +410,10 @@ class WorkbookCache:
         # As an update to Kent's comment above, not sure it's a timing error
         # as much as it's just not indexing long enough to get everything in...
         # Adding the loop below should fix that - Will Feb 9 2024
-        testapp.post_json('/index', {})
+        testapp.post_json('/index', {'record': True})
         counts_total = testapp.get('/counts').json['db_es_total']
         while 'more items' in counts_total:  # this string is always present in uneven counts
-            testapp.post_json('/index', {})
+            testapp.post_json('/index', {'record': True})
             counts_total = testapp.get('/counts').json['db_es_total']
         return True
 

--- a/src/encoded/tests/conftest_settings.py
+++ b/src/encoded/tests/conftest_settings.py
@@ -1,11 +1,12 @@
 import os
+from random import randint
 
 
 REPOSITORY_ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
 
 
 _app_settings = {
-    "env.name": "smaht-testing",
+    "env.name": f"smaht-{randint(1000, 100000)}",
     "collection_datastore": "database",
     "item_datastore": "database",
     "multiauth.policies": "session remoteuser accesskey auth0",


### PR DESCRIPTION
- Namespace all env names in unit testing, to ensure no collisions across local deploys/test runs