### PR TITLE
SN Make antibody an array

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ smaht-portal
 Change Log
 ----------
 
+0.90.2
+======
+`PR 245: SN Make antibody an array <https://github.com/smaht-dac/smaht-portal/pull/245>`_
+* In Library, make `antibody` and array of strings
+* Small fix to submission template delimiter description
+
+
 0.90.1
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.90.1"
+version = "0.90.2"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/commands/write_submission_spreadsheets.py
+++ b/src/encoded/commands/write_submission_spreadsheets.py
@@ -883,7 +883,7 @@ def get_comment_value_type(property_: Property, indent: str) -> List[str]:
             return [
                 (
                     f"Type:{indent}{property_.array_subtype}"
-                    f"{indent}(Multiple values allowed. Use '|' as a delimiter)"
+                    f"{indent}(Multiple values allowed. Use '|' as a delimiter.)"
                 )
             ]
         else:

--- a/src/encoded/schemas/library.json
+++ b/src/encoded/schemas/library.json
@@ -98,11 +98,14 @@
         "antibody": {
             "title": "Antibody",
             "description":"Antibody used for affinity enrichment",
-            "type": "string",
-            "suggested_enum": [
-                "H3K4me3",
-                "RNAPII"
-            ]
+            "type": "array",
+            "items": {
+                "type": "string",
+                "suggested_enum": [
+                    "H3K4me3",
+                    "RNAPII"
+                ]
+            }
         },
         "barcode_sequences": {
             "title": "Barcode Sequences",

--- a/src/encoded/tests/test_write_submission_spreadsheets.py
+++ b/src/encoded/tests/test_write_submission_spreadsheets.py
@@ -573,7 +573,7 @@ def test_get_ordered_properties(
         ),
         (  # Array type
             Property("foo", value_type="array", array_subtype="string"),
-            "Type:  string  (Multiple values allowed. Use '|' as a delimiter)\nRequired:  No",
+            "Type:  string  (Multiple values allowed. Use '|' as a delimiter.)\nRequired:  No",
         ),
         (  # Possibly required
             Property("foo", exclusive_requirements=["bar", "bu"]),


### PR DESCRIPTION
- In Library, change `antibody` property to an array of strings (property is new and currently empty on the portal)
- Small fix to submission template delimiter description