### PR TITLE
SN Release tracker description

### DIFF
--- a/src/encoded/commands/release_file.py
+++ b/src/encoded/commands/release_file.py
@@ -63,7 +63,7 @@ class AnnotatedFilenameInfo:
 
 
 # dataset is required but comes in through input args for now
-REQUIRED_FILE_PROPS = [file_constants.SEQUENCING_CENTER]
+REQUIRED_FILE_PROPS = [file_constants.SEQUENCING_CENTER, "release_tracker_description"]
 
 
 class FileRelease:

--- a/src/encoded/item_utils/file.py
+++ b/src/encoded/item_utils/file.py
@@ -422,6 +422,11 @@ def get_override_group_coverage(file: Dict[str, Any]) -> str:
     return file.get("override_group_coverage","")
 
 
+def get_override_release_tracker_description(file: Dict[str, Any]) -> str:
+    """Get override release tracker description from properties."""
+    return file.get("override_release_tracker_description","")
+
+
 def get_release_tracker_description(file: Dict[str, Any]) -> str:
     """Get release tracker description from properties."""
     return file.get("release_tracker_description","")

--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -217,7 +217,15 @@
             "title": "Group Coverage Override",
             "desciption": "An override count for expected group coverage from sequencing that is used in the File Overview page if present, particularly for downsampled files",
             "type": "number",
-            "minimum": 0
+            "minimum": 0,
+            "permission": "restricted_fields"
+        },
+        "override_release_tracker_description": {
+            "title": "Release Tracker Description Override",
+            "desciption": "An override value for release tracker description that is used in the File Release Tracker on the home page if present, particularly for supplementary files",
+            "type": "string",
+            "minimum": 0,
+            "permission": "restricted_fields"
         },
         "version": {
             "type": "string",

--- a/src/encoded/tests/data/workbook-inserts/supplementary_file.json
+++ b/src/encoded/tests/data/workbook-inserts/supplementary_file.json
@@ -20,7 +20,8 @@
         "sequencing_center": "smaht",
         "donor_specific_assembly": "TEST_DONOR-SPECIFIC-ASSEMBLY_HELA",
         "target_assembly": "Hela_DSA",
-        "source_assembly": "GRCh38"
+        "source_assembly": "GRCh38",
+        "override_release_tracker_description": "HELA DSA"
     },
     {
         "uuid": "f1074e68-5c24-462b-909d-472356e5a15f",
@@ -42,6 +43,7 @@
         "sequencing_center": "smaht",
         "file_size": 1000,
         "md5sum": "00000000000000000000000000000001",
-        "donor_specific_assembly": "TEST_DONOR-SPECIFIC-ASSEMBLY_HELA"
+        "donor_specific_assembly": "TEST_DONOR-SPECIFIC-ASSEMBLY_HELA",
+        "override_release_tracker_description": "HELA DSA"
     }
 ]

--- a/src/encoded/tests/test_types_file.py
+++ b/src/encoded/tests/test_types_file.py
@@ -1225,20 +1225,22 @@ def test_release_tracker_description(es_testapp: TestApp, workbook: None) -> Non
 def assert_release_tracker_description_matches_expected(file: Dict[str, Any], es_testapp: TestApp):
     """Assert release_tracker_description calcprop matches expected."""
 
-    release_tracker_description = file_utils. get_release_tracker_description(file)
-
-    assay_from_calcprop = item_utils.get_display_title(
-        file_utils.get_assays(file)[0]
-    )
-    sequencer_from_calcprop = item_utils.get_display_title(
-        sequencing_utils.get_sequencer(
-            file_utils.get_sequencings(file)[0]
-        )
-    )
+    release_tracker_description = file_utils.get_release_tracker_description(file)
     file_format = item_utils.get_display_title(
         file_utils.get_file_format(file)
-    )                          
-    description_from_calcprops=f"{assay_from_calcprop} {sequencer_from_calcprop} {file_format}"
+    )
+    if "override_release_tracker_description" in file:
+        description_from_calcprops=f"{file_utils.get_override_release_tracker_description(file)} {file_format}"
+    if "file_sets" in file:
+        assay_from_calcprop = item_utils.get_display_title(
+            file_utils.get_assays(file)[0]
+        )
+        sequencer_from_calcprop = item_utils.get_display_title(
+            sequencing_utils.get_sequencer(
+                file_utils.get_sequencings(file)[0]
+            )
+        )                 
+        description_from_calcprops=f"{assay_from_calcprop} {sequencer_from_calcprop} {file_format}"
     assert release_tracker_description == description_from_calcprops
    
     

--- a/src/encoded/tests/test_types_file.py
+++ b/src/encoded/tests/test_types_file.py
@@ -1229,8 +1229,6 @@ def assert_release_tracker_description_matches_expected(file: Dict[str, Any], es
     file_format = item_utils.get_display_title(
         file_utils.get_file_format(file)
     )
-    if "override_release_tracker_description" in file:
-        description_from_calcprops=f"{file_utils.get_override_release_tracker_description(file)} {file_format}"
     if "file_sets" in file:
         assay_from_calcprop = item_utils.get_display_title(
             file_utils.get_assays(file)[0]
@@ -1241,6 +1239,8 @@ def assert_release_tracker_description_matches_expected(file: Dict[str, Any], es
             )
         )                 
         description_from_calcprops=f"{assay_from_calcprop} {sequencer_from_calcprop} {file_format}"
+    if "override_release_tracker_description" in file:
+        description_from_calcprops=f"{file_utils.get_override_release_tracker_description(file)} {file_format}"
     assert release_tracker_description == description_from_calcprops
    
     

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -1032,10 +1032,10 @@ class File(Item, CoreFile):
                 )
             if len(assay_title) > 1 or len(sequencer_title) > 1:
                 # More than one unique assay or sequencer
-                return ""
+                return None
             elif len(assay_title) == 0 or len(sequencer_title) == 0:
                 # No assay or sequencer
-                return ""
+                return None
             to_include = [
                 assay_title[0],
                 sequencer_title[0],

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -716,13 +716,11 @@ class File(Item, CoreFile):
         file_sets: Optional[List[str]] = None
     ) -> Union[str, None]:
         """Get file release tracker description for display on home page."""
-        result = None
-        if file_sets:
-            request_handler = RequestHandler(request=request)
-            result = self._get_release_tracker_description(
-                request_handler,
-                file_properties=self.properties
-            )
+        request_handler = RequestHandler(request=request)
+        result = self._get_release_tracker_description(
+            request_handler,
+            file_properties=self.properties
+        )
         return result     
 
     def _get_libraries(
@@ -1016,32 +1014,40 @@ class File(Item, CoreFile):
             file_properties: Dict[str, Any],
         ) -> Union[str, None]:
         """Get release tracker description for display on the home page."""
-        assay_title= get_unique_values(
-            request_handler.get_items(file_utils.get_assays(file_properties, request_handler)),
-            item_utils.get_display_title,
-            )
-        sequencer_title = get_unique_values(
-            request_handler.get_items(
-            file_utils.get_sequencers(file_properties, request_handler)),
-            item_utils.get_display_title,
-            )
+        to_include = None
         file_format_title = get_property_value_from_identifier(
-                request_handler,
-                file_utils.get_file_format(file_properties),
+            request_handler,
+            file_utils.get_file_format(file_properties),
+            item_utils.get_display_title,
+        )
+        if "file_sets" in file_properties:
+            assay_title= get_unique_values(
+                request_handler.get_items(file_utils.get_assays(file_properties, request_handler)),
                 item_utils.get_display_title,
-            )
-        if len(assay_title) > 1 or len(sequencer_title) > 1:
-            # More than one unique assay or sequencer
-            return ""
-        elif len(assay_title) == 0 or len(sequencer_title) == 0:
-            # No assay or sequencer
-            return ""
-        to_include = [
-            assay_title[0],
-            sequencer_title[0],
-            file_format_title
-        ]
-        return " ".join(to_include)
+                )
+            sequencer_title = get_unique_values(
+                request_handler.get_items(
+                file_utils.get_sequencers(file_properties, request_handler)),
+                item_utils.get_display_title,
+                )
+            if len(assay_title) > 1 or len(sequencer_title) > 1:
+                # More than one unique assay or sequencer
+                return ""
+            elif len(assay_title) == 0 or len(sequencer_title) == 0:
+                # No assay or sequencer
+                return ""
+            to_include = [
+                assay_title[0],
+                sequencer_title[0],
+                file_format_title
+            ]
+        if "override_release_tracker_description" in file_properties:
+            to_include = [
+                file_utils.get_override_release_tracker_description(file_properties),
+                file_format_title
+            ]
+        if to_include:
+            return " ".join(to_include)
 
 
 @view_config(name='drs', context=File, request_method='GET',

--- a/src/encoded/types/supplementary_file.py
+++ b/src/encoded/types/supplementary_file.py
@@ -7,6 +7,8 @@ def _build_supplementary_file_embedded_list():
     """Embeds for search on supplementary files."""
     return SubmittedFile.embedded_list + [
         "reference_genome.display_title",
+        "donor_specific_assembly.donors",
+        "donor_specific_assembly.cell_lines.code",
     ]
 
 


### PR DESCRIPTION
- Add property `override_release_tracker_description` to `file.json` that can set the calcprop `release_tracker_description` to desired value
- Embed `donor_specific_assembly.donors` and `donor_specific_assembly.cell_lines.code` in `file.py`
- In `release-file.py`, require that a file has `release_tracker_description` set prior to release