### PR TITLE
Add `code` to Tissue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ smaht-portal
 Change Log
 ----------
 
+0.51.0
+======
+
+`PR 164: Add Tissue code for table search <https://github.com/smaht-dac/smaht-portal/pull/164>`_
+
+* Add `code` property to Tissue to be used in benchmarking table search
+
+
 0.50.0
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.50.0"
+version = "0.51.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/tissue.json
+++ b/src/encoded/schemas/tissue.json
@@ -24,6 +24,9 @@
             "$ref": "mixins.json#/attribution"
         },
         {
+            "$ref": "mixins.json#/code"
+        },
+        {
             "$ref": "mixins.json#/external_id"
         },
         {


### PR DESCRIPTION
This PR adds the `code` property to Tissues to be used for the benchmarking data tables.