### PR TITLE
SN reference genome facet

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ smaht-portal
 Change Log
 ----------
 
+0.141.1
+=======
+`PR 366: SN OntologyTerm update <https://github.com/smaht-dac/smaht-portal/pull/366>`_
+
+* Add `reference_genome.display_title` facet to all file types with a `reference_genome` property (AlignedReads, OutputFile, SupplementaryFile, and VariantCalls) so that the facet shows up in File Search view
+
+
 0.141.0
 =======
 `PR 349: SN OntologyTerm update <https://github.com/smaht-dac/smaht-portal/pull/349>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.141.0"
+version = "0.141.1"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/aligned_reads.json
+++ b/src/encoded/schemas/aligned_reads.json
@@ -114,5 +114,10 @@
         "submitted_id": {
             "pattern": "^[A-Z0-9]{3,}_ALIGNED-READS_[A-Z0-9-_.]{4,}$"
         }
+    },
+    "facets": {
+        "reference_genome.display_title": {
+            "title": "Reference Genome"
+        }
     }
 }

--- a/src/encoded/schemas/output_file.json
+++ b/src/encoded/schemas/output_file.json
@@ -105,5 +105,10 @@
                 "Final Output"
             ]
         }
+    },
+    "facets": {
+        "reference_genome.display_title": {
+            "title": "Reference Genome"
+        }
     }
 }

--- a/src/encoded/schemas/supplementary_file.json
+++ b/src/encoded/schemas/supplementary_file.json
@@ -110,5 +110,10 @@
             "description": "The assembly from which the coordinates are being converted (required for chain files)",
             "type": "string"
         }
+    },
+    "facets": {
+        "reference_genome.display_title": {
+            "title": "Reference Genome"
+        }
     }
 }

--- a/src/encoded/schemas/variant_calls.json
+++ b/src/encoded/schemas/variant_calls.json
@@ -156,5 +156,10 @@
                 "comparator_description"
             ]
         }
-  ]
+  ],
+  "facets": {
+        "reference_genome.display_title": {
+            "title": "Reference Genome"
+        }
+    }
 }


### PR DESCRIPTION
- Add `reference_genome.display_title` facet to all file types with a `reference_genome` property (AlignedReads, OutputFile, SupplementaryFile, and VariantCalls) so that the facet shows up in File Search view