### PR TITLE
SN Add functionality for arrays of objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ smaht-portal
 Change Log
 ----------
 
+0.78.0
+======
+`PR212: Add functionality for arrays of objects <https://github.com/smaht-dac/smaht-portal/pull/212>`_
+* Updates write_submission_spreadsheets to write out columns for arrays of objects
+* Currently relevant for CellCultureMixture and the components property which has two nested properties, `ratio` and `cull_culture`
+
+
 0.77.0
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.77.0"
+version = "0.78.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/commands/write_submission_spreadsheets.py
+++ b/src/encoded/commands/write_submission_spreadsheets.py
@@ -531,7 +531,6 @@ def get_property(property_name: str, property_schema: Dict[str, Any]) -> Propert
 
 def get_nested_properties(property_name: str, property_schema: Dict[str, Any]) -> List[Property]:
     """Get nested property information if property is array of objects, otherwise get property information."""
-    import pdb; pdb.set_trace()
     if object_array := is_property_array_of_objects(property_schema):
         return get_array_object_properties(property_name, object_array)
     return [get_property(property_name,property_schema)]

--- a/src/encoded/commands/write_submission_spreadsheets.py
+++ b/src/encoded/commands/write_submission_spreadsheets.py
@@ -531,15 +531,18 @@ def get_property(property_name: str, property_schema: Dict[str, Any]) -> Propert
 
 def get_nested_properties(property_name: str, property_schema: Dict[str, Any]) -> List[Property]:
     """Get nested property information if property is array of objects, otherwise get property information."""
-    if object_array := is_property_array_of_objects(property_schema):
-        return get_array_object_properties(property_name, object_array)
+    if object_array := get_array_object_properties(property_schema):
+        return get_nested_property(property_name, object_array)
     return [get_property(property_name,property_schema)]
 
 
-def get_array_object_properties(property_name:str, property_schema: Dict[str, Any]) -> List[Property]:
-    """Get property information for nested objects."""
+def get_nested_property(property_name:str, property_schema: Dict[str, Any]) -> List[Property]:
+    """Get property information for nested objects.
+    
+    `count` value is arbitrarily set to 2 to show that multiple values can be accepted in the template
+    """
     object_properties = []
-    count = 2 # duplicate columns twice to show that multiple values are accepted
+    count = 2 
     for index in range(0,count): 
         for key, value in property_schema.items():
             combined_property_name=f"{property_name}#{index}.{key}"
@@ -549,7 +552,7 @@ def get_array_object_properties(property_name:str, property_schema: Dict[str, An
     return object_properties
 
 
-def is_property_array_of_objects(property_schema: Dict[str, Any]) -> Union[Dict[str,Any], None]:
+def get_array_object_properties(property_schema: Dict[str, Any]) -> Union[Dict[str,Any], None]:
     """Get nested properties if property is an array of objects."""
     if item := property_schema.get("items",""):
         return item.get("properties","")

--- a/src/encoded/tests/test_write_submission_spreadsheets.py
+++ b/src/encoded/tests/test_write_submission_spreadsheets.py
@@ -22,6 +22,7 @@ from ..commands.write_submission_spreadsheets import (
     get_font,
     get_ordered_properties,
     get_property,
+    get_nested_properties,
     get_spreadsheet,
     is_link,
     write_all_spreadsheets,
@@ -296,7 +297,7 @@ def test_get_spreadsheet(submission_schema: Dict[str, Any]) -> None:
         (  # Simple case with defaults
             "bar",
             {},
-            [Property(
+            Property(
                 name="bar",
                 description="",
                 value_type="",
@@ -310,7 +311,7 @@ def test_get_spreadsheet(submission_schema: Dict[str, Any]) -> None:
                 format_="",
                 requires=[],
                 exclusive_requirements=[],
-            )],
+            ),
         ),
         (  # More complicated case with most attributes
             "baz",
@@ -327,7 +328,7 @@ def test_get_spreadsheet(submission_schema: Dict[str, Any]) -> None:
                 "also_requires": ["foo"],
                 "required_if_not_one_of": ["bar"],
             },
-            [Property(
+            Property(
                 name="baz",
                 description="Baz",
                 value_type="number",
@@ -341,7 +342,7 @@ def test_get_spreadsheet(submission_schema: Dict[str, Any]) -> None:
                 format_="format",
                 requires=["foo"],
                 exclusive_requirements=["bar"],
-            )],
+            ),
         ),
         (  # More complicated case with suggested_enum
             "baz",
@@ -358,7 +359,7 @@ def test_get_spreadsheet(submission_schema: Dict[str, Any]) -> None:
                 "also_requires": ["foo"],
                 "required_if_not_one_of": ["bar"],
             },
-            [Property(
+            Property(
                 name="baz",
                 description="Baz",
                 value_type="number",
@@ -372,8 +373,24 @@ def test_get_spreadsheet(submission_schema: Dict[str, Any]) -> None:
                 format_="format",
                 requires=["foo"],
                 exclusive_requirements=["bar"],
-            )],
+            ),
         ),
+    ],
+)
+def test_get_property(
+    property_name: str, property_schema: Dict[str, Any], expected: Property
+) -> None:
+    """Test creation of Property class from schema.
+
+    For more complicated attributes, see respective unit tests.
+    """
+    property_ = get_property(property_name, property_schema)
+    assert property_ == expected
+
+
+@pytest.mark.parametrize(
+    "property_name,property_schema,expected",
+    [
         (
             "baz", # test array of objects
             {
@@ -387,49 +404,49 @@ def test_get_spreadsheet(submission_schema: Dict[str, Any]) -> None:
                             "type": "number"
                         }
                     }
-                },
+                }
             },
-            [Property(
-                name="baz#0.foo",
-                description="Foo",
-                value_type="number",
-                required=False,
-                link=False,
-                enum=[],
-                array_subtype="",
-                pattern="",
-                comment="",
-                examples=[],
-                format_="",
-                requires=[],
-                exclusive_requirements=[],
-            ),
-            Property(
-                name="baz#1.foo",
-                description="Foo",
-                value_type="number",
-                required=False,
-                link=False,
-                enum=[],
-                array_subtype="",
-                pattern="",
-                comment="",
-                examples=[],
-                format_="",
-                requires=[],
-                exclusive_requirements=[],
-            )],
+            [
+                Property(
+                    name="baz#0.foo",
+                    description="Foo",
+                    value_type="number",
+                    required=False,
+                    link=False,
+                    enum=[],
+                    array_subtype="",
+                    pattern="",
+                    comment="",
+                    examples=[],
+                    format_="",
+                    requires=[],
+                    exclusive_requirements=[],
+                ),
+                Property(
+                    name="baz#1.foo",
+                    description="Foo",
+                    value_type="number",
+                    required=False,
+                    link=False,
+                    enum=[],
+                    array_subtype="",
+                    pattern="",
+                    comment="",
+                    examples=[],
+                    format_="",
+                    requires=[],
+                    exclusive_requirements=[],
+                )
+            ]
         ),
-    ],
+    ]
 )
-def test_get_property(
+def test_get_nested_properties(
     property_name: str, property_schema: Dict[str, Any], expected: Property
 ) -> None:
-    """Test creation of Property class from schema.
-
-    For more complicated attributes, see respective unit tests.
+    """Test get_nested_properties from schema.
     """
-    property_ = get_property(property_name, property_schema)
+    property_ = get_nested_properties(property_name, property_schema)
     assert property_ == expected
 
 

--- a/src/encoded/tests/test_write_submission_spreadsheets.py
+++ b/src/encoded/tests/test_write_submission_spreadsheets.py
@@ -374,6 +374,52 @@ def test_get_spreadsheet(submission_schema: Dict[str, Any]) -> None:
                 exclusive_requirements=["bar"],
             )],
         ),
+        (
+            "baz", # test array of objects
+            {
+                "description": "Baz",
+                "type": "array",
+                "is_required": True,
+                "items": {
+                    "properties": {
+                        "foo": {
+                            "description": "Foo",
+                            "type": "number"
+                        }
+                    }
+                },
+            },
+            [Property(
+                name="baz#0.foo",
+                description="Foo",
+                value_type="number",
+                required=False,
+                link=False,
+                enum=[],
+                array_subtype="",
+                pattern="",
+                comment="",
+                examples=[],
+                format_="",
+                requires=[],
+                exclusive_requirements=[],
+            ),
+            Property(
+                name="baz#1.foo",
+                description="Foo",
+                value_type="number",
+                required=False,
+                link=False,
+                enum=[],
+                array_subtype="",
+                pattern="",
+                comment="",
+                examples=[],
+                format_="",
+                requires=[],
+                exclusive_requirements=[],
+            )],
+        ),
     ],
 )
 def test_get_property(

--- a/src/encoded/tests/test_write_submission_spreadsheets.py
+++ b/src/encoded/tests/test_write_submission_spreadsheets.py
@@ -296,7 +296,7 @@ def test_get_spreadsheet(submission_schema: Dict[str, Any]) -> None:
         (  # Simple case with defaults
             "bar",
             {},
-            Property(
+            [Property(
                 name="bar",
                 description="",
                 value_type="",
@@ -310,7 +310,7 @@ def test_get_spreadsheet(submission_schema: Dict[str, Any]) -> None:
                 format_="",
                 requires=[],
                 exclusive_requirements=[],
-            ),
+            )],
         ),
         (  # More complicated case with most attributes
             "baz",
@@ -327,7 +327,7 @@ def test_get_spreadsheet(submission_schema: Dict[str, Any]) -> None:
                 "also_requires": ["foo"],
                 "required_if_not_one_of": ["bar"],
             },
-            Property(
+            [Property(
                 name="baz",
                 description="Baz",
                 value_type="number",
@@ -341,7 +341,7 @@ def test_get_spreadsheet(submission_schema: Dict[str, Any]) -> None:
                 format_="format",
                 requires=["foo"],
                 exclusive_requirements=["bar"],
-            ),
+            )],
         ),
         (  # More complicated case with suggested_enum
             "baz",
@@ -358,7 +358,7 @@ def test_get_spreadsheet(submission_schema: Dict[str, Any]) -> None:
                 "also_requires": ["foo"],
                 "required_if_not_one_of": ["bar"],
             },
-            Property(
+            [Property(
                 name="baz",
                 description="Baz",
                 value_type="number",
@@ -372,7 +372,7 @@ def test_get_spreadsheet(submission_schema: Dict[str, Any]) -> None:
                 format_="format",
                 requires=["foo"],
                 exclusive_requirements=["bar"],
-            ),
+            )],
         ),
     ],
 )


### PR DESCRIPTION
Updates `write_submission_spreadsheets` to write out columns for arrays of objects
- Currently relevant for CellCultureMixture and the `components` property which has two nested properties, `ratio` and `cull_culture`
- Output of script looks like this 
[cell_culture_mixture_submission.xlsx](https://github.com/user-attachments/files/16395074/cell_culture_mixture_submission.xlsx)
