### PR TITLE
fix: add resources to hard-coded disabled breadcrumbs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ smaht-portal
 Change Log
 ----------
 
+0.139.0
+=======
+`PR 360: fix: add resources to hard-coded disabled breadcrumbs <https://github.com/smaht-dac/smaht-portal/pull/360>`_
+
+* Disable breadcrumbs for resources pages
+
+
 0.138.0
 =======
 `PR 351: FileSearchView for type=File search <https://github.com/smaht-dac/smaht-portal/pull/351>`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.138.0"
+version = "0.139.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/PageTitleSection.js
+++ b/src/encoded/static/components/PageTitleSection.js
@@ -413,7 +413,7 @@ export class StaticPageBreadcrumbs extends React.Component {
         var inner;
 
         // Hard-coded link groups to disable
-        const breadcrumbsToDisable = ['docs', 'data', 'about'];
+        const breadcrumbsToDisable = ['docs', 'data', 'about', 'resources'];
         const shouldDisable = ancestor.identifier
             .split('/')
             .some((ancestor) => breadcrumbsToDisable.includes(ancestor));
@@ -423,7 +423,11 @@ export class StaticPageBreadcrumbs extends React.Component {
         } else if (shouldDisable) {
             inner = <span>{ancestor.display_title}</span>;
         } else {
-            inner = <a href={ancestor['@id']} className="link-underline-hover">{ancestor.display_title}</a>;
+            inner = (
+                <a href={ancestor['@id']} className="link-underline-hover">
+                    {ancestor.display_title}
+                </a>
+            );
         }
         return (
             <div


### PR DESCRIPTION
[Trello Ticket 637](https://trello.com/c/JZluzUVI/637-fix-disable-breadcrumbs-on-reference-data-doc-page)
- Disable breadcrumbs for resources pages