### PR TITLE
Server-side validation skip when skip_links=True

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ smaht-portal
 Change Log
 ----------
 
+0.93.0
+======
+* Effectively disable server-side validators which reference
+  linked objects for smaht-submitr, when the skip_links=True.
+
+
 0.92.0
 ======
 `PR244: SN FileSet calcprop <https://github.com/smaht-dac/smaht-portal/pull/244>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.92.0"
+version = "0.92.0.1b1"  # TODO: To become 0.93.0
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.92.0.1b1"  # TODO: To become 0.93.0
+version = "0.93.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/types/file_set.py
+++ b/src/encoded/types/file_set.py
@@ -4,6 +4,7 @@ from pyramid.view import view_config
 from pyramid.request import Request
 from snovault import calculated_property, collection, load_schema
 from snovault.util import debug_log, get_item_or_none
+from encoded.validator_decorators import link_related_validator
 import structlog
 
 from .submitted_item import (
@@ -293,6 +294,7 @@ class FileSet(SubmittedItem):
         return result
 
 
+@link_related_validator
 def validate_compatible_assay_and_sequencer_on_add(context, request):
     """Check filesets to make sure they are linked to compatible library.assay and sequencing items on add.
     

--- a/src/encoded/types/library.py
+++ b/src/encoded/types/library.py
@@ -1,5 +1,6 @@
 from snovault import collection, load_schema
 from snovault.util import debug_log, get_item_or_none
+from encoded.validator_decorators import link_related_validator
 
 from pyramid.view import view_config
 
@@ -49,6 +50,7 @@ class Library(SubmittedItem):
     class Collection(Item.Collection):
         pass
 
+@link_related_validator
 def validate_molecule_specific_assay_on_add(context, request):
     """Check that analyte.molecule includes the correct molecule for molecule-specific assays.
     

--- a/src/encoded/types/unaligned_reads.py
+++ b/src/encoded/types/unaligned_reads.py
@@ -1,5 +1,6 @@
 from snovault import collection, load_schema
 from snovault.util import debug_log, get_item_or_none
+from encoded.validator_decorators import link_related_validator
 from pyramid.view import view_config
 
 
@@ -37,6 +38,7 @@ class UnalignedReads(SubmittedFile):
         pass
 
 
+@link_related_validator
 def validate_read_pairs_on_add(context,request):
     """Check that file is R2 if it has `paired_with` and link of R2 files corresponds to an R1 file on add."""
     data = request.json

--- a/src/encoded/validator_decorators.py
+++ b/src/encoded/validator_decorators.py
@@ -1,0 +1,9 @@
+from typing import Callable
+
+def link_related_validator(wrapped_function: Callable) -> Callable:
+    def decorator(context, request) -> Callable:
+        nonlocal wrapped_function
+        if "skip_links=true" in request.url:
+            return
+        return wrapped_function(context, request)
+    return decorator


### PR DESCRIPTION
Effectively disable server-side validators which reference linked objects for smaht-submitr, when the skip_links=True.