### PR TITLE
Add parent samples to TissueSample

### DIFF
--- a/src/encoded/schemas/cell_sample.json
+++ b/src/encoded/schemas/cell_sample.json
@@ -35,6 +35,9 @@
             "$ref": "mixins.json#/modified"
         },
         {
+            "$ref": "mixins.json#/parent_samples"
+        },
+        {
             "$ref": "mixins.json#/protocols"
         },
         {
@@ -76,25 +79,14 @@
         "schema_version": {
             "default": "1"
         },
+        "submitted_id": {
+            "pattern": "^[A-Z0-9]{3,}_CELL-SAMPLE_[A-Z0-9-_.]{4,}$"
+        },
         "cell_ontology_id": {
             "title": "Cell Ontology ID",
             "description": "Cell Ontology identifier for the cell sample",
             "type": "string",
             "pattern": "^CL:[0-9]{7}$"
-        },
-        "parent_samples": {
-            "title": "Parent Samples",
-            "desscription": "Samples from which the cells were isolated",
-            "type": "array",
-            "minItems": 1,
-            "uniqueItems": true,
-            "items": {
-                "type": "string",
-                "linkTo": "Sample"
-            }
-        },
-        "submitted_id": {
-            "pattern": "^[A-Z0-9]{3,}_CELL-SAMPLE_[A-Z0-9-_.]{4,}$"
         }
     }
 }

--- a/src/encoded/schemas/mixins.json
+++ b/src/encoded/schemas/mixins.json
@@ -675,6 +675,19 @@
             "linkTo": "OntologyTerm"
         }
     },
+    "parent_samples": {
+        "parent_samples": {
+            "title": "Parent Samples",
+            "description": "Link to associated parent samples",
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+                "type": "string",
+                "linkTo": "Sample"
+            }
+        }
+    },
     "protocols": {
         "protocols": {
             "title": "Protocols",

--- a/src/encoded/schemas/tissue_sample.json
+++ b/src/encoded/schemas/tissue_sample.json
@@ -33,6 +33,9 @@
             "$ref": "mixins.json#/modified"
         },
         {
+            "$ref": "mixins.json#/parent_samples"
+        },
+        {
             "$ref": "mixins.json#/protocols"
         },
         {


### PR DESCRIPTION
This PR moves the `parent_samples` property on CellSample to mixins and adds it to TissueSample items to enable submitters to specify which samples derive from which.