### PR TITLE
SN Remove tissue recovery_interval

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,17 @@ smaht-portal
 Change Log
 ----------
 
+0.73.0
+======
+
+`PR 206: SN Remove tisuse recovery_interval  <https://github.com/smaht-dac/smaht-portal/pull/206>`_
+
+* Removes `recovery_interval` property from Tissue schema
+* Includes upgrader for tissue schema from version 2 to 3 with test
+* All existing `recovery_interval` values for Tissue items have already been transferred to TissueCollection items linked to Donor
+
+
+
 0.72.0
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.72.0"
+version = "0.73.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/mixins.json
+++ b/src/encoded/schemas/mixins.json
@@ -343,7 +343,8 @@
                 "lb_ipsc_4",
                 "lb_ipsc_52",
                 "lb_ipsc_60",
-                "tissue"
+                "tissue",
+                "colo829_snv_indel_challenge_data"
             ]
         }
     },

--- a/src/encoded/schemas/tissue.json
+++ b/src/encoded/schemas/tissue.json
@@ -79,7 +79,7 @@
             ]
         },
         "schema_version": {
-            "default": "2"
+            "default": "3"
         },
         "submitted_id": {
             "pattern": "^[A-Z0-9]{3,}_TISSUE_[A-Z0-9-_.]{4,}$"
@@ -124,12 +124,6 @@
                     "format": "date"
                 }
             ]
-        },
-        "recovery_interval": {
-            "title": "Recovery Interval",
-            "description": "Time interval of tissue recovery (minutes)",
-            "type": "integer",
-            "minimum": 0
         },
         "sample_count": {
             "title": "Sample Count",

--- a/src/encoded/tests/test_upgrade_tissue.py
+++ b/src/encoded/tests/test_upgrade_tissue.py
@@ -8,8 +8,8 @@ from .utils import get_upgrader
 @pytest.mark.parametrize(
     "tissue,expected",
     [
-        ({}, {"schema_version": "2"}),
-        ({"recovery_interval": 123}, {"schema_version": "2"}),
+        ({}, {"schema_version": "3"}),
+        ({"recovery_interval": 123}, {"schema_version": "3"}),
     ],
 )
 def test_upgrade_tissue_2_3(

--- a/src/encoded/tests/test_upgrade_tissue.py
+++ b/src/encoded/tests/test_upgrade_tissue.py
@@ -1,0 +1,25 @@
+from typing import Any, Dict
+
+import pytest
+from pyramid.router import Router
+
+from .utils import get_upgrader
+
+@pytest.mark.parametrize(
+    "tissue,expected",
+    [
+        ({}, {"schema_version": "2"}),
+        ({"recovery_interval": 123}, {"schema_version": "2"}),
+    ],
+)
+def test_upgrade_tissue_2_3(
+    app: Router, tissue: Dict[str, Any], expected: Dict[str, Any]
+) -> None:
+    """Test tissue upgrader from version 2 to 3."""
+    upgrader = get_upgrader(app)
+    assert (
+        upgrader.upgrade(
+            "tissue", tissue, current_version="2", target_version="3"
+        )
+        == expected
+    )

--- a/src/encoded/upgrade/tissue.py
+++ b/src/encoded/upgrade/tissue.py
@@ -9,3 +9,10 @@ def upgrade_tissue_1_2(value: Dict[str, Any], system: Dict[str, Any]) -> Dict[st
     if existing_location:
         value["anatomical_location"] = existing_location
         del value["location"]
+
+
+@upgrade_step("tissue", "2", "3")
+def upgrade_tissue_2_3(value: Dict[str, Any], system: Dict[str, Any]) -> Dict[str, Any]:
+    existing_recovery_interval = value.get("recovery_interval")
+    if existing_recovery_interval:
+        del value["recovery_interval"]


### PR DESCRIPTION
Removes `recovery_interval` property from Tissue schema
- Includes upgrader for tissue schema from version 2 to 3 with test
- All existing `recovery_interval` values for Tissue items have already been transferred to TissueCollection items linked to Donor