### PR TITLE
Add N50 prop + in silico data type

### DIFF
--- a/src/encoded/schemas/aligned_reads.json
+++ b/src/encoded/schemas/aligned_reads.json
@@ -43,6 +43,9 @@
             "$ref": "mixins.json#/modified"
         },
         {
+            "$ref": "mixins.json#/n50"
+        },
+        {
             "$ref": "mixins.json#/reference_genome"
         },
         {

--- a/src/encoded/schemas/aligned_reads.json
+++ b/src/encoded/schemas/aligned_reads.json
@@ -96,7 +96,8 @@
             "items": {
                 "type": "string",
                 "enum": [
-                    "Aligned Reads"
+                    "Aligned Reads",
+                    "In Silico Generated"
                 ]
             },
             "default": [

--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -132,6 +132,7 @@
                     "Gene Expression",
                     "Gene Model",
                     "Image",
+                    "In Silico Generated",
                     "Index",
                     "Reference Sequence",
                     "Sequence Interval",

--- a/src/encoded/schemas/mixins.json
+++ b/src/encoded/schemas/mixins.json
@@ -650,6 +650,14 @@
             }
         }
     },
+    "n50": {
+        "n50": {
+            "title": "N50",
+            "description": "The sequence length of the shortest read at 50% of the total sequencing dataset sorted by read length",
+            "type": "number",
+            "minimum": 0
+        }
+    },
     "name": {
         "name": {
             "title": "Name",

--- a/src/encoded/schemas/unaligned_reads.json
+++ b/src/encoded/schemas/unaligned_reads.json
@@ -66,6 +66,9 @@
             "$ref": "mixins.json#/modified"
         },
         {
+            "$ref": "mixins.json#/n50"
+        },
+        {
             "$ref": "mixins.json#/schema_version"
         },
         {


### PR DESCRIPTION
This PR adds a new property (`n50`) to (Un)AlignedReads as requested by submitters as well as a new enum for File `data_type` for the in silico BAMs coming from the research team.