### PR TITLE
Repair file_group

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ smaht-portal
 Change Log
 ----------
 
+0.83.1
+======
+
+* Updates `file_group` calcprop to properly resolve analyte.samples only when computing the `sample_source_part`
+
+
 0.83.0
 ======
 `PR226: SN Add tissue link to cell_culture <https://github.com/smaht-dac/smaht-portal/pull/226>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.83.0"
+version = "0.83.1"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/item_utils/file_set.py
+++ b/src/encoded/item_utils/file_set.py
@@ -47,7 +47,7 @@ def get_samples(
         result = get_property_values_from_identifiers(
             request_handler,
             get_libraries(file_set),
-            partial(library_utils.get_samples, request_handler=request_handler),
+            partial(library_utils.get_all_samples, request_handler=request_handler),
         )
     return result
 

--- a/src/encoded/item_utils/library.py
+++ b/src/encoded/item_utils/library.py
@@ -15,7 +15,7 @@ def get_analytes(library: Dict[str, Any]) -> List[Union[str, Dict[str, Any]]]:
     return library.get("analytes", [])
 
 
-def get_samples(
+def get_all_samples(
     library: Dict[str, Any], request_handler: Optional[RequestHandler] = None
 ) -> List[str]:
     """Get samples connected to library."""
@@ -28,6 +28,19 @@ def get_samples(
     return []
 
 
+def get_samples(
+    library: Dict[str, Any], request_handler: Optional[RequestHandler] = None
+) -> List[str]:
+    """Get samples connected to library."""
+    if request_handler:
+        return get_property_values_from_identifiers(
+            request_handler,
+            get_analytes(library),
+            partial(analyte_utils.get_samples, request_handler),
+        )
+    return []
+
+
 def get_sample_sources(
     library: Dict[str, Any], request_handler: Optional[RequestHandler] = None
 ) -> List[str]:
@@ -35,7 +48,7 @@ def get_sample_sources(
     if request_handler:
         return get_property_values_from_identifiers(
             request_handler,
-            get_samples(library, request_handler=request_handler),
+            get_all_samples(library, request_handler=request_handler),
             sample_utils.get_sample_sources,
         )
     return []

--- a/src/encoded/item_utils/library.py
+++ b/src/encoded/item_utils/library.py
@@ -2,7 +2,7 @@ from functools import partial
 from typing import Any, Dict, List, Optional, Union
 
 from . import analyte as analyte_utils, sample as sample_utils
-from .utils import RequestHandler, get_property_values_from_identifiers
+from .utils import RequestHandler, get_property_values_from_identifiers, get_property_value_from_identifier
 
 
 def get_assay(library: Dict[str, Any]) -> Union[str, Dict[str, Any]]:
@@ -33,10 +33,10 @@ def get_samples(
 ) -> List[str]:
     """Get samples connected to library."""
     if request_handler:
-        return get_property_values_from_identifiers(
+        return get_property_value_from_identifier(
             request_handler,
             get_analytes(library),
-            partial(analyte_utils.get_samples, request_handler),
+            analyte_utils.get_samples,
         )
     return []
 

--- a/src/encoded/item_utils/library.py
+++ b/src/encoded/item_utils/library.py
@@ -18,7 +18,7 @@ def get_analytes(library: Dict[str, Any]) -> List[Union[str, Dict[str, Any]]]:
 def get_all_samples(
     library: Dict[str, Any], request_handler: Optional[RequestHandler] = None
 ) -> List[str]:
-    """Get samples connected to library."""
+    """Get all samples (including parent_samples) connected to library."""
     if request_handler:
         return get_property_values_from_identifiers(
             request_handler,
@@ -31,7 +31,7 @@ def get_all_samples(
 def get_samples(
     library: Dict[str, Any], request_handler: Optional[RequestHandler] = None
 ) -> List[str]:
-    """Get samples connected to library."""
+    """Get samples (excluding parent_samples) connected to library."""
     if request_handler:
         return get_property_values_from_identifiers(
             request_handler,

--- a/src/encoded/item_utils/library.py
+++ b/src/encoded/item_utils/library.py
@@ -2,7 +2,7 @@ from functools import partial
 from typing import Any, Dict, List, Optional, Union
 
 from . import analyte as analyte_utils, sample as sample_utils
-from .utils import RequestHandler, get_property_values_from_identifiers, get_property_value_from_identifier
+from .utils import RequestHandler, get_property_values_from_identifiers
 
 
 def get_assay(library: Dict[str, Any]) -> Union[str, Dict[str, Any]]:
@@ -33,7 +33,7 @@ def get_samples(
 ) -> List[str]:
     """Get samples connected to library."""
     if request_handler:
-        return get_property_value_from_identifier(
+        return get_property_values_from_identifiers(
             request_handler,
             get_analytes(library),
             analyte_utils.get_samples,

--- a/src/encoded/types/file_set.py
+++ b/src/encoded/types/file_set.py
@@ -146,6 +146,7 @@ class FileSet(SubmittedItem):
         samples = library_utils.get_samples(
             library, request_handler=request_handler
         )
+        log.error(f'Got samples {samples} for library {library}')
         if len(samples) > 1:
             return None  # there is too much complexity
 
@@ -153,6 +154,7 @@ class FileSet(SubmittedItem):
         # sources field
         sample = samples[0]
         if 'tissue' in sample:
+            log.error(f'Attempting to grab submitted_id from {sample}')
             return get_property_value_from_identifier(
                 request_handler, sample, item_utils.get_submitted_id
             )
@@ -161,10 +163,12 @@ class FileSet(SubmittedItem):
         sample_sources = library_utils.get_sample_sources(
             library, request_handler=request_handler
         )
+        log.error(f'Got sample_sources {sample_sources}')
         if len(sample_sources) > 1:
             return None  # there is too much complexity
         else:
             sample_source = sample_sources[0]
+        log.error(f'Attempting to grab submitted_id from {sample_source}')
         return get_property_value_from_identifier(
             request_handler, sample_source, item_utils.get_submitted_id
         )

--- a/src/encoded/types/file_set.py
+++ b/src/encoded/types/file_set.py
@@ -147,7 +147,7 @@ class FileSet(SubmittedItem):
             library, request_handler=request_handler
         )
         log.error(f'Got samples {samples} for library {library}')
-        if len(samples) > 1:
+        if len(samples) > 1 or len(samples) == 0:
             return None  # there is too much complexity
 
         # If we are a tissue sample, generate this based on the sample field, not the sample

--- a/src/encoded/types/file_set.py
+++ b/src/encoded/types/file_set.py
@@ -146,7 +146,6 @@ class FileSet(SubmittedItem):
         samples = library_utils.get_samples(
             library, request_handler=request_handler
         )
-        log.error(f'Got samples {samples} for library {library}')
         if len(samples) > 1 or len(samples) == 0:
             return None  # there is too much complexity
 
@@ -154,7 +153,6 @@ class FileSet(SubmittedItem):
         # sources field
         sample = samples[0]
         if 'tissue' in sample:
-            log.error(f'Attempting to grab submitted_id from {sample}')
             return get_property_value_from_identifier(
                 request_handler, sample, item_utils.get_submitted_id
             )
@@ -163,12 +161,10 @@ class FileSet(SubmittedItem):
         sample_sources = library_utils.get_sample_sources(
             library, request_handler=request_handler
         )
-        log.error(f'Got sample_sources {sample_sources}')
         if len(sample_sources) > 1:
             return None  # there is too much complexity
         else:
             sample_source = sample_sources[0]
-        log.error(f'Attempting to grab submitted_id from {sample_source}')
         return get_property_value_from_identifier(
             request_handler, sample_source, item_utils.get_submitted_id
         )
@@ -220,17 +216,14 @@ class FileSet(SubmittedItem):
         request_handler = RequestHandler(request=request)
         library = file_set_utils.get_libraries(self.properties)
         if not library:
-            log.error(f'Did not get library for {self.properties}')
             return None
         library = request_handler.get_item(library[0])
         assay_part = self.generate_assay_part(request_handler, library)
         if not assay_part:  # we return none if this is a single cell assay to omit this prop
-            log.error(f'Did not get assay part for {assay_part}')
             return None
 
         sample_source_part = self.generate_sample_source_part(request_handler, library)
         if not sample_source_part:
-            log.error(f'Did not get sample_source_part for {library}')
             return None
 
         # If we've reached this part, the library/assay is compatible
@@ -239,7 +232,6 @@ class FileSet(SubmittedItem):
         )
         sequencing_part = self.generate_sequencing_part(request_handler, sequencing)
         if not sequencing_part:
-            log.error(f'Did not get sequencing part for {sequencing}')
             return None
 
         # We need this because sequencing and sample submission centers could be different


### PR DESCRIPTION
- Adds `get_samples` to `library_utils` to indicate retrieving _only_ the `samples` field from `analyte`, and clarify/refactor use of old definition of `get_samples` to new function `get_all_samples`