### PR TITLE
fix: HapMap description formatting / Access key button text update

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,16 @@ smaht-portal
 Change Log
 ----------
 
+0.44.1
+======
+
+`PR 151: fix: HapMap description formatting fix <https://github.com/smaht-dac/smaht-portal/pull/151>`_
+
+* Fixes formatting issue with HapMap description. Wraps p elements in a div, 
+  previously nested p elements caused issue in React's hydration.
+* Removes empty div when BamQCLink not provided
+
+
 0.44.0
 ======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,11 +10,11 @@ Change Log
 0.45.1
 ======
 
-`PR 151: fix: HapMap description formatting fix <https://github.com/smaht-dac/smaht-portal/pull/151>`_
+`PR 151: fix: HapMap description formatting / Access key button text update <https://github.com/smaht-dac/smaht-portal/pull/151>`_
 
-* Fixes formatting issue with HapMap description. Wraps p elements in a div, 
-  previously nested p elements caused issue in React's hydration.
-* Removes empty div when BamQCLink not provided
+* Fixes formatting issue with HapMap description
+* Removes empty di element when BamQCLink not provided
+* Updates the access key button text
 
 
 0.45.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ smaht-portal
 Change Log
 ----------
 
-0.45.1
+0.46.2
 ======
 
 `PR 151: fix: HapMap description formatting / Access key button text update <https://github.com/smaht-dac/smaht-portal/pull/151>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.44.0"
+version = "0.44.1"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.45.1"
+version = "0.46.2"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/item-pages/UserView.js
+++ b/src/encoded/static/components/item-pages/UserView.js
@@ -345,7 +345,7 @@ class SyncedAccessKeyTable extends React.PureComponent {
                         id="add-access-key"
                         className="btn btn-success"
                         onClick={this.handleCreate}>
-                        Add Access Key
+                        Generate Access Key
                     </button>
                 </div>
                 {modal}

--- a/src/encoded/static/components/static-pages/components/benchmarking/BenchmarkingUI.js
+++ b/src/encoded/static/components/static-pages/components/benchmarking/BenchmarkingUI.js
@@ -26,16 +26,16 @@ export const BenchmarkingLayout = ({
             <div className="row">
                 <div className="col-auto col-lg-9">
                     <h2>{title}</h2>
-                    <p className={cls}>{description}</p>
-                    {description ? (
-                        <p className="readable disclaimer mb-2">
+                    <div className={cls}>{description}</div>
+                    {description && (
+                        <p className={cls + ' disclaimer'}>
                             <span className="">Note:</span> The unaligned BAM
                             and FASTQ files, and data from unofficial
                             benchmarking samples will be available upon request
                             &#40;through Globus&#41; or at the next release of
                             the portal.
                         </p>
-                    ) : null}
+                    )}
                 </div>
                 {/* TODO: Re-add documentation button once we have it available */}
                 <div className="col-auto mb-2 mb-lg-0 col-lg-3">

--- a/src/encoded/static/components/static-pages/components/benchmarking/BenchmarkingUI.js
+++ b/src/encoded/static/components/static-pages/components/benchmarking/BenchmarkingUI.js
@@ -38,8 +38,8 @@ export const BenchmarkingLayout = ({
                     )}
                 </div>
                 {/* TODO: Re-add documentation button once we have it available */}
-                <div className="col-auto mb-2 mb-lg-0 col-lg-3">
-                    {showBamQCLink && (
+                {showBamQCLink && (
+                    <div className="col-auto mb-2 mb-lg-0 col-lg-3">
                         <a
                             className="btn btn-outline-secondary btn-sm float-right"
                             href={'/bam-qc-overview' + bamQCHash}
@@ -47,8 +47,8 @@ export const BenchmarkingLayout = ({
                             target="_blank">
                             BAM QC Results
                         </a>
-                    )}
-                </div>
+                    </div>
+                )}
             </div>
             {/* Schemas are loading, so hash won't be available yet; can't pick correct tab */}
             {!schemas && (


### PR DESCRIPTION
Corresponds to [Trello Ticket 257](https://trello.com/c/d7AjldNd/257-hapmap-margin-padding-bug).

- Fixes formatting issue with HapMap description. Wraps p elements in a div, previously nested p elements caused issue in React's hydration.
- Removes empty div when BamQCLink not provided