### PR TITLE
SN Cell Culture upgrade

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ smaht-portal
 Change Log
 ----------
 
+0.84.0
+======
+`PR 229`: SN Cell Culture upgrade `<https://github.com/smaht-dac/smaht-portal/pull/229>`_
+* Change `CellCulture.cell_line` property to be an array of strings linking to `CellLine`, rather than a string.
+  * Adds an upgrader with test for `cell_culture`
+
+
 0.83.0
 ======
 `PR226: SN Add tissue link to cell_culture <https://github.com/smaht-dac/smaht-portal/pull/226>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.83.0"
+version = "0.84.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/item_utils/cell_culture.py
+++ b/src/encoded/item_utils/cell_culture.py
@@ -10,4 +10,4 @@ def is_cell_culture(properties: Dict[str, Any]) -> bool:
 
 def get_cell_line(properties: Dict[str, Any]) -> Union[Dict[str, Any], str]:
     """Get the cell line of a cell culture."""
-    return properties.get("cell_line", "")
+    return properties.get("cell_line", [])

--- a/src/encoded/item_utils/sample.py
+++ b/src/encoded/item_utils/sample.py
@@ -163,13 +163,11 @@ def get_sample_source_description(
             request_handler, sample_source
         )
     if cell_culture.is_cell_culture(sample_source):
-        result = [
-            get_property_value_from_identifier(
+        result = get_property_value_from_identifier(
                 request_handler,
                 cell_culture.get_cell_line(sample_source),
                 item.get_code,
             )
-        ]
     return result
 
 

--- a/src/encoded/item_utils/sample.py
+++ b/src/encoded/item_utils/sample.py
@@ -12,7 +12,6 @@ from . import (
     tissue_sample,
 )
 from .utils import (
-    get_property_value_from_identifier,
     get_property_values_from_identifiers,
     RequestHandler,
 )
@@ -163,7 +162,7 @@ def get_sample_source_description(
             request_handler, sample_source
         )
     if cell_culture.is_cell_culture(sample_source):
-        result = get_property_value_from_identifier(
+        result = get_property_values_from_identifiers(
                 request_handler,
                 cell_culture.get_cell_line(sample_source),
                 item.get_code,

--- a/src/encoded/item_utils/sample_source.py
+++ b/src/encoded/item_utils/sample_source.py
@@ -46,7 +46,7 @@ def get_cell_lines(
     Currently only used for CellCulture and CellCultureMixtures.
     """
     if cell_culture.is_cell_culture(sample_source):
-        return [cell_culture.get_cell_line(sample_source)]
+        return cell_culture.get_cell_line(sample_source)
     if cell_culture_mixture.is_cell_culture_mixture(sample_source):
         return cell_culture_mixture.get_cell_lines(request_handler, sample_source)
     return []

--- a/src/encoded/item_utils/sample_source.py
+++ b/src/encoded/item_utils/sample_source.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 
 from . import cell_culture, cell_culture_mixture, constants, item, tissue
-from .utils import RequestHandler, get_property_value_from_identifier
+from .utils import RequestHandler, get_property_values_from_identifiers
 
 
 def get_code(request_handler: RequestHandler, sample_source: Dict[str, Any]) -> str:
@@ -12,7 +12,7 @@ def get_code(request_handler: RequestHandler, sample_source: Dict[str, Any]) -> 
     if cell_culture_mixture.is_cell_culture_mixture(sample_source):
         return item.get_code(sample_source)
     if cell_culture.is_cell_culture(sample_source):
-        return get_property_value_from_identifier(
+        return get_property_values_from_identifiers(
             request_handler,
             cell_culture.get_cell_line(sample_source),
             item.get_code,

--- a/src/encoded/schemas/cell_culture.json
+++ b/src/encoded/schemas/cell_culture.json
@@ -71,7 +71,7 @@
             "accessionType": "CC"
         },
         "schema_version": {
-            "default": "3"
+            "default": "4"
         },
         "culture_duration": {
             "title": "Culture Duration",
@@ -118,14 +118,20 @@
         "cell_line": {
             "title": "Cell Line",
             "description": "Cell line used for the cell culture",
-            "type": "string",
-            "linkTo": "CellLine"
+            "type": "array",
+            "items": {
+                "type": "string",
+                "linkTo": "CellLine"
+            }
         },
         "tissue": {
             "title": "Tissue",
             "description": "Tissue used for the cell culture",
-            "type": "string",
-            "linkTo": "Tissue"
+            "type": "array",
+            "items": {
+                "type": "string",
+                "linkTo": "Tissue"
+            }
         },
         "submitted_id": {
             "pattern": "^[A-Z0-9]{3,}_CELL-CULTURE_[A-Z0-9-_.]{4,}$"

--- a/src/encoded/tests/data/workbook-inserts/cell_culture.json
+++ b/src/encoded/tests/data/workbook-inserts/cell_culture.json
@@ -5,7 +5,7 @@
             "smaht"
         ],
         "submitted_id": "TEST_CELL-CULTURE_HELA",
-        "cell_line": "TEST_CELL-LINE_HELA",
+        "cell_line": ["TEST_CELL-LINE_HELA"],
         "culture_duration": 15,
         "culture_start_date": "2023-12-25",
         "growth_medium": "EMEM",
@@ -17,7 +17,7 @@
             "smaht"
         ],
         "submitted_id": "TEST_CELL-CULTURE_HEK293",
-        "cell_line": "TEST_CELL-LINE_HEK293"
+        "cell_line": ["TEST_CELL-LINE_HEK293"]
     },
     {
         "uuid": "3e1597a2-00b7-4953-b0d3-bb96344b1d28",
@@ -25,6 +25,6 @@
             "smaht"
         ],
         "submitted_id": "TEST_CELL-CULTURE_LIVER",
-        "tissue": "TEST_TISSUE_LIVER"
+        "tissue": ["TEST_TISSUE_LIVER"]
     }
 ]

--- a/src/encoded/tests/test_types_donor_specific_assembly.py
+++ b/src/encoded/tests/test_types_donor_specific_assembly.py
@@ -30,7 +30,7 @@ def test_cell_culture(
     test_cell_line
 ):
     item = {
-        "cell_line": test_cell_line["uuid"],
+        "cell_line": [test_cell_line["uuid"]],
         "submission_centers": [test_submission_center["uuid"]],
         "submitted_id": "TEST_CELL-CULTURE_HELA",
         "culture_duration": 15,

--- a/src/encoded/tests/test_upgrade_cell_culture.py
+++ b/src/encoded/tests/test_upgrade_cell_culture.py
@@ -60,3 +60,29 @@ def test_upgrade_cell_culture_2_3(
         )
         == expected
     )
+
+
+@pytest.mark.parametrize(
+    "cell_culture,expected",
+    [
+        ({}, {"schema_version": "4"}),
+        (
+            {
+                "cell_line": "SOME_CELL-LINE_XYZ",
+                "schema_version": "3",
+            },
+            {"cell_line": ["SOME_CELL-LINE_XYZ"], "schema_version": "4"},
+        ),
+    ],
+)
+def test_upgrade_cell_culture_3_4(
+    app: Router, cell_culture: Dict[str, Any], expected: Dict[str, Any]
+) -> None:
+    """Test cell culture upgrader from version 3 to 4."""
+    upgrader = get_upgrader(app)
+    assert (
+        upgrader.upgrade(
+            "cell_culture", cell_culture, current_version="3", target_version="4"
+        )
+        == expected
+    )

--- a/src/encoded/types/cell_culture_mixture.py
+++ b/src/encoded/types/cell_culture_mixture.py
@@ -5,7 +5,9 @@ from snovault import calculated_property, collection, load_schema
 
 from .cell_culture import CellCulture
 from .utils import get_item
-
+from ..item_utils import (
+    cell_culture as cell_culture_utils
+)
 
 def _build_cell_culture_mixture_embedded_list():
     """Embeds for CellCultureMixture."""
@@ -53,12 +55,10 @@ class CellCultureMixture(CellCulture):
                 get_item(request, cell_culture_id, collection="CellCulture")
                 for cell_culture_id in cell_culture_ids
             ]
-            cell_lines = set(
-                [
-                    cell_culture.get("cell_line") for cell_culture in cell_cultures
-                    if cell_culture.get("cell_line")
-                ]
-            )
+            cell_lines = []
+            for cell_culture in cell_cultures:
+                if cell_line := cell_culture_utils.get_cell_line(cell_culture):
+                    cell_lines += cell_line
             if cell_lines:
-                result = sorted(list(cell_lines))
+                result = sorted(list(set(cell_lines)))
         return result

--- a/src/encoded/upgrade/cell_culture.py
+++ b/src/encoded/upgrade/cell_culture.py
@@ -20,3 +20,11 @@ def upgrade_cell_culture_2_3(value: Dict[str, Any], system: Dict[str, Any]) -> N
         del value["doubling_time"]
     if "doubling_number" in value:
         del value["doubling_number"]
+
+
+@upgrade_step("cell_culture", "3", "4")
+def upgrade_cell_culture_3_4(value: Dict[str, Any], system: Dict[str, Any]) -> Dict[str, Any]:
+    """Change `cell_line` linkTo to `cell_line` list of linkTos."""
+    cell_line = value.get("cell_line")
+    if cell_line:
+        value["cell_line"] = [cell_line]


### PR DESCRIPTION
Change `CellCulture.cell_line` property to be an `array` of `strings` linking to `CellLine`, rather than a `string`.
- Adds an upgrader with tests for `cell_culture`  