### PR TITLE
Broaden `derived_from` to all files

### DIFF
--- a/src/encoded/item_utils/item.py
+++ b/src/encoded/item_utils/item.py
@@ -69,3 +69,8 @@ def get_external_id(properties: Dict[str, Any]) -> str:
 def get_tags(properties: Dict[str, Any]) -> List[str]:
     """Get tags from properties."""
     return properties.get("tags", [])
+
+
+def get_submitted_id(properties: Dict[str, Any]) -> str:
+    """Get submitted ID from properties."""
+    return properties.get("submitted_id", "")

--- a/src/encoded/schemas/mixins.json
+++ b/src/encoded/schemas/mixins.json
@@ -275,7 +275,7 @@
             "uniqueItems": true,
             "items": {
                 "type": "string",
-                "linkTo": "SubmittedFile"
+                "linkTo": "File"
             }
         },
         "file_sets": {

--- a/src/encoded/tests/test_types_aligned_reads.py
+++ b/src/encoded/tests/test_types_aligned_reads.py
@@ -1,7 +1,8 @@
 import pytest
 from webtest import TestApp
 
-from .utils import get_item
+from .utils import get_item, get_search, patch_item
+from ..item_utils import item as item_utils
 
 
 @pytest.mark.workbook
@@ -15,3 +16,30 @@ def test_submitted_id_resource_path(es_testapp: TestApp, workbook: None) -> None
         collection="SubmittedFile",
         status=301,
     )
+
+
+@pytest.mark.workbook
+def test_derived_from(es_testapp: TestApp, workbook: None) -> None:
+    """Ensure `derived_from` can link to an OutputFile or SubmittedFile."""
+    aligned_reads_search = get_search(es_testapp, "?type=AlignedReads")
+    assert aligned_reads_search, "No AlignedReads found in workbook"
+    aligned_reads = aligned_reads_search[0]
+    aligned_reads_uuid = item_utils.get_uuid(aligned_reads)
+
+    output_file_search = get_search(es_testapp, "?type=OutputFile")
+    assert output_file_search, "No OutputFile found in workbook"
+    output_file = output_file_search[-1]
+
+    submitted_file_search = get_search(
+        es_testapp, f"?type=SubmittedFile&uuid!={aligned_reads_uuid}"
+    )
+    assert submitted_file_search, "No suitable SubmittedFile found in workbook"
+    submitted_file = submitted_file_search[0]
+
+    patch_body = {
+        "derived_from": [
+            item_utils.get_uuid(output_file),
+            item_utils.get_submitted_id(submitted_file),
+        ]
+    }
+    patch_item(es_testapp, patch_body, aligned_reads_uuid)

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -347,7 +347,7 @@ def _build_file_embedded_list() -> List[str]:
 
 @abstract_collection(
     name="files",
-    unique_key='accession',
+    unique_key="submitted_id",  # To permit lookup on submission
     properties={
         "title": "Files",
         "description": "Listing of Files",


### PR DESCRIPTION
This PR allows any file type as a link on the `derived_from` prop, specifically to enable links to OutputFiles (as desired for the in silico BAMs).

In addition, to allow this to work properly on submission, we change the File `unique_key` to `submitted_id` from `accession`. This is required to ensure submitted IDs are properly found on look up with the broader scope above.