### PR TITLE
Dataset for Colo829 in silico mixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ smaht-portal
 Change Log
 ----------
 
+0.46.0
+======
+
+`PR 153: New dataset for in silico Colo829 mixes <https://github.com/smaht-dac/smaht-portal/pull/153>`_
+
+* Add new option for in silico Colo829 mixtures to File `dataset` enum
+
+
 0.45.0
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.45.0"
+version = "0.46.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/mixins.json
+++ b/src/encoded/schemas/mixins.json
@@ -330,6 +330,7 @@
                 "colo829bl",
                 "colo829t",
                 "colo829blt_50to1",
+                "colo829blt_in_silico",
                 "hapmap",
                 "hg002",
                 "hg00438",


### PR DESCRIPTION
This PR adds a new option under `dataset` on Files to be used for the incoming in silico BAMs.