### PR TITLE
SN Rna-seq filenames

### DIFF
--- a/src/encoded/commands/create_annotated_filenames.py
+++ b/src/encoded/commands/create_annotated_filenames.py
@@ -914,6 +914,11 @@ def get_chain_file_value(file: Dict[str, Any]) -> str:
     return CHAIN_FILE_INFO_SEPARATOR.join([source_assembly,target_assembly])
 
 
+def get_rna_seq_tsv_value(file: Dict[str, Any]) -> str:
+    """Get isoform or gene from description and gencode version for RNA-seq tsv and bam files."""
+    # Use description and file format to determine with value
+    
+
 def get_file_extension(
     file: Dict[str, Any], file_format: Dict[str, Any]
 ) -> FilenamePart:

--- a/src/encoded/item_utils/file.py
+++ b/src/encoded/item_utils/file.py
@@ -76,6 +76,11 @@ def get_reference_genome(properties: Dict[str, Any]) -> Union[str, Dict[str, Any
     return properties.get("reference_genome", "")
 
 
+def get_gene_annotation(properties: Dict[str, Any]) -> Union[str, Dict[str, Any]]:
+    """Get gene annotation from properties."""
+    return properties.get("gene_annotation", "")
+
+
 def get_file_sets(properties: Dict[str, Any]) -> List[Union[str, Dict[str, Any]]]:
     """Get file sets from properties."""
     return properties.get("file_sets", [])
@@ -426,3 +431,8 @@ def get_associated_files_status(
 def get_override_group_coverage(file: Dict[str, Any]) -> str:
     """Get override group coverage from properties."""
     return file.get("override_group_coverage","")
+
+
+def is_rsem_tsv(properties: Dict[str, Any], request_handler: RequestHandler) -> bool:
+    """Check if file is an RSEM tsv output file."""
+    return get_file_extension(request_handler,properties) == "tsv" and "RNA Quantification" in get_data_category(properties)

--- a/src/encoded/item_utils/file_format.py
+++ b/src/encoded/item_utils/file_format.py
@@ -10,4 +10,8 @@ def get_other_allowed_extensions(properties: Dict[str, Any]) -> str:
 
 
 def is_chain_file(properties: Dict[str, Any]) -> bool:
-    return get_standard_file_extension(properties) == "chain.gz"
+    return get_standard_file_extension(properties) in ["chain.gz","chain"]
+
+
+def is_tsv_file(properties: Dict[str, Any]) -> bool:
+    return get_standard_file_extension(properties) == "tsv"

--- a/src/encoded/project/loadxl.py
+++ b/src/encoded/project/loadxl.py
@@ -11,6 +11,7 @@ class SMaHTProjectLoadxl(SnovaultProjectLoadxl):
         "file_format",
         "quality_metric",
         "reference_genome",
+        "gene_annotation",
         "software",
         "tracking_item",
         "image",

--- a/src/encoded/schemas/mixins.json
+++ b/src/encoded/schemas/mixins.json
@@ -364,6 +364,14 @@
             "minimum": 1
         }
     },
+    "gene_annotation": {
+        "gene_annotation": {
+            "title": "Gene Annotation",
+            "description": "Gene annotation used for gene or transcript quantification",
+            "type": "string",
+            "linkTo": "GeneAnnotation"
+        }
+    },
     "identifier": {
         "identifier": {
             "title": "Identifier",

--- a/src/encoded/schemas/output_file.json
+++ b/src/encoded/schemas/output_file.json
@@ -50,6 +50,9 @@
             "$ref": "mixins.json#/file_release"
         },
         {
+            "$ref": "mixins.json#/gene_annotation"
+        },
+        {
             "$ref": "mixins.json#/modified"
         },
         {

--- a/src/encoded/schemas/supplementary_file.json
+++ b/src/encoded/schemas/supplementary_file.json
@@ -36,6 +36,9 @@
             "$ref": "mixins.json#/file_release"
         },
         {
+            "$ref": "mixins.json#/gene_annotation"
+        },
+        {
             "$ref": "mixins.json#/modified"
         },
         {

--- a/src/encoded/tests/test_annotated_filename.py
+++ b/src/encoded/tests/test_annotated_filename.py
@@ -527,14 +527,24 @@ ANOTHER_SOFTWARE_VERSION = "2.3.4"
 ANOTHER_SOFTWARE = {"code": ANOTHER_SOFTWARE_CODE, "version": ANOTHER_SOFTWARE_VERSION}
 REFERENCE_GENOME_CODE = "GRCh38"
 TARGET_GENOME_CODE = "HELA_DSA"
+GENE_ANNOTATION_CODE = "gencode45"
 
 SOME_REFERENCE_GENOME = {"code": REFERENCE_GENOME_CODE}
+SOME_GENE_ANNOTATION = {"code": GENE_ANNOTATION_CODE}
 SOME_UNALIGNED_READS = {"data_type": ["Unaligned Reads"]}
 SOME_ALIGNED_READS = {"data_type": ["Aligned Reads"]}
 SOME_CHAIN_FILE = {
     "data_type": ["SupplementaryFile"],
     "source_assembly": REFERENCE_GENOME_CODE,
     "target_assembly": TARGET_GENOME_CODE
+}
+SOME_TSV_FILE = {
+    "data_type": ["Gene Expression"],
+    "data_category": ["RNA Quantification"]
+}
+SOME_ISOFORM_TSV_FILE = {
+    "data_type": ["Transcript Expression"],
+    "data_category": ["RNA Quantification"]
 }
 SOME_SOMATIC_VARIANT_CALLS = {"data_category": ["Somatic Variant Calls"]}
 SOME_VARIANT_CALLS = {
@@ -556,37 +566,45 @@ CHAIN_FILE_EXTENSION = {
     "standard_file_extension": "chain.gz",
     "valid_item_types": ["SupplementaryFile"]
 }
+TSV_FILE_EXTENSION = {
+    "identifier": "TSV",
+    "standard_file_extension": "tsv",
+    "valid_item_types": ["SupplementaryFile", "OutputFile"]
+}
 
 
 @pytest.mark.parametrize(
-    "file,software,reference_genome,file_extension,expected,errors",
+    "file,software,reference_genome,gene_annotation,file_extension,expected,errors",
     [
-        ({}, [], {}, {},"" , True),
-        (SOME_UNALIGNED_READS, [], {}, SOME_FILE_EXTENSION,DEFAULT_ABSENT_FIELD, False),
+        ({}, [], {}, {}, {},"" , True),
+        (SOME_UNALIGNED_READS, [], {}, {}, SOME_FILE_EXTENSION,DEFAULT_ABSENT_FIELD, False),
         (
             SOME_UNALIGNED_READS,
             [SOME_SOFTWARE],
+            {},
             {},
             SOME_FILE_EXTENSION,
             f"{SOFTWARE_CODE}_{SOFTWARE_VERSION}",
             False,
         ),
-        (SOME_UNALIGNED_READS, [SOME_SOFTWARE], SOME_REFERENCE_GENOME, SOME_FILE_EXTENSION, "", True),
-        (SOME_ALIGNED_READS, [], {}, {},"", True),
-        (SOME_ALIGNED_READS, [SOME_SOFTWARE], {}, SOME_FILE_EXTENSION, "", True),
+        (SOME_UNALIGNED_READS, [SOME_SOFTWARE], SOME_REFERENCE_GENOME, {}, SOME_FILE_EXTENSION, "", True),
+        (SOME_ALIGNED_READS, [], {}, {}, {},"", True),
+        (SOME_ALIGNED_READS, [SOME_SOFTWARE], {}, {}, SOME_FILE_EXTENSION, "", True),
         (
             SOME_ALIGNED_READS,
             [SOME_SOFTWARE],
             SOME_REFERENCE_GENOME,
+            {},
             SOME_FILE_EXTENSION,
             f"{SOFTWARE_CODE}_{SOFTWARE_VERSION}_{REFERENCE_GENOME_CODE}",
             False,
         ),
-        (SOME_SOMATIC_VARIANT_CALLS, [SOME_SOFTWARE], SOME_REFERENCE_GENOME, VCF_FILE_EXTENSION, f"{SOFTWARE_CODE}_{SOFTWARE_VERSION}_{REFERENCE_GENOME_CODE}", False),
+        (SOME_SOMATIC_VARIANT_CALLS, [SOME_SOFTWARE], SOME_REFERENCE_GENOME, {}, VCF_FILE_EXTENSION, f"{SOFTWARE_CODE}_{SOFTWARE_VERSION}_{REFERENCE_GENOME_CODE}", False),
         (
             SOME_VARIANT_CALLS,
             [SOME_SOFTWARE],
             SOME_REFERENCE_GENOME,
+            {},
             VCF_FILE_EXTENSION,
             f"{SOFTWARE_CODE}_{SOFTWARE_VERSION}_{REFERENCE_GENOME_CODE}",
             False,
@@ -595,6 +613,7 @@ CHAIN_FILE_EXTENSION = {
             SOME_ALIGNED_READS,
             [SOME_SOFTWARE, ANOTHER_SOFTWARE],
             SOME_REFERENCE_GENOME,
+            {},
             SOME_FILE_EXTENSION,
             f"{ANOTHER_SOFTWARE_CODE}_{ANOTHER_SOFTWARE_VERSION}_{SOFTWARE_CODE}_{SOFTWARE_VERSION}_{REFERENCE_GENOME_CODE}",
             False,
@@ -603,6 +622,7 @@ CHAIN_FILE_EXTENSION = {
             SOME_ALIGNED_READS,
             [SOME_SOFTWARE, SOME_ITEM],
             SOME_REFERENCE_GENOME,
+            {},
             SOME_FILE_EXTENSION,
             f"{SOFTWARE_CODE}_{SOFTWARE_VERSION}_{REFERENCE_GENOME_CODE}",
             False,
@@ -611,22 +631,51 @@ CHAIN_FILE_EXTENSION = {
             SOME_CHAIN_FILE,
             [SOME_SOFTWARE, SOME_ITEM],
             {},
+            {},
             CHAIN_FILE_EXTENSION,
             f"{SOFTWARE_CODE}_{SOFTWARE_VERSION}_{REFERENCE_GENOME_CODE}To{TARGET_GENOME_CODE}",
             False,
         ),
+        (
+            SOME_TSV_FILE,
+            [SOME_SOFTWARE],
+            SOME_REFERENCE_GENOME,
+            SOME_GENE_ANNOTATION,
+            TSV_FILE_EXTENSION,
+            f"{SOFTWARE_CODE}_{SOFTWARE_VERSION}_{REFERENCE_GENOME_CODE}_{GENE_ANNOTATION_CODE}_gene",
+            False
+        ),
+                (
+            SOME_ISOFORM_TSV_FILE,
+            [SOME_SOFTWARE],
+            SOME_REFERENCE_GENOME,
+            SOME_GENE_ANNOTATION,
+            TSV_FILE_EXTENSION,
+            f"{SOFTWARE_CODE}_{SOFTWARE_VERSION}_{REFERENCE_GENOME_CODE}_{GENE_ANNOTATION_CODE}_isoform",
+            False
+        ),
+        (
+            SOME_ALIGNED_READS,
+            [SOME_SOFTWARE],
+            SOME_REFERENCE_GENOME,
+            SOME_GENE_ANNOTATION,
+            SOME_FILE_EXTENSION,
+            f"{SOFTWARE_CODE}_{SOFTWARE_VERSION}_{REFERENCE_GENOME_CODE}_{GENE_ANNOTATION_CODE}",
+            False
+        )
     ],
 )
 def test_get_analysis(
     file: Dict[str, Any],
     software: List[Dict[str, Any]],
     reference_genome: Dict[str, Any],
+    gene_annotation: Dict[str, Any],
     file_extension: Dict[str, Any],
     expected: str,
     errors: bool,
 ) -> None:
     """Test analysis info retrieval for annotated filenames."""
-    result = get_analysis(file, software, reference_genome, file_extension)
+    result = get_analysis(file, software, reference_genome, gene_annotation, file_extension)
     assert_filename_part_matches(result, expected, errors)
 
 


### PR DESCRIPTION
- Create new item GeneAnnotation that OutputFile and SupplementaryFile link to with property `gene_annotation`
- Update `commands/create_annotated_filenames.py` to include gencode version and gene/isoform information for RSEM tsv output files and RNA-seq aligned bams