### PR TITLE
SN Include target_coverage in file data_generation_summary

### DIFF
--- a/src/encoded/item_utils/sequencing.py
+++ b/src/encoded/item_utils/sequencing.py
@@ -16,6 +16,11 @@ def get_target_read_length(properties: Dict[str, Any]) -> Union[int, None]:
     return properties.get("target_read_length")
 
 
+def get_target_coverage(properties: Dict[str, Any]) -> Union[int, None]:
+    """Get target coverage from properties."""
+    return properties.get("target_coverage")
+
+
 def get_flow_cell(properties: Dict[str, Any]) -> str:
     """Get flow cell from properties."""
     return properties.get("flow_cell", "")

--- a/src/encoded/tests/test_types_file.py
+++ b/src/encoded/tests/test_types_file.py
@@ -998,6 +998,12 @@ def assert_data_generation_summary_matches_expected(
         )
         for sequencing in sequencings
     ] if sequencings else []
+    expected_target_coverage = [
+        sequencing_utils.get_target_coverage(
+            get_item(es_testapp, item_utils.get_uuid(sequencing))
+        )
+        for sequencing in sequencings
+    ] if sequencings else []
     assert_values_match_if_present(
         data_generation_summary, "data_category", expected_data_category
     )
@@ -1013,6 +1019,9 @@ def assert_data_generation_summary_matches_expected(
     assert_values_match_if_present(data_generation_summary, "assays", expected_assays)
     assert_values_match_if_present(
         data_generation_summary, "sequencing_platforms", expected_platforms
+    )
+    assert_values_match_if_present(
+        data_generation_summary,"target_group_coverage",expected_target_coverage
     )
 
 

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -55,6 +55,7 @@ from ..item_utils import (
     sample as sample_utils,
     software as software_utils,
     tissue as tissue_utils,
+    sequencing as sequencing_utils
 )
 from ..item_utils.utils import (
     get_property_value_from_identifier,
@@ -187,6 +188,7 @@ class CalcPropConstants:
     DATA_GENERATION_SUBMISSION_CENTERS = "submission_centers"
     DATA_GENERATION_ASSAYS = "assays"
     DATA_GENERATION_SEQUENCING_PLATFORMS = "sequencing_platforms"
+    DATA_GENERATION_TARGET_COVERAGE = "target_group_coverage"
     DATA_GENERATION_SCHEMA = {
         "title": "Data Generation Summary",
         "description": "Summary of data generation",
@@ -231,6 +233,13 @@ class CalcPropConstants:
                     "type": "string",
                 },
             },
+            DATA_GENERATION_TARGET_COVERAGE: {
+                "title": "Target Group Coverage",
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
         },
     }
     SAMPLE_SUMMARY_DONOR_IDS = "donor_ids"
@@ -325,6 +334,7 @@ def _build_file_embedded_list() -> List[str]:
         # Facets + Data generation summary + Link calcprops
         "file_sets.libraries.assay",
         "file_sets.sequencing.sequencer",
+        "file_sets.sequencing.target_coverage",
 
         # Sample summary + Link calcprops
         "file_sets.libraries.analytes.molecule",
@@ -834,6 +844,13 @@ class File(Item, CoreFile):
                     item_utils.get_display_title,
                 )
             ),
+            constants.DATA_GENERATION_TARGET_COVERAGE: (
+                get_property_values_from_identifiers(
+                    request_handler,
+                    file_utils.get_sequencings(file_properties, request_handler),
+                    sequencing_utils.get_target_coverage
+                )
+            )
         }
         return {
             key: value for key, value in to_include.items() if value


### PR DESCRIPTION
Embed `file_sets.sequencing.target_coverage` in `file.py` and adds "Target Group Coverage" to `data_generation_summary` used in the File Overview Page