### PR TITLE
fix: update broken link in error page

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,9 +7,13 @@ smaht-portal
 Change Log
 ----------
 
+0.132.1
+=======
 `PR 328 fix: update broken link in error page <https://github.com/smaht-dac/smaht-portal/pull/328>`
 
 * Correct broken link to account creation doc
+
+
 =======
 0.132.0
 =======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ smaht-portal
 Change Log
 ----------
 
+0.131.2
+=======
+`PR 328 fix: update broken link in error page <https://github.com/smaht-dac/smaht-portal/pull/328>`
+
+* Correct broken link to account creation doc
+
+
 0.131.1
 =======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.131.1"
+version = "0.131.2"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.132.0"
+version = "0.132.1"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/static-pages/ErrorPage.js
+++ b/src/encoded/static/components/static-pages/ErrorPage.js
@@ -16,7 +16,10 @@ export default class ErrorPage extends React.PureComponent {
                 <div>
                     <h3>
                         The account you provided is not valid.{' '}
-                        <a href="/" className="link-underline-hover">Return</a> to the homepage.
+                        <a href="/" className="link-underline-hover">
+                            Return
+                        </a>{' '}
+                        to the homepage.
                     </h3>
                     <h5>
                         Please note: our authentication system will
@@ -28,7 +31,9 @@ export default class ErrorPage extends React.PureComponent {
                     </h5>
                     <h5>Access is restricted to 4DN consortium members.</h5>
                     <h5>
-                        <a href="mailto:4DN.DCIC.support@hms-dbmi.atlassian.net" className="link-underline-hover">
+                        <a
+                            href="mailto:4DN.DCIC.support@hms-dbmi.atlassian.net"
+                            className="link-underline-hover">
                             Request an account.
                         </a>
                     </h5>
@@ -44,7 +49,10 @@ export default class ErrorPage extends React.PureComponent {
                     {
                         "The page you've requested does not exist or you have found an error."
                     }{' '}
-                    <a href="/" className="link-underline-hover">Return</a> to the homepage.
+                    <a href="/" className="link-underline-hover">
+                        Return
+                    </a>{' '}
+                    to the homepage.
                 </h3>
             );
         }
@@ -77,7 +85,10 @@ const HTTPNotFoundView = React.memo(function (props) {
                 {"The page you've requested does not exist."}
             </h4>
             <p className="mb-0 mt-0">
-                <a href="/" className="link-underline-hover">Return</a> to the homepage.
+                <a href="/" className="link-underline-hover">
+                    Return
+                </a>{' '}
+                to the homepage.
             </p>
         </ErrorContainer>
     );
@@ -91,11 +102,19 @@ const HTTPForbiddenView = React.memo(function HTTPForbiddenView(props) {
             </h4>
             <p className="mb-0 mt-0">
                 If you have an account, please try logging in or return to the{' '}
-                <a href="/" className="link-underline-hover">homepage</a>.
+                <a href="/" className="link-underline-hover">
+                    homepage
+                </a>
+                .
                 <br />
                 For instructions on how to set up an account, please visit the
                 help page for{' '}
-                <a href="/help/account-creation" className="link-underline-hover">Creating an Account</a>.
+                <a
+                    href="/docs/access/creating-an-account"
+                    className="link-underline-hover">
+                    Creating an Account
+                </a>
+                .
             </p>
         </ErrorContainer>
     );

--- a/src/encoded/static/components/static-pages/ErrorPage.js
+++ b/src/encoded/static/components/static-pages/ErrorPage.js
@@ -25,14 +25,14 @@ export default class ErrorPage extends React.PureComponent {
                         Please note: our authentication system will
                         automatically attempt to log you in through your
                         selected provider if you are already logged in there. If
-                        you have an account with 4DN, please make sure that you
-                        are logged in to the provider (e.g. google) with the
+                        you have an account with SMaHT, please make sure that
+                        you are logged in to the provider (e.g. google) with the
                         matching email address.
                     </h5>
-                    <h5>Access is restricted to 4DN consortium members.</h5>
+                    <h5>Access is restricted to SMaHT consortium members.</h5>
                     <h5>
                         <a
-                            href="mailto:4DN.DCIC.support@hms-dbmi.atlassian.net"
+                            href="mailto:smhelp@hms-dbmi.atlassian.net"
                             className="link-underline-hover">
                             Request an account.
                         </a>


### PR DESCRIPTION
[Trello Ticket 409](https://trello.com/c/kEB34L6q/409-bug-broken-link-in-alert-banner)
- Correct broken link from the error page to the account creation doc
<img width="1512" alt="Screenshot 2025-01-31 at 10 54 09 AM" src="https://github.com/user-attachments/assets/5c33c0b0-4f5c-4573-b56e-50381be784a4" />
