### PR TITLE
Submission Status page bugfix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,10 +7,16 @@ smaht-portal
 Change Log
 ----------
 
+0.102.1
+=======
+* Bugfix on Submission Status page. Could not set tags from Review File Group Qc modal when there were no tags present
+
+
 0.102.0
 =======
 `PR267: SN Add target_read_count <https://github.com/smaht-dac/smaht-portal/pull/267>`_
 * Add `target_read_count` to File `data_generation_summary`
+
 
 0.101.0
 =======

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.102.0"
+version = "0.102.1"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/submission_status.py
+++ b/src/encoded/submission_status.py
@@ -97,7 +97,7 @@ def get_file_group_qc(context, request):
 
             filesets[fs.get(UUID)] = {
                 "uuid": fs.get(UUID),
-                "tags": fs.get("tags"),
+                "tags": fs.get("tags", []),
                 "comments": fs.get("comments", []),
                 "submitted_id": fs.get("submitted_id"),
             }


### PR DESCRIPTION
Bugfix on Submission Status page. Could not set tags from Review File Group Qc modal when there were no tags present