### PR TITLE
Download Cli

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ smaht-portal
 Change Log
 ----------
 
+0.53.0
+======
+
+* Adds a new API /download_cli that accepts a resource path as a URL or POST param and returns federation token for use with `awscli`
+
+
 0.52.1
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.52.1"
+version = "0.53.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/__init__.py
+++ b/src/encoded/__init__.py
@@ -47,6 +47,7 @@ def include_encoded(config):
     config.include('encoded.metadata')
     config.include('encoded.homepage')
     config.include('encoded.benchmarking')
+    config.include('encoded.download_cli')
     config.include('encoded.upgrade')
     config.include('encoded.submission_status')
     config.include('encoded.ingestion.ingestion_status')

--- a/src/encoded/download_cli.py
+++ b/src/encoded/download_cli.py
@@ -1,0 +1,64 @@
+from json import JSONDecodeError
+from pyramid.view import view_config
+from pyramid.response import Response
+from pyramid.httpexceptions import HTTPTemporaryRedirect
+from urllib.parse import urlparse
+from snovault.util import debug_log
+from dcicutils.misc_utils import ignored
+from encoded_core.types.file import external_creds
+from structlog import getLogger
+
+
+log = getLogger(__name__)
+
+
+def includeme(config):
+    config.add_route('download_cli', '/download_cli/')
+    config.scan(__name__)
+
+
+def extract_bucket_and_key(url):
+    """ Takes an HTTPS URL to S3 and extracts the bucket and key """
+    parsed_url = urlparse(url)
+    bucket = parsed_url.netloc.split('.')[0]
+    key = parsed_url.path.strip('/')
+    if '?' in key:  # remove query params
+        key = key.split('?', 1)[0]
+    return bucket, key
+
+
+def generate_creds(e):
+    """ Processes HTTPTemporary redirect response from the app, grabbing the bucket/key
+        and calling external_creds with upload=False
+    """
+    url = e.location
+    bucket, key = extract_bucket_and_key(url)
+    return external_creds(bucket, key, name=f'DownloadCredentials')
+
+
+@view_config(route_name='download_cli', request_method=['GET', 'POST'])
+@debug_log
+def get_download_federation_token(context, request):
+    """ Runs the external_creds function with upload=False assuming user passes auth check """
+    ignored(context)
+    # TODO: refactor to helper
+    if request.content_type == 'application/json':
+        try:
+            atid = request.json_body['item']
+        except (JSONDecodeError, KeyError):
+            return Response('Invalid JSON format or no item key present', status=400)
+    else:
+        atid = request.GET.get('item')  # would have failed further up if not present
+
+    # Direct to @@download to track via GA and run perm check
+    if '@@download' in atid:  # allow direct pass
+        try:  # this call will raise HTTPTemporary redirect if successful
+            request.embed(f'{atid}', as_user=True)
+        except HTTPTemporaryRedirect as e:
+            return generate_creds(e)
+    else:  # otherwise, try something reasonable
+        try:
+            request.embed(f'{atid}/@@download', as_user=True)
+        except HTTPTemporaryRedirect as e:
+            return generate_creds(e)
+    return Response('Could not retrieve creds')

--- a/src/encoded/tests/data/workbook-inserts/output_file.json
+++ b/src/encoded/tests/data/workbook-inserts/output_file.json
@@ -8,15 +8,16 @@
             "Aligned Reads"
         ],
         "file_format": "BAM",
+        "accession": "TSTFI2115172",
         "extra_files": [
             {
-                "filename": "a_bam_bai.bai",
+                "filename": "TSTFI2115172.bai",
                 "file_size": 3000,
                 "status": "uploaded",
                 "file_format": "BAI"
             },
             {
-                "filename": "a_vcf.vcf",
+                "filename": "TSTFI2115172.vcf",
                 "file_size": 5000,
                 "status": "uploaded",
                 "file_format": "VCF"

--- a/src/encoded/tests/test_download_cli.py
+++ b/src/encoded/tests/test_download_cli.py
@@ -1,0 +1,89 @@
+import pytest
+from ..download_cli import extract_bucket_and_key
+
+
+@pytest.mark.parametrize('url, expected', [
+    ('https://test-bucket.s3.com/file.bam',
+     ('test-bucket', 'file.bam')),
+    ('http://test-bucket.s3.amazonaws.com/file.bam',
+     ('test-bucket', 'file.bam')),
+    ('https://test-bucket.s3.amazonaws.com/file.bam',
+     ('test-bucket', 'file.bam')),
+    ('https://smaht-unit-testing-wfout.s3.amazonaws.com/cca15caa-bc11-4a6a-8998-ea0c69df8b9d/TSTFI0211073.bam',
+     ('smaht-unit-testing-wfout', 'cca15caa-bc11-4a6a-8998-ea0c69df8b9d/TSTFI0211073.bam'))
+])
+def test_extract_bucket_and_key(url, expected):
+    """ Tests the helper function for pulling bucket/key information from a URL """
+    bucket, key = extract_bucket_and_key(url)
+    assert bucket == expected[0]
+    assert key == expected[1]
+
+
+def test_uri_get(es_testapp, uri):
+    """ Helper functions that tests that we can get back download creds via GET """
+    res = es_testapp.get(f'/download_cli/?item={uri}').json['upload_credentials']
+    assert 'AccessKeyId' in res
+    assert 'ASIA' in res['AccessKeyId']  # only real check we can do that this key is real
+    assert 'SecretAccessKey' in res
+    assert 'SessionToken' in res
+
+
+def test_uri_post(es_testapp, uri):
+    """ Helper functions that tests that we can get back download creds via POST """
+    res = es_testapp.post_json('/download_cli/', {
+        'item': f'{uri}'
+    }).json['upload_credentials']
+    assert 'AccessKeyId' in res
+    assert 'ASIA' in res['AccessKeyId']  # only real check we can do that this key is real
+    assert 'SecretAccessKey' in res
+    assert 'SessionToken' in res
+
+
+@pytest.mark.workbook
+def test_download_cli_workbook_post(workbook, es_testapp):
+    """ Tests that we can retrieve federation tokens for regular and extra files """
+    item = es_testapp.get('/output-files/cca15caa-bc11-4a6a-8998-ea0c69df8b9d/').json
+    atid, uuid, accession = item['@id'], item['uuid'], item['accession']
+    # test with @@download
+    test_uri_post(es_testapp, f'{atid}@@download')
+    test_uri_post(es_testapp, f'/{uuid}/@@download')
+    test_uri_post(es_testapp, f'/{accession}/@@download')
+    # test without @@download
+    test_uri_post(es_testapp, f'{atid}')
+    test_uri_post(es_testapp, f'/{uuid}')
+    test_uri_post(es_testapp, f'/{accession}')
+    # test extra file 1 with @@download
+    # NOTE: dummy data that doesn't use the accession as the file name
+    # does NOT work to download!
+    test_uri_post(es_testapp, f'{atid}@@download/TSTFI2115172.bai')
+    test_uri_post(es_testapp, f'/{uuid}/@@download/TSTFI2115172.bai')
+    test_uri_post(es_testapp, f'/{accession}/@@download/TSTFI2115172.bai')
+    # test extra file 2 with @@download
+    test_uri_post(es_testapp, f'{atid}@@download/TSTFI2115172.vcf')
+    test_uri_post(es_testapp, f'/{uuid}/@@download/TSTFI2115172.vcf')
+    test_uri_post(es_testapp, f'/{accession}/@@download/TSTFI2115172.vcf')
+
+
+@pytest.mark.workbook
+def test_download_cli_workbook_get(workbook, es_testapp):
+    """ Runs the above tests using the GET version of the API """
+    item = es_testapp.get('/output-files/cca15caa-bc11-4a6a-8998-ea0c69df8b9d/').json
+    atid, uuid, accession = item['@id'], item['uuid'], item['accession']
+    # test with @@download
+    test_uri_get(es_testapp, f'{atid}@@download')
+    test_uri_get(es_testapp, f'/{uuid}/@@download')
+    test_uri_get(es_testapp, f'/{accession}/@@download')
+    # test without @@download
+    test_uri_get(es_testapp, f'{atid}')
+    test_uri_get(es_testapp, f'/{uuid}')
+    test_uri_get(es_testapp, f'/{accession}')
+    # test extra file 1 with @@download
+    # NOTE: dummy data that doesn't use the accession as the file name
+    # does NOT work to download!
+    test_uri_get(es_testapp, f'{atid}@@download/TSTFI2115172.bai')
+    test_uri_get(es_testapp, f'/{uuid}/@@download/TSTFI2115172.bai')
+    test_uri_get(es_testapp, f'/{accession}/@@download/TSTFI2115172.bai')
+    # test extra file 2 with @@download
+    test_uri_get(es_testapp, f'{atid}@@download/TSTFI2115172.vcf')
+    test_uri_get(es_testapp, f'/{uuid}/@@download/TSTFI2115172.vcf')
+    test_uri_get(es_testapp, f'/{accession}/@@download/TSTFI2115172.vcf')


### PR DESCRIPTION
- Adds a new API, `download_cli`, that accepts any unique key/resource path and returns AWS Access keys for download. It does this by first checking access against `@@download`, then processing the redirect result if successful and calling get_federation_token subsequently.
- TODO: hook in new version of encoded-core, which will change response to include "download" instead of "upload" credentials, and constrain the permissions to only download 