### PR TITLE
Access table button and table styles

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ smaht-portal
 Change Log
 ----------
 
+0.107.1
+=======
+
+`PR 281: Access table button and table styles <https://github.com/smaht-dac/smaht-portal/pull/281>`_
+
+* Bug fix: Make link buttons not underlined and access keys table reponsive for small and mid-size screens
+
+
 0.107.0
 =======
 `PR 235: Sn ExternalQualityMetric submission template <https://github.com/smaht-dac/smaht-portal/pull/235>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.107.0"
+version = "0.107.1"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/item-pages/UserView.js
+++ b/src/encoded/static/components/item-pages/UserView.js
@@ -386,27 +386,29 @@ const AccessKeyTable = React.memo(function AccessKeyTable({
     }
 
     return (
-        <table className="table table-responsive-md access-keys-table bg-white">
-            <thead>
-                <tr>
-                    <th>Access Key ID</th>
-                    <th>Created</th>
-                    <th>Expires</th>
-                    <th>Description</th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
-                {accessKeys.map(function (accessKey, idx) {
-                    return (
-                        <AccessKeyTableRow
-                            {...{ onDelete, onResetSecret, accessKey, idx }}
-                            key={idx}
-                        />
-                    );
-                })}
-            </tbody>
-        </table>
+        <div className="table-responsive-md">
+            <table className="table access-keys-table bg-white">
+                <thead>
+                    <tr>
+                        <th>Access Key ID</th>
+                        <th>Created</th>
+                        <th>Expires</th>
+                        <th>Description</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {accessKeys.map(function (accessKey, idx) {
+                        return (
+                            <AccessKeyTableRow
+                                {...{ onDelete, onResetSecret, accessKey, idx }}
+                                key={idx}
+                            />
+                        );
+                    })}
+                </tbody>
+            </table>
+        </div>
     );
 });
 

--- a/src/encoded/static/scss/encoded/_bootstrap-theme-overrides.scss
+++ b/src/encoded/static/scss/encoded/_bootstrap-theme-overrides.scss
@@ -77,6 +77,7 @@ $margin-util-sizes-mini: 1, 2, 3, 4, 5, 6, 7, 8; 		// * 1px
     font-weight: 400;
 	border-width: 2px;
 	border-radius: 5px; 
+	text-decoration: none;
 
 	/* The following heights are aligned to bootstrap btn padding and our font's calculated line-height. */
 	/* These must be updated in response to any font, bootstrap, etc. updates. */


### PR DESCRIPTION
Ticket: [Trello](https://trello.com/c/6CTX09G6/369-fix-button-styling-and-table-responsiveness)

This PR ensures that `btn-link` elements are never underlined and correctly applies the `table-responsive-md` class to the access keys table.

**Before:**

![Before 1](https://github.com/user-attachments/assets/e5c67531-9e5d-4ce1-a894-8edd343acd46)
![Before 2](https://github.com/user-attachments/assets/bfc9c313-ed88-414b-bcdb-e47322105757)

**After:**

![After 1](https://github.com/user-attachments/assets/b39c735c-70d3-4798-834b-c60b77e23759)
![After 2](https://github.com/user-attachments/assets/3a3990b3-0007-4250-9c3c-3a62d92aaa4a)
