### PR TITLE
SN File release tracker

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ smaht-portal
 Change Log
 ----------
 
+0.114.0
+=======
+`PR 298 SN File release tracker <https://github.com/smaht-dac/smaht-portal/pull/298>`_
+
+* Add calcprop to file returning concatenated string of `file_sets.libraries.assays.display_title`, `file_sets.sequencing.sequencer.display_title`, and `file_format.display_title`
+* If there are multiple values for assay or sequencer, return an empty string
+
+
 0.113.1
 =======
 `PR 294 BM Truth Set <https://github.com/smaht-dac/smaht-portal/pull/294>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.113.1"
+version = "0.114.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/item_utils/file.py
+++ b/src/encoded/item_utils/file.py
@@ -412,17 +412,11 @@ def has_mobile_element_insertions(file: Dict[str, Any]) -> bool:
     return "MEI" in get_data_type(file)
 
 
-def get_associated_files_status(
-    file: Dict[str, Any], request_handler: RequestHandler, at_id: str
-) -> List[str]:
-    """Get associated files status from the FileSet.files_status calcprop"""
-    return  get_property_values_from_identifiers(
-            request_handler,
-            get_file_sets(file),
-            partial(file_set.get_associated_files_status, request_handler, at_id)
-    )
-
-
 def get_override_group_coverage(file: Dict[str, Any]) -> str:
     """Get override group coverage from properties."""
     return file.get("override_group_coverage","")
+
+
+def get_release_tracker_description(file: Dict[str, Any]) -> str:
+    """Get release tracker description from properties."""
+    return file.get("release_tracker_description","")

--- a/src/encoded/tests/test_types_file.py
+++ b/src/encoded/tests/test_types_file.py
@@ -1201,6 +1201,35 @@ def assert_analysis_software_matches_expected(
         analysis_summary, "software", expected_software
     )
 
+
+@pytest.mark.workbook
+def test_release_tracker_description(es_testapp: TestApp, workbook: None) -> None:
+    """Ensure 'release_tracker_description' calcprop fields correct for inserts.
+
+    Checks fields present on inserts and as expected by parsing
+    properties/embeds."""
+    
+    search_key = "release_tracker_description"
+    file_without_release_tracker_description = search_type_for_key(
+        es_testapp, "File", search_key, exists=False
+    )
+    assert file_without_release_tracker_description  # Not expected for Reference Files
+
+    files_with_release_tracker_description = search_type_for_key(
+        es_testapp, "File", search_key
+    )
+    for file in files_with_release_tracker_description:
+        assert_release_tracker_description_matches_expected(file, es_testapp)
+
+
+def assert_release_tracker_description_matches_expected(file: Dict[str, Any], es_testapp: TestApp):
+    """Assert release_tracker_description calcprop matches expected."""
+    release_tracker_description = file_utils.get_release_tracker_description(file)
+
+    
+
+
+
 @pytest.mark.workbook
 def test_unique_key(es_testapp: TestApp, workbook: None) -> None:
     """Ensure `submitted_id` is valid unique key for File."""

--- a/src/encoded/tests/test_types_file.py
+++ b/src/encoded/tests/test_types_file.py
@@ -1224,7 +1224,24 @@ def test_release_tracker_description(es_testapp: TestApp, workbook: None) -> Non
 
 def assert_release_tracker_description_matches_expected(file: Dict[str, Any], es_testapp: TestApp):
     """Assert release_tracker_description calcprop matches expected."""
-    release_tracker_description = file_utils.get_release_tracker_description(file)
+
+    release_tracker_description = file_utils. get_release_tracker_description(file)
+
+    assay_from_calcprop = item_utils.get_display_title(
+        file_utils.get_assays(file)[0]
+    )
+    sequencer_from_calcprop = item_utils.get_display_title(
+        sequencing_utils.get_sequencer(
+            file_utils.get_sequencings(file)[0]
+        )
+    )
+    file_format = item_utils.get_display_title(
+        file_utils.get_file_format(file)
+    )                          
+    description_from_calcprops=f"{assay_from_calcprop} {sequencer_from_calcprop} {file_format}"
+    assert release_tracker_description == description_from_calcprops
+   
+    
 
     
 

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -712,7 +712,7 @@ class File(Item, CoreFile):
             request_handler = RequestHandler(request=request)
             result = self._get_release_tracker_description(
                 request_handler,
-                file_properties=self.propertes
+                file_properties=self.properties
             )
         return result     
 
@@ -1008,11 +1008,12 @@ class File(Item, CoreFile):
         ) -> Union[str, None]:
         """Get release tracker description for display on the home page."""
         assay_title= get_unique_values(
-            file_utils.get_assays(file_properties),
+            request_handler.get_items(file_utils.get_assays(file_properties, request_handler)),
             item_utils.get_display_title,
             )
         sequencer_title = get_unique_values(
-            file_utils.get_sequencers(file_properties),
+            request_handler.get_items(
+            file_utils.get_sequencers(file_properties, request_handler)),
             item_utils.get_display_title,
             )
         file_format_title = get_property_value_from_identifier(

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -62,6 +62,7 @@ from ..item_utils import (
 from ..item_utils.utils import (
     get_property_value_from_identifier,
     get_property_values_from_identifiers,
+    get_unique_values,
     RequestHandler,
 )
 
@@ -251,6 +252,10 @@ class CalcPropConstants:
                 }
             }
         },
+    }
+    RELEASE_TRACKER_DESCRIPTION = {
+        "title": "Release Tracker Description",
+        "type": "string",
     }
     SAMPLE_SUMMARY_DONOR_IDS = "donor_ids"
     SAMPLE_SUMMARY_TISSUES = "tissues"
@@ -695,6 +700,22 @@ class File(Item, CoreFile):
             reference_genome=reference_genome,
         )
 
+    @calculated_property(schema=CalcPropConstants.RELEASE_TRACKER_DESCRIPTION)
+    def release_tracker_description(
+        self,
+        request: Request,
+        file_sets: Optional[List[str]] = None
+    ) -> Union[str, None]:
+        """Get file release tracker description for display on home page."""
+        result = None
+        if file_sets:
+            request_handler = RequestHandler(request=request)
+            result = self._get_release_tracker_description(
+                request_handler,
+                file_properties=self.propertes
+            )
+        return result     
+
     def _get_libraries(
         self, request: Request, file_sets: Optional[List[str]] = None
     ) -> List[str]:
@@ -979,6 +1000,38 @@ class File(Item, CoreFile):
             ),
         }
         return {key: value for key, value in to_include.items() if value}
+    
+    def _get_release_tracker_description(
+            self,
+            request_handler: RequestHandler,
+            file_properties: Dict[str, Any],
+        ) -> Union[str, None]:
+        """Get release tracker description for display on the home page."""
+        assay_title= get_unique_values(
+            file_utils.get_assays(file_properties),
+            item_utils.get_display_title,
+            )
+        sequencer_title = get_unique_values(
+            file_utils.get_sequencers(file_properties),
+            item_utils.get_display_title,
+            )
+        file_format_title = get_property_value_from_identifier(
+                request_handler,
+                file_utils.get_file_format(file_properties),
+                item_utils.get_display_title,
+            )
+        if len(assay_title) > 1 or len(sequencer_title) > 1:
+            # More than one unique assay or sequencer
+            return ""
+        elif len(assay_title) == 0 or len(sequencer_title) == 0:
+            # No assay or sequencer
+            return ""
+        to_include = [
+            assay_title[0],
+            sequencer_title[0],
+            file_format_title
+        ]
+        return " ".join(to_include)
 
 
 @view_config(name='drs', context=File, request_method='GET',


### PR DESCRIPTION
* Add calcprop to file returning concatenated string of `file_sets.libraries.assays.display_title`, `file_sets.sequencing.sequencer.display_title`, and `file_format.display_title` (e.g. "Fiber-seq PacBio Revio BAM", "Illumina WGS BAM")
* If there are multiple values for assay or sequencer, return an empty string