### PR TITLE
Multiple analytes per library

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@ smaht-portal
 Change Log
 ----------
 
+0.57.0
+======
+
+`PR 173: Multiple analytes per library <https://github.com/smaht-dac/smaht-portal/pull/173>`_
+
+* **Breaking change**: Remove `analyte` from Library and replace with `analytes` array of linkTos
+* Includes corresponding changes to `item_utils`, commands, calcprops, embeds, front-end, and tests
+
+
 0.56.0
 ======
 
@@ -15,6 +24,7 @@ Change Log
 * Add a bunch of new inserts to serve as the new links to these various pages
 * Rework the old inserts into redirect-only pages, so that people who have bookmarked old links don't lose their place
 * Permission and order tweaks for sanity's sake
+
 
 0.55.0
 =======

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.56.0"
+version = "0.57.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/commands/create_annotated_filenames.py
+++ b/src/encoded/commands/create_annotated_filenames.py
@@ -41,7 +41,7 @@ class PortalConstants:
     AGE = "age"
     ALIGNED_READS = "Aligned Reads"
     ALIGNMENT_DETAILS = "alignment_details"
-    ANALYTE = "analyte"
+    ANALYTE = "analytes"
     ANNOTATED_FILENAME = "annotated_filename"
     ASSAY = "assay"
     CELL_CULTURE = "cell_culture"
@@ -498,14 +498,18 @@ def get_analytes_from_libraries(
 ) -> List[Dict[str, Any]]:
     """Get analytes for libraries."""
     analytes = deduplicate_items_by_uuid(
-        [get_analyte(library) for library in libraries]
+        [
+            analyte
+            for library in libraries
+            for analyte in get_analytes(library)
+        ]
     )
     return [get_item(get_uuid(analyte), auth_key) for analyte in analytes]
 
 
-def get_analyte(item: Dict[str, Any]) -> Dict[str, Any]:
+def get_analytes(item: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Get analyte property from item."""
-    return item.get(PortalConstants.ANALYTE, {})
+    return item.get(PortalConstants.ANALYTE, [])
 
 
 def get_samples_from_analytes(

--- a/src/encoded/commands/release_file.py
+++ b/src/encoded/commands/release_file.py
@@ -142,7 +142,7 @@ class FileRelease:
             assay = self.get_metadata(library[PC.ASSAY])
             self.add_release_item_to_patchdict(assay, f"Assay - {assay[PC.IDENTIFIER]}")
 
-            analyte_ids = library[PC.ANALYTES]
+            analyte_ids = library[PC.ANALYTE]
             for analyte_id in analyte_ids:
                 analyte = self.get_metadata(analyte_id)
                 self.add_release_item_to_patchdict(

--- a/src/encoded/commands/release_file.py
+++ b/src/encoded/commands/release_file.py
@@ -36,7 +36,7 @@ class PC:  # PortalConstants
     AGE = "age"
     ALIGNED_READS = "Aligned Reads"
     ALIGNMENT_DETAILS = "alignment_details"
-    ANALYTE = "analyte"
+    ANALYTE = "analytes"
     ANNOTATED_FILENAME = "annotated_filename"
     ASSAY = "assay"
     CONSORTIA = "consortia"
@@ -142,20 +142,22 @@ class FileRelease:
             assay = self.get_metadata(library[PC.ASSAY])
             self.add_release_item_to_patchdict(assay, f"Assay - {assay[PC.IDENTIFIER]}")
 
-            analyte = self.get_metadata(library[PC.ANALYTE])
-            self.add_release_item_to_patchdict(
-                analyte, f"Analyte - {analyte[PC.SUBMITTED_ID]}"
-            )
-
-            for sample_uuid in analyte[PC.SAMPLES]:
-                sample = self.get_metadata(sample_uuid)
+            analyte_ids = library[PC.ANALYTES]
+            for analyte_id in analyte_ids:
+                analyte = self.get_metadata(analyte_id)
                 self.add_release_item_to_patchdict(
-                    sample, f"Sample - {sample[PC.SUBMITTED_ID]}"
+                    analyte, f"Analyte - {analyte[PC.SUBMITTED_ID]}"
                 )
 
-                sample_sources = sample[PC.SAMPLE_SOURCES]
-                for sample_source in sample_sources:
-                    self.release_sample_source(sample_source)
+                for sample_uuid in analyte[PC.SAMPLES]:
+                    sample = self.get_metadata(sample_uuid)
+                    self.add_release_item_to_patchdict(
+                        sample, f"Sample - {sample[PC.SUBMITTED_ID]}"
+                    )
+
+                    sample_sources = sample[PC.SAMPLE_SOURCES]
+                    for sample_source in sample_sources:
+                        self.release_sample_source(sample_source)
 
         if "obsolete_file_identifier" in kwargs and kwargs["obsolete_file_identifier"]:
             obsolete_file = self.get_metadata_object(kwargs["obsolete_file_identifier"])

--- a/src/encoded/item_utils/file.py
+++ b/src/encoded/item_utils/file.py
@@ -5,7 +5,6 @@ from . import file_set, library, sample, sequencing, tissue
 from .utils import (
     RequestHandler,
     get_property_values_from_identifiers,
-    get_unique_values,
 )
 
 
@@ -117,7 +116,7 @@ def get_analytes(
         return get_property_values_from_identifiers(
             request_handler,
             get_libraries(properties, request_handler),
-            library.get_analyte,
+            library.get_analytes,
         )
     return properties.get("analytes", [])
 

--- a/src/encoded/item_utils/item.py
+++ b/src/encoded/item_utils/item.py
@@ -79,3 +79,8 @@ def get_submitted_id(properties: Dict[str, Any]) -> str:
 def get_aliases(properties: Dict[str, Any]) -> List[str]:
     """Get aliases from properties."""
     return properties.get("aliases", [])
+
+
+def get_identifier(properties: Dict[str, Any]) -> str:
+    """Get identifier from properties."""
+    return properties.get("identifier", "")

--- a/src/encoded/item_utils/library.py
+++ b/src/encoded/item_utils/library.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional, Union
 
 from . import analyte as analyte_utils
-from .utils import RequestHandler, get_property_value_from_identifier
+from .utils import RequestHandler, get_property_values_from_identifiers
 
 
 def get_assay(library: Dict[str, Any]) -> Union[str, Dict[str, Any]]:
@@ -9,9 +9,9 @@ def get_assay(library: Dict[str, Any]) -> Union[str, Dict[str, Any]]:
     return library.get("assay", "")
 
 
-def get_analyte(library: Dict[str, Any]) -> Union[str, Dict[str, Any]]:
-    """Get analyte connected to library."""
-    return library.get("analyte", "")
+def get_analytes(library: Dict[str, Any]) -> List[Union[str, Dict[str, Any]]]:
+    """Get analytes connected to library."""
+    return library.get("analytes", [])
 
 
 def get_samples(
@@ -19,7 +19,7 @@ def get_samples(
 ) -> List[str]:
     """Get samples connected to library."""
     if request_handler:
-        return get_property_value_from_identifier(
-            request_handler, get_analyte(library), analyte_utils.get_samples
+        return get_property_values_from_identifiers(
+            request_handler, get_analytes(library), analyte_utils.get_samples
         )
     return []

--- a/src/encoded/item_utils/library.py
+++ b/src/encoded/item_utils/library.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional, Union
 
-from . import analyte as analyte_utils
+from . import analyte as analyte_utils, sample as sample_utils
 from .utils import RequestHandler, get_property_values_from_identifiers
 
 
@@ -21,5 +21,18 @@ def get_samples(
     if request_handler:
         return get_property_values_from_identifiers(
             request_handler, get_analytes(library), analyte_utils.get_samples
+        )
+    return []
+
+
+def get_sample_sources(
+    library: Dict[str, Any], request_handler: Optional[RequestHandler] = None
+) -> List[str]:
+    """Get sample sources connected to library."""
+    if request_handler:
+        return get_property_values_from_identifiers(
+            request_handler,
+            get_samples(library, request_handler=request_handler),
+            sample_utils.get_sample_sources,
         )
     return []

--- a/src/encoded/item_utils/sequencing.py
+++ b/src/encoded/item_utils/sequencing.py
@@ -4,3 +4,18 @@ from typing import Any, Dict, Union
 def get_sequencer(properties: Dict[str, Any]) -> Union[str, Dict[str, Any]]:
     """Get sequencer from properties."""
     return properties.get("sequencer", "")
+
+
+def get_read_type(properties: Dict[str, Any]) -> str:
+    """Get read type from properties."""
+    return properties.get("read_type", "")
+
+
+def get_target_read_length(properties: Dict[str, Any]) -> Union[int, None]:
+    """Get target read length from properties."""
+    return properties.get("target_read_length")
+
+
+def get_flow_cell(properties: Dict[str, Any]) -> str:
+    """Get flow cell from properties."""
+    return properties.get("flow_cell", "")

--- a/src/encoded/schemas/library.json
+++ b/src/encoded/schemas/library.json
@@ -4,7 +4,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "required": [
-        "analyte",
+        "analytes",
         "assay",
         "submission_centers",
         "submitted_id"
@@ -58,7 +58,7 @@
             "accessionType": "LI"
         },
         "schema_version": {
-            "default": "1"
+            "default": "2"
         },
         "submitted_id": {
             "pattern": "^[A-Z0-9]{3,}_LIBRARY_[A-Z0-9-_.]{4,}$"
@@ -179,11 +179,16 @@
             "type": "integer",
             "minimum": 0
         },
-        "analyte": {
-            "title": "Analyte",
-            "description": "Link to associated analyte",
-            "type": "string",
-            "linkTo": "Analyte"
+        "analytes": {
+            "title": "Analytes",
+            "description": "Links to associated analytes",
+            "type": "array",
+            "uniqueItems": true,
+            "minItems": 1,
+            "items": {
+                "type": "string",
+                "linkTo": "Analyte"
+            }
         },
         "assay": {
             "title": "Assay",

--- a/src/encoded/static/components/static-pages/components/internal/SubmissionStatus.js
+++ b/src/encoded/static/components/static-pages/components/internal/SubmissionStatus.js
@@ -385,12 +385,14 @@ class SubmissionStatusComponent extends React.PureComponent {
                         Library: {getLink(lib.uuid, lib.display_title)}
                     </li>
                 );
-                lib.analyte?.samples?.forEach((sample) => {
-                    fs_details.push(
-                        <li className="ss-line-height-140">
-                            Sample: {getLink(sample.uuid, sample.display_title)}
-                        </li>
-                    );
+                lib.analytes?.forEach((analyte) => {
+                    analyte.samples?.forEach((sample) => {
+                        fs_details.push(
+                            <li className="ss-line-height-140">
+                                Sample: {getLink(sample.uuid, sample.display_title)}
+                            </li>
+                        );
+                    });
                 });
                 fs_details.push(
                     <li className="ss-line-height-140">

--- a/src/encoded/tests/data/workbook-inserts/library.json
+++ b/src/encoded/tests/data/workbook-inserts/library.json
@@ -5,7 +5,9 @@
             "smaht"
         ],
         "submitted_id": "TEST_LIBRARY_LIVER",
-        "analyte": "TEST_ANALYTE_LIVER",
+        "analytes": [
+            "TEST_ANALYTE_LIVER"
+        ],
         "a260_a280_ratio": 3.2,
         "amplification_cycles": 10,
         "analyte_weight": 5.4,
@@ -20,7 +22,9 @@
             "smaht"
         ],
         "submitted_id": "TEST_LIBRARY_HELA",
-        "analyte": "TEST_ANALYTE_HELA",
+        "analytes": [
+            "TEST_ANALYTE_HELA"
+        ],
         "a260_a280_ratio": 3.2,
         "fragment_mean_length": 150.7,
         "insert_mean_length": 150.2,

--- a/src/encoded/tests/test_types_file.py
+++ b/src/encoded/tests/test_types_file.py
@@ -520,11 +520,7 @@ def assert_libraries_calcprop_matches_embeds(file: Dict[str, Any]) -> None:
     """Ensure 'libraries' calcprop matches file_sets.libraries."""
     libraries_from_calcprop = file_utils.get_libraries(file)
     file_sets = file_utils.get_file_sets(file)
-    libraries_from_file_set = [
-        library
-        for file_set in file_sets
-        for library in file_set_utils.get_libraries(file_set)
-    ]
+    libraries_from_file_set = get_unique_values(file_sets, file_set_utils.get_libraries)
     assert_items_match(libraries_from_calcprop, libraries_from_file_set)
 
 
@@ -572,9 +568,9 @@ def assert_sequencing_calcprop_matches_embeds(file: Dict[str, Any]) -> None:
     """Ensure 'sequencing' calcprop matches file_sets.sequencing."""
     sequencing_from_calcprop = file_utils.get_sequencings(file)
     file_sets = file_utils.get_file_sets(file)
-    sequencing_from_file_set = [
-        file_set_utils.get_sequencing(file_set) for file_set in file_sets
-    ]
+    sequencing_from_file_set = get_unique_values(
+        file_sets, file_set_utils.get_sequencing
+    )
     assert_items_match(sequencing_from_calcprop, sequencing_from_file_set)
 
 
@@ -613,12 +609,8 @@ def assert_assays_calcprop_matches_embeds(file: Dict[str, Any]) -> None:
     """Ensure 'assays' calcprop matches file_sets.assay."""
     assays_from_calcprop = file_utils.get_assays(file)
     file_sets = file_utils.get_file_sets(file)
-    libraries = [
-        library
-        for file_set in file_sets
-        for library in file_set_utils.get_libraries(file_set)
-    ]
-    assays = [library_utils.get_assay(library) for library in libraries]
+    libraries = get_unique_values(file_sets, file_set_utils.get_libraries)
+    assays = get_unique_values(libraries, library_utils.get_assay)
     assert_items_match(assays_from_calcprop, assays)
 
 
@@ -657,12 +649,8 @@ def assert_analytes_calcprop_matches_embeds(file: Dict[str, Any]) -> None:
     """Ensure 'analytes' calcprop matches file_sets.libraries.analytes."""
     analytes_from_calcprop = file_utils.get_analytes(file)
     file_sets = file_utils.get_file_sets(file)
-    libraries = [
-        library
-        for file_set in file_sets
-        for library in file_set_utils.get_libraries(file_set)
-    ]
-    analytes = [library_utils.get_analyte(library) for library in libraries]
+    libraries = get_unique_values(file_sets, file_set_utils.get_libraries)
+    analytes = get_unique_values(libraries, library_utils.get_analytes)
     assert_items_match(analytes_from_calcprop, analytes)
 
 
@@ -701,25 +689,13 @@ def assert_samples_calcprop_matches_embeds(file: Dict[str, Any]) -> None:
     """Ensure 'samples' calcprop matches file_sets.libraries.analytes.samples."""
     samples_from_calcprop = file_utils.get_samples(file)
     file_sets = file_utils.get_file_sets(file)
-    samples = [
-        sample
-        for file_set in file_sets
-        for sample in file_set_utils.get_samples(file_set)
-    ]
+    samples = get_unique_values(file_sets, file_set_utils.get_samples)
     if samples:
         assert_items_match(samples_from_calcprop, samples)
     else:
-        libraries = [
-            library
-            for file_set in file_sets
-            for library in file_set_utils.get_libraries(file_set)
-        ]
-        analytes = [library_utils.get_analyte(library) for library in libraries]
-        samples = [
-            sample
-            for analyte in analytes
-            for sample in analyte_utils.get_samples(analyte)
-        ]
+        libraries = get_unique_values(file_sets, file_set_utils.get_libraries)
+        analytes = get_unique_values(libraries, library_utils.get_analytes)
+        samples = get_unique_values(analytes, analyte_utils.get_samples)
         assert_items_match(samples_from_calcprop, samples)
 
 
@@ -758,22 +734,10 @@ def assert_sample_sources_calcprop_matches_embeds(file: Dict[str, Any]) -> None:
     """Ensure 'sample_sources' calcprop matches upstream sample sources."""
     sample_sources_from_calcprop = file_utils.get_sample_sources(file)
     file_sets = file_utils.get_file_sets(file)
-    libraries = [
-        library
-        for file_set in file_sets
-        for library in file_set_utils.get_libraries(file_set)
-    ]
-    analytes = [library_utils.get_analyte(library) for library in libraries]
-    samples = [
-        sample
-        for analyte in analytes
-        for sample in analyte_utils.get_samples(analyte)
-    ]
-    sample_sources = [
-        sample_source
-        for sample in samples
-        for sample_source in sample_utils.get_sample_sources(sample)
-    ]
+    libraries = get_unique_values(file_sets, file_set_utils.get_libraries)
+    analytes = get_unique_values(libraries, library_utils.get_analytes)
+    samples = get_unique_values(analytes, analyte_utils.get_samples)
+    sample_sources = get_unique_values(samples, sample_utils.get_sample_sources)
     assert_items_match(sample_sources_from_calcprop, sample_sources)
 
 
@@ -812,25 +776,11 @@ def assert_donors_calcprop_matches_embeds(file: Dict[str, Any]) -> None:
     """Ensure 'donors' calcprop matches upstream donors."""
     donors_from_calcprop = file_utils.get_donors(file)
     file_sets = file_utils.get_file_sets(file)
-    libraries = [
-        library
-        for file_set in file_sets
-        for library in file_set_utils.get_libraries(file_set)
-    ]
-    analytes = [library_utils.get_analyte(library) for library in libraries]
-    samples = [
-        sample
-        for analyte in analytes
-        for sample in analyte_utils.get_samples(analyte)
-    ]
-    sample_sources = [
-        sample_source
-        for sample in samples
-        for sample_source in sample_utils.get_sample_sources(sample)
-    ]
-    donors = [
-        tissue_utils.get_donor(sample_source) for sample_source in sample_sources
-    ]
+    libraries = get_unique_values(file_sets, file_set_utils.get_libraries)
+    analytes = get_unique_values(libraries, library_utils.get_analytes)
+    samples = get_unique_values(analytes, analyte_utils.get_samples)
+    sample_sources = get_unique_values(samples, sample_utils.get_sample_sources)
+    donors = get_unique_values(sample_sources, tissue_utils.get_donor)
     assert_items_match(donors_from_calcprop, donors)
 
 

--- a/src/encoded/tests/test_types_file.py
+++ b/src/encoded/tests/test_types_file.py
@@ -630,7 +630,7 @@ def test_analytes(es_testapp: TestApp, workbook: None) -> None:
 
     Calcprop expected on SubmittedFile and OutputFile.
     """
-    search_key = "file_sets.libraries.analyte.uuid"
+    search_key = "file_sets.libraries.analytes.uuid"
     file_without_analytes_search = search_type_for_key(
         es_testapp, "File", search_key, exists=False
     )
@@ -654,7 +654,7 @@ def test_analytes(es_testapp: TestApp, workbook: None) -> None:
 
 
 def assert_analytes_calcprop_matches_embeds(file: Dict[str, Any]) -> None:
-    """Ensure 'analytes' calcprop matches file_sets.libraries.analyte."""
+    """Ensure 'analytes' calcprop matches file_sets.libraries.analytes."""
     analytes_from_calcprop = file_utils.get_analytes(file)
     file_sets = file_utils.get_file_sets(file)
     libraries = [
@@ -674,7 +674,7 @@ def test_samples(es_testapp: TestApp, workbook: None) -> None:
 
     Calcprop expected on SubmittedFile and OutputFile.
     """
-    search_key = "file_sets.libraries.analyte.samples.uuid"
+    search_key = "file_sets.libraries.analytes.samples.uuid"
     file_without_samples_search = search_type_for_key(
         es_testapp, "File", search_key, exists=False
     )
@@ -698,7 +698,7 @@ def test_samples(es_testapp: TestApp, workbook: None) -> None:
 
 
 def assert_samples_calcprop_matches_embeds(file: Dict[str, Any]) -> None:
-    """Ensure 'samples' calcprop matches file_sets.libraries.analyte.samples."""
+    """Ensure 'samples' calcprop matches file_sets.libraries.analytes.samples."""
     samples_from_calcprop = file_utils.get_samples(file)
     file_sets = file_utils.get_file_sets(file)
     samples = [
@@ -731,7 +731,7 @@ def test_sample_sources(es_testapp: TestApp, workbook: None) -> None:
 
     Calcprop expected on SubmittedFile and OutputFile.
     """
-    search_key = "file_sets.libraries.analyte.samples.sample_sources.uuid"
+    search_key = "file_sets.libraries.analytes.samples.sample_sources.uuid"
     file_without_sample_sources_search = search_type_for_key(
         es_testapp, "File", search_key, exists=False
     )
@@ -785,7 +785,7 @@ def test_donors(es_testapp: TestApp, workbook: None) -> None:
 
     Calcprop expected on SubmittedFile and OutputFile.
     """
-    search_key = "file_sets.libraries.analyte.samples.sample_sources.donor.uuid"
+    search_key = "file_sets.libraries.analytes.samples.sample_sources.donor.uuid"
     file_without_donors_search = search_type_for_key(
         es_testapp, "File", search_key, exists=False
     )

--- a/src/encoded/tests/test_upgrade_library.py
+++ b/src/encoded/tests/test_upgrade_library.py
@@ -1,0 +1,27 @@
+from typing import Any, Dict
+
+import pytest
+from pyramid.router import Router
+
+from .utils import get_upgrader
+
+
+@pytest.mark.parametrize(
+    "library,expected",
+    [
+        ({"schema_version": "1"}, {"schema_version": "2"}),
+        (
+            {"schema_version": "1", "analyte": "analyte_link"},
+            {"schema_version": "2", "analytes": ["analyte_link"]},
+        ),
+    ],
+)
+def test_upgrade_library_1_2(
+    library: Dict[str, Any], expected: Dict[str, Any], app: Router
+) -> None:
+    """Test library upgrader from version 1 to 2."""
+    upgrader = get_upgrader(app)
+    assert (
+        upgrader.upgrade("library", library, current_version="1", target_version="2")
+        == expected
+    )

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -326,12 +326,12 @@ def _build_file_embedded_list() -> List[str]:
         "file_sets.sequencing.sequencer",
 
         # Sample summary + Link calcprops
-        "file_sets.libraries.analyte.molecule",
-        "file_sets.libraries.analyte.samples.sample_sources.code",
-        "file_sets.libraries.analyte.samples.sample_sources.description",
-        "file_sets.libraries.analyte.samples.sample_sources.donor",
-        "file_sets.libraries.analyte.samples.sample_sources.cell_line.code",
-        "file_sets.libraries.analyte.samples.sample_sources.components.cell_culture.cell_line.code",
+        "file_sets.libraries.analytes.molecule",
+        "file_sets.libraries.analytes.samples.sample_sources.code",
+        "file_sets.libraries.analytes.samples.sample_sources.description",
+        "file_sets.libraries.analytes.samples.sample_sources.donor",
+        "file_sets.libraries.analytes.samples.sample_sources.cell_line.code",
+        "file_sets.libraries.analytes.samples.sample_sources.components.cell_culture.cell_line.code",
         "file_sets.samples.sample_sources.code",
         "file_sets.samples.sample_sources.description",
         "file_sets.samples.sample_sources.donor",

--- a/src/encoded/types/file_set.py
+++ b/src/encoded/types/file_set.py
@@ -110,7 +110,9 @@ class FileSet(SubmittedItem):
             the read type, the target read length and flow cell
         """
         sequencer = get_property_value_from_identifier(
-            request_handler, sequencing_utils.get_sequencer, item_utils.get_identifier
+            request_handler,
+            sequencing_utils.get_sequencer(sequencing),
+            item_utils.get_identifier
         )
         read_type_part = sequencing_utils.get_read_type(sequencing)
         target_read_length = sequencing_utils.get_target_read_length(sequencing)
@@ -143,7 +145,7 @@ class FileSet(SubmittedItem):
         else:
             sample_source = sample_sources[0]
         return get_property_value_from_identifier(
-            request_handler, sample_source, item_utils.get_identifier
+            request_handler, sample_source, item_utils.get_submitted_id
         )
 
     @calculated_property(
@@ -204,7 +206,9 @@ class FileSet(SubmittedItem):
             return None
 
         # If we've reached this part, the library/assay is compatible
-        sequencing = request_handler.get_item(file_set_utils.get_sequencing(self.properties))
+        sequencing = request_handler.get_item(
+            file_set_utils.get_sequencing(self.properties)
+        )
         sequencing_part = self.generate_sequencing_part(request_handler, sequencing)
         if not sequencing_part:
             return None
@@ -212,10 +216,11 @@ class FileSet(SubmittedItem):
         # We need this because sequencing and sample submission centers could be different
         # this is the last thing we do since we could have exited above and the submission
         # center will always be present
-        sc = request_handler.get_item(
-            item_utils.get_submission_centers(self.properties)[0]
+        sc_part = get_property_value_from_identifier(
+            request_handler,
+            item_utils.get_submission_centers(self.properties)[0],
+            item_utils.get_identifier,
         )
-        sc_part = item_utils.get_identifier(sc)
 
         return {
             'submission_center': sc_part,

--- a/src/encoded/types/file_set.py
+++ b/src/encoded/types/file_set.py
@@ -1,9 +1,13 @@
-from typing import List, Union
-from ..utils import load_extended_descriptions_in_schemas
+from typing import Any, Dict, List, Union
+
 from pyramid.request import Request
 from snovault import calculated_property, collection, load_schema
 from snovault.util import get_item_or_none
+
 from .submitted_item import SubmittedItem
+from ..item_utils import file_set_utils, item_utils, library_utils, sequencing_utils
+from ..item_utils.utils import RequestHandler, get_property_value_from_identifier
+from ..utils import load_extended_descriptions_in_schemas
 
 
 # These codes are used to generate the mergeable bam grouping calc prop
@@ -95,44 +99,48 @@ class FileSet(SubmittedItem):
         return
 
     @staticmethod
-    def generate_sequencing_part(request, sequencing):
+    def generate_sequencing_part(
+        request_handler: RequestHandler, sequencing: Dict[str, Any]
+    ) -> str:
         """ The sequencing part of the file_merge_group consists of the name of the sequencer,
             the read type, the target read length and flow cell
         """
-        read_type_part = sequencing.get('read_type')
-        sequencer = get_item_or_none(request, sequencing.get('sequencer')).get('identifier')
-        target_read_length = sequencing.get('target_read_length')
-        flow_cell = sequencing.get('flow_cell', 'no-flow-cell')
+        sequencer = get_property_value_from_identifier(
+            request_handler, sequencing_utils.get_sequencer, item_utils.get_identifier
+        )
+        read_type_part = sequencing_utils.get_read_type(sequencing)
+        target_read_length = sequencing_utils.get_target_read_length(sequencing)
+        flow_cell = sequencing_utils.get_flow_cell(sequencing) or "no-flow-cell"
         return f'{sequencer}-{read_type_part}-{target_read_length}-{flow_cell}'
 
     @staticmethod
-    def generate_assay_part(request, library):
+    def generate_assay_part(
+        request_handler: RequestHandler, library: Dict[str, Any]
+    ) -> Union[str, None]:
         """ The library of the merge_file_group contains information on the assay
             This basically just checks the assay code isn't a single cell type and if
             it isn't return the identifier
         """
-        assay = get_item_or_none(request, library.get('assay'))
-        assay_code = assay.get('code')
+        assay = request_handler.get_item(library_utils.get_assay(library))
+        assay_code = item_utils.get_code(assay)
         if assay_code not in SINGLE_CELL_ASSAY_CODES:
-            return assay.get('identifier')
+            return item_utils.get_identifier(assay)
 
     @staticmethod
-    def generate_sample_source_part(request, library):
+    def generate_sample_source_part(
+        request_handler: RequestHandler, library: Dict[str, Any]
+    ) -> Union[str, None]:
         """ Note this is also derived from the library """
-        analyte = get_item_or_none(request, library.get('analyte'))
-        samples = analyte.get('samples')
-        if len(samples) > 1:
-            return None  # there is too much complexity
-        else:
-            sample = samples[0]
-        sample = get_item_or_none(request, sample)
-        sample_sources = sample.get('sample_sources')
+        sample_sources = library_utils.get_sample_sources(
+            library, request_handler=request_handler
+        )
         if len(sample_sources) > 1:
             return None  # there is too much complexity
         else:
             sample_source = sample_sources[0]
-        sample_source = get_item_or_none(request, sample_source)
-        return sample_source.get('submitted_id')
+        return get_property_value_from_identifier(
+            request_handler, sample_source, item_utils.get_identifier
+        )
 
     @calculated_property(
         schema={
@@ -178,29 +186,32 @@ class FileSet(SubmittedItem):
         # NOTE: we assume the first library is representative if there are multiple
         # We also assume this will always be present, and if not we do not produce this property
         # This assumption may not hold true forever, we should monitor this closely - Will 17 April 24
-        library = self.properties.get('libraries')
+        request_handler = RequestHandler(request=request)
+        library = file_set_utils.get_libraries(self.properties)
         if not library:
             return None
-        library = get_item_or_none(request, library[0])
-        assay_part = self.generate_assay_part(request, library)
+        library = request_handler.get_item(library[0])
+        assay_part = self.generate_assay_part(request_handler, library)
         if not assay_part:  # we return none if this is a single cell assay to omit this prop
             return None
 
-        sample_source_part = self.generate_sample_source_part(request, library)
+        sample_source_part = self.generate_sample_source_part(request_handler, library)
         if not sample_source_part:
             return None
 
         # If we've reached this part, the library/assay is compatible
-        sequencing = get_item_or_none(request, self.properties.get('sequencing'))
-        sequencing_part = self.generate_sequencing_part(request, sequencing)
+        sequencing = request_handler.get_item(file_set_utils.get_sequencing(self.properties))
+        sequencing_part = self.generate_sequencing_part(request_handler, sequencing)
         if not sequencing_part:
             return None
 
         # We need this because sequencing and sample submission centers could be different
         # this is the last thing we do since we could have exited above and the submission
         # center will always be present
-        sc = get_item_or_none(request, self.properties.get('submission_centers')[0])
-        sc_part = sc.get('identifier')
+        sc = request_handler.get_item(
+            item_utils.get_submission_centers(self.properties)[0]
+        )
+        sc_part = item_utils.get_identifier(sc)
 
         return {
             'submission_center': sc_part,

--- a/src/encoded/types/file_set.py
+++ b/src/encoded/types/file_set.py
@@ -2,10 +2,14 @@ from typing import Any, Dict, List, Union
 
 from pyramid.request import Request
 from snovault import calculated_property, collection, load_schema
-from snovault.util import get_item_or_none
 
 from .submitted_item import SubmittedItem
-from ..item_utils import file_set_utils, item_utils, library_utils, sequencing_utils
+from ..item_utils import (
+    file_set as file_set_utils,
+    item as item_utils,
+    library as library_utils,
+    sequencing as sequencing_utils,
+)
 from ..item_utils.utils import RequestHandler, get_property_value_from_identifier
 from ..utils import load_extended_descriptions_in_schemas
 

--- a/src/encoded/types/file_set.py
+++ b/src/encoded/types/file_set.py
@@ -24,8 +24,8 @@ def _build_file_set_embedded_list():
         "libraries.assay.identifier",
 
         # Sample/SampleSource LinkTo - used in file_merge_group
-        "libraries.analyte.samples.display_title",
-        "libraries.analyte.samples.sample_sources.submitted_id",
+        "libraries.analytes.samples.display_title",
+        "libraries.analytes.samples.sample_sources.submitted_id",
 
         # Sequencing/Sequencer LinkTo - used in file_merge_group
         "sequencing.submitted_id",

--- a/src/encoded/upgrade/library.py
+++ b/src/encoded/upgrade/library.py
@@ -1,0 +1,14 @@
+from typing import Any, Dict
+
+from snovault import upgrade_step
+
+
+@upgrade_step("library", "1", "2")
+def upgrade_library_1_2(
+    value: Dict[str, Any], system: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Change `analyte` linkTo to `analytes` list of linkTos."""
+    analyte = value.get("analyte")
+    if analyte:
+        value["analytes"] = [analyte]
+        del value["analyte"]


### PR DESCRIPTION
This PR introduces a breaking change to the data model, changing the existing Library link to an Analyte to an array of links and pluralizing the property name accordingly.

Accompanying changes include:

- Library upgrader for existing items
- `item_utils` updates
- Embed updates
- File calcprop refactoring
- FileSet calcprop refactoring (switched over to using `item_utils`)
- Command refactoring for file naming and file release
- Test + workbook inserts updates
- Submission status updates (courtesy of Alex)