### PR TITLE
fix: file size NaN bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ smaht-portal
 Change Log
 ----------
 
+0.142.2
+=======
+`PR 369: fix: file size NaN bug <https://github.com/smaht-dac/smaht-portal/pull/369>`_
+
+* Prevent file size from rendering as NaN when undefined
+
+
 0.142.1
 =======
 `PR 359: feat: release tracker updates <hhttps://github.com/smaht-dac/smaht-portal/pull/359>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.142.1"
+version = "0.142.2"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/item-pages/components/file-overview/FileViewDataCards.js
+++ b/src/encoded/static/components/item-pages/components/file-overview/FileViewDataCards.js
@@ -69,8 +69,14 @@ const default_file_properties = [
     },
     {
         title: 'Size',
-        getProp: (context = {}) =>
-            bytesToLargerUnit(context?.file_summary?.file_size),
+        getProp: (context = {}) => {
+            const fileSize = context?.file_summary?.file_size;
+            if (fileSize) {
+                return bytesToLargerUnit(fileSize);
+            } else {
+                return null;
+            }
+        },
     },
     {
         title: 'MD5 Checksum',


### PR DESCRIPTION
[Trello Ticket 644](https://trello.com/c/PPJhWjcG/644-bug-file-overview-vcf-file-size)
- Prevent file size from rendering as NaN when undefined