### PR TITLE
Assay link change #1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ smaht-portal
 Change Log
 ----------
 
+0.30.2
+======
+
+* Add assay linkTo to library in preparation for future removal from current location on file set
+* Add anyOf requirement on sequencing for coverage or read count
+
+
 0.30.1
 ======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Change Log
 0.30.2
 ======
 
+`PR 112: Assay link change #1 <https://github.com/smaht-dac/smaht-portal/pull/112>`_
+
 * Add assay linkTo to library in preparation for future removal from current location on file set
 * Add anyOf requirement on sequencing for coverage or read count
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.30.1"
+version = "0.30.2"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -180,7 +180,7 @@
         "data_type": {
             "title": "Data Category"
         },
-        "file_sets.assay.display_title": {
+        "file_sets.libraries.assay.display_title": {
             "title": "Experimental Assay"
         },
         "file_sets.sequencing.sequencer.display_title": {
@@ -209,7 +209,7 @@
         "data_type": {
             "title": "Data Category"
         },
-        "file_sets.assay.display_title": {
+        "file_sets.libraries.assay.display_title": {
             "title": "Assay"
         },
         "file_sets.sequencing.sequencer.display_title": {

--- a/src/encoded/schemas/file_set.json
+++ b/src/encoded/schemas/file_set.json
@@ -89,7 +89,7 @@
         "submission_centers.display_title": {
             "title": "Submitted By"
         },
-        "assay.display_title": {
+        "libraries.assay.display_title": {
             "title": "Assay"
         },
         "sequencing.sequencer.display_title": {
@@ -103,7 +103,7 @@
         "submission_centers.display_title": {
             "title": "Submitted By"
         },
-        "assay.display_title": {
+        "libraries.assay.display_title": {
             "title": "Assay"
         },
         "sequencing.sequencer.display_title": {

--- a/src/encoded/schemas/library.json
+++ b/src/encoded/schemas/library.json
@@ -198,6 +198,9 @@
         "submission_centers.display_title": {
             "title": "Submitted By"
         },
+        "assay.display_title": {
+            "title": "Assay"
+        },
         "status": {
             "title": "Status"
         }
@@ -205,6 +208,9 @@
     "columns": {
         "submission_centers.display_title": {
             "title": "Submitted By"
+        },
+        "assay.display_title": {
+            "title": "Assay"
         }
     }
 }

--- a/src/encoded/schemas/library.json
+++ b/src/encoded/schemas/library.json
@@ -181,6 +181,12 @@
             "type": "string",
             "linkTo": "Analyte"
         },
+        "assay": {
+            "title": "Assay",
+            "description": "Link to associated assay",
+            "type": "string",
+            "linkTo": "Assay"
+        },
         "library_preparation": {
             "title": "Library Preparation",
             "description": "Link to associated library preparation",

--- a/src/encoded/schemas/sequencing.json
+++ b/src/encoded/schemas/sequencing.json
@@ -15,6 +15,18 @@
         "submitted_id",
         "uuid"
     ],
+    "anyOf": [
+        {
+            "required": [
+                "target_coverage"
+            ]
+        },
+        {
+            "required": [
+                "target_read_count"
+            ]
+        }
+    ],
     "additionalProperties": false,
     "mixinProperties": [
         {

--- a/src/encoded/tests/data/workbook-inserts/library.json
+++ b/src/encoded/tests/data/workbook-inserts/library.json
@@ -5,12 +5,13 @@
             "smaht"
         ],
         "submitted_id": "TEST_LIBRARY_LIVER",
-		"analyte": "TEST_ANALYTE_LIVER",
+        "analyte": "TEST_ANALYTE_LIVER",
         "a260_a280_ratio": 3.2,
         "amplification_cycles": 10,
         "analyte_weight": 5.4,
         "fragment_mean_length": 150.7,
         "insert_mean_length": 150.2,
-        "preparation_date": "2023-05-11"
+        "preparation_date": "2023-05-11",
+        "assay": "bulk_wgs"
     }
 ]

--- a/src/encoded/tests/test_schema_sequencing.py
+++ b/src/encoded/tests/test_schema_sequencing.py
@@ -1,0 +1,35 @@
+from typing import Any, Dict
+
+import pytest
+from webtest import TestApp
+
+from .utils import delete_field, get_item_from_search
+
+
+@pytest.mark.workbook
+@pytest.mark.parametrize(
+    "patch_body,delete_fields,expected_status",
+    [
+        ({}, "", 200),
+        ({"target_coverage": 200.0}, "target_read_count", 200),
+        ({"target_read_count": 200}, "target_coverage", 200),
+        ({"target_coverage": 200.0, "target_read_count": 200}, "", 200),
+        ({}, "target_coverage,target_read_count", 422),
+    ],
+)
+def test_any_of_requirements(
+    patch_body: Dict[str, Any],
+    delete_fields: str,
+    expected_status: int,
+    es_testapp: TestApp,
+    workbook: None,
+) -> None:
+    """Ensure anyOf requirements properly enforced."""
+    sequencing_item = get_item_from_search(es_testapp, "sequencing")
+    delete_field(
+        es_testapp,
+        sequencing_item["uuid"],
+        delete_fields,
+        patch_body=patch_body,
+        status=expected_status,
+    )

--- a/src/encoded/tests/utils.py
+++ b/src/encoded/tests/utils.py
@@ -254,7 +254,9 @@ def get_submitted_item_types(test_app: TestApp) -> Dict[str, TypeInfo]:
 
 def is_submitted_item(type_info: AbstractTypeInfo) -> bool:
     """Is type child of SubmittedItem?"""
-    return issubclass(type_info.factory, SubmittedItem) or issubclass(type_info.factory, SubmittedFile)
+    return issubclass(type_info.factory, SubmittedItem) or issubclass(
+        type_info.factory, SubmittedFile
+    )
 
 
 def get_all_item_types(
@@ -421,8 +423,7 @@ def get_item_properties_from_workbook_inserts(
 
 
 def clean_workbook_inserts(
-    workbook_inserts: Dict[str, Dict[str, Any]],
-    submission_center: Dict[str, Any]
+    workbook_inserts: Dict[str, Dict[str, Any]], submission_center: Dict[str, Any]
 ) -> Dict[str, Dict[str, Any]]:
     """Clean workbook inserts to only include submission center.
 
@@ -436,8 +437,7 @@ def clean_workbook_inserts(
 
 
 def replace_inserts_affiliations(
-    item_inserts: List[Dict[str, Any]],
-    submission_center: Dict[str, Any]
+    item_inserts: List[Dict[str, Any]], submission_center: Dict[str, Any]
 ) -> Dict[str, Any]:
     """Replace affiliations in item inserts with provided submission center."""
     return [
@@ -447,8 +447,7 @@ def replace_inserts_affiliations(
 
 
 def replace_insert_affiliations(
-    item_insert: Dict[str, Any],
-    submission_center: Dict[str, Any]
+    item_insert: Dict[str, Any], submission_center: Dict[str, Any]
 ) -> Dict[str, Any]:
     """If needed, replace affiliations in item insert with provided
     submission center.
@@ -467,9 +466,9 @@ def has_affiliations(item_insert: Dict[str, Any]) -> bool:
         ]
     )
 
+
 def replace_affiliations(
-    item_insert: Dict[str, Any],
-    submission_center: Dict[str, Any]
+    item_insert: Dict[str, Any], submission_center: Dict[str, Any]
 ) -> Dict[str, Any]:
     """Replace affiliations in item insert with provided submission center.
 
@@ -477,11 +476,13 @@ def replace_affiliations(
     assumption no longer holds.
     """
     insert_without_affiliation = {
-        key: value for key, value in item_insert.items()
+        key: value
+        for key, value in item_insert.items()
         if key not in ["submission_centers", "consortia"]
     }
     return {
-        **insert_without_affiliation, "submission_centers": [submission_center["uuid"]]
+        **insert_without_affiliation,
+        "submission_centers": [submission_center["uuid"]],
     }
 
 
@@ -554,10 +555,18 @@ def delete_field(
     test_app: TestApp,
     identifier: str,
     to_delete: str,
+    patch_body: Optional[Dict[str, Any]] = None,
     status: Union[int, List[int]] = 200,
 ) -> Dict[str, Any]:
     """Delete field from item with given identifier."""
     resource_path = get_formatted_resource_path(
         identifier, add_on=f"delete_fields={to_delete}"
     )
-    return patch_item(test_app, {}, resource_path, status=status)
+    return patch_item(test_app, patch_body or {}, resource_path, status=status)
+
+
+def get_item_from_search(test_app: TestApp, collection: str) -> Dict[str, Any]:
+    """Get workbook item for given collection via search."""
+    search_results = get_search(test_app, f"type={to_camel_case(collection)}")
+    assert search_results, f"No {collection} found in search results"
+    return search_results[0]

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -60,8 +60,7 @@ def show_upload_credentials(
 def _build_file_embedded_list() -> List[str]:
     """Embeds for search on files."""
     return [
-        "file_sets.assay",
-        "file_sets.libraries",
+        "file_sets.libraries.assay",
         "file_sets.sequencing.sequencer",
         "software.name",
     ]

--- a/src/encoded/types/file_set.py
+++ b/src/encoded/types/file_set.py
@@ -9,6 +9,7 @@ from .submitted_item import SubmittedItem
 def _build_file_set_embedded_list():
     """Embeds for search on file sets."""
     return [
+        "libraries.assay",
         "sequencing.sequencer.display_title",
     ]
 

--- a/src/encoded/types/library.py
+++ b/src/encoded/types/library.py
@@ -3,6 +3,13 @@ from snovault import collection, load_schema
 from .submitted_item import SubmittedItem
 
 
+def _build_library_embedded_list():
+    """Embeds for search on libraries."""
+    return [
+        "assay",
+    ]
+
+
 @collection(
     name="libraries",
     unique_key="submitted_id",
@@ -14,4 +21,4 @@ from .submitted_item import SubmittedItem
 class Library(SubmittedItem):
     item_type = "library"
     schema = load_schema("encoded:schemas/library.json")
-    embedded_list = []
+    embedded_list = _build_library_embedded_list()


### PR DESCRIPTION
This PR is the first of 2 designed to move the current location of the assay linkTo from file set to library.

Changes here include:

- Addition of assay link on library
- Updates to embeddings, columns, and facets to accommodate the move
- Unrelated addition of an anyOf requirement on sequencing items

The second PR to come will remove the linkTo and its requirement on file set and add as a requirement to library once this PR has been merged/deployed and relevant metadata updates are made on all accounts.