### PR TITLE
fix: include missing TPC and GCC in awardees table

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ smaht-portal
 Change Log
 ----------
 
+0.68.1
+======
+
+`PR 192: fix: include missing TPC and GCC in awardees table <https://github.com/smaht-dac/smaht-portal/pull/192>`_
+
+* Fix missing consortium entries in the awardees table
+
+
 0.68.0
 ======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ smaht-portal
 Change Log
 ----------
 
+0.67.1
+======
+
+`PR 192: fix: include missing TPC and GCC in awardees table <https://github.com/smaht-dac/smaht-portal/pull/192>`_
+
+* Fix missing consortium entries in the awardees table.
+
+
 0.67.0
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.68.0"
+version = "0.68.1"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.67.0"
+version = "0.67.1"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/viz/AboutPageVisualizations/ConsortiumMap/data/consortia.json
+++ b/src/encoded/static/components/viz/AboutPageVisualizations/ConsortiumMap/data/consortia.json
@@ -62,7 +62,7 @@
         "x": 78,
         "y": 10,
         "pis": ["Bennet, James T", "Eichler, Evan", "Stergachis, Andrew B"],
-        "institution": "Seattle Children's Hospital",
+        "institution": "University of Washington & Seattle Children's Hospital",
         "center-type": "Genome Characterization Center",
         "center-type-short": "GCC",
         "marker-color": "orange",

--- a/src/encoded/static/components/viz/AboutPageVisualizations/ConsortiumMap/data/consortia.json
+++ b/src/encoded/static/components/viz/AboutPageVisualizations/ConsortiumMap/data/consortia.json
@@ -67,7 +67,7 @@
         "center-type-short": "GCC",
         "marker-color": "orange",
         "marker-color-hex": "#ff7f00",
-        "project": "Mosaicism in Human Tissues, from Telomere to Telomere to RFA-22-013: Somatic Mosaicism across Human Tissues Program: Genome Characterization Centers.",
+        "project": "Mosaicism in Human Tissues, from Telomere to Telomere to RFA-22-013: Somatic Mosaicism across Human Tissues Program: Genome Characterization Centers",
         "project-number": "1UM1DA058220-01",
         "url": "https://reporter.nih.gov/project-details/10662071",
         "include_in_table": true

--- a/src/encoded/static/components/viz/AboutPageVisualizations/ConsortiumMap/data/consortia.json
+++ b/src/encoded/static/components/viz/AboutPageVisualizations/ConsortiumMap/data/consortia.json
@@ -40,7 +40,8 @@
         "marker-color-hex": "#984ea3",
         "project": "Tissue Procurement Center (TPC) Supporting the Somatic Mosaicism across Human Tissues (SMaHT) Network",
         "project-number": "1U24MH133204-01",
-        "url": "https://reporter.nih.gov/project-details/10661300"
+        "url": "https://reporter.nih.gov/project-details/10661300",
+        "include_in_table": true
     },
     {
         "x": 940,
@@ -68,7 +69,8 @@
         "marker-color-hex": "#ff7f00",
         "project": "Mosaicism in Human Tissues, from Telomere to Telomere to RFA-22-013: Somatic Mosaicism across Human Tissues Program: Genome Characterization Centers.",
         "project-number": "1UM1DA058220-01",
-        "url": "https://reporter.nih.gov/project-details/10662071"
+        "url": "https://reporter.nih.gov/project-details/10662071",
+        "include_in_table": true
     },
     {
         "x": 912,

--- a/src/encoded/static/components/viz/AboutPageVisualizations/ConsortiumMap/data/consortia_labels.json
+++ b/src/encoded/static/components/viz/AboutPageVisualizations/ConsortiumMap/data/consortia_labels.json
@@ -22,7 +22,7 @@
     {
         "x": 70,
         "y": 65,
-        "institution": ["Seattle Children's", "Hospital"]
+        "institution": ["University of Washington &", "Seattle Children's Hospital"]
     },
     {
         "x": 945,


### PR DESCRIPTION
Corresponds to [Trello ticket 301](https://trello.com/c/2cdN64Wc/301-fix-missing-awardees-in-table).
* Small PR to include consortiums into the awardees table.

Deployed to [smaht-devtest](https://devtest.smaht.org/about/consortium/awardees).