### PR TITLE
SN recovery_datetime

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ smaht-portal
 Change Log
 ----------
 
+0.111.0
+=======
+`PR 291 SN recovery_datetime <https://github.com/smaht-dac/smaht-portal/pull/291>`_
+
+* Add `recovery_datetime` to Tissue Collection, to then remove this property from Tissue, as this can be considered identifying information
+
+
 0.110.0
 =======
 * 2024-11-04/dmichaels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.110.0"
+version = "0.111.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/tissue_collection.json
+++ b/src/encoded/schemas/tissue_collection.json
@@ -97,6 +97,19 @@
                 ]
             }
         },
+        "recovery_datetime": {
+            "title": "Recovery Datetime",
+            "description": "Date and time of tissue recovery",
+            "type": "string",
+            "anyOf": [
+                {
+                    "format": "date-time"
+                },
+                {
+                    "format": "date"
+                }
+            ]
+        },
         "recovery_interval": {
             "title": "Recovery Interval",
             "description": "Total time interval of tissue collection (minutes)",


### PR DESCRIPTION
- Add `recovery_datetime` to Tissue Collection, to then remove this property from Tissue, as this can be considered identifying information