### PR TITLE
Add uberon_id check for tissue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,16 @@ smaht-portal
 Change Log
 ----------
 
+0.144.0
+=======
+`PR 371: SN Add uberon_id check for tissue <https://github.com/smaht-dac/smaht-portal/pull/371>`_
+
+* Add property `valid_protocol_ids` to OntologyTerm that is a list of protocol IDs (e.g. 1D, 3A), the portion of `external_id` indicating tissue types
+* Add a check to Tissue ensuring that the protocol ID in `external_id` is among the `valid_protocol_ids` for the OntologyTerm linked with uberon_id
+* Add checks to Donor and Tissue ensuring that `external_id` matches expected format for Benchmarking and Production
+* Makes `external_id` a required property for Donor
+
+
 0.143.3
 =======
 `PR 377: Add not logged in alerts while navigating <https://github.com/smaht-dac/smaht-portal/pull/377>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.143.3"
+version = "0.144.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/item_utils/donor.py
+++ b/src/encoded/item_utils/donor.py
@@ -54,6 +54,11 @@ def get_study(properties: Dict[str, Any]) -> str:
     return ""
 
 
+def is_valid_external_id(external_id: str) -> bool:
+    """Check if donor external_id matches TPC Donor nomenclature."""
+    return PRODUCTION_DONOR_REGEX.match(external_id) is not None or BENCHMARKING_DONOR_REGEX.match(external_id) is not None or TPC_ALT_DONOR_REGEX.match(external_id) is not None
+
+
 def is_benchmarking(properties: Dict[str, Any]) -> bool:
     """Check if donor is from benchmarking study."""
     external_id = item.get_external_id(properties)

--- a/src/encoded/item_utils/ontology_term.py
+++ b/src/encoded/item_utils/ontology_term.py
@@ -57,4 +57,4 @@ def get_top_grouping_term(
 
 def get_valid_protocol_ids(properties: Dict[str, Any]) -> str:
     """Get valid_protocol_ids from properties."""
-    return properties.get("valid_protocol_ids","")
+    return properties.get("valid_protocol_ids",[])

--- a/src/encoded/item_utils/ontology_term.py
+++ b/src/encoded/item_utils/ontology_term.py
@@ -53,3 +53,8 @@ def get_top_grouping_term(
         )
     else:
         return item_utils.get_display_title(properties)
+    
+
+def get_valid_protocol_ids(properties: Dict[str, Any]) -> str:
+    """Get valid_protocol_ids from properties."""
+    return properties.get("valid_protocol_ids","")

--- a/src/encoded/item_utils/tissue.py
+++ b/src/encoded/item_utils/tissue.py
@@ -87,6 +87,11 @@ def is_production(properties: Dict[str, Any]) -> bool:
     return PRODUCTION_TISSUE_REGEX.match(external_id) is not None
 
 
+def is_valid_external_id(external_id: str) -> bool:
+    """Check if tissue external_id matches Benchmarking or Production."""
+    return PRODUCTION_TISSUE_REGEX.match(external_id) is not None or BENCHMARKING_TISSUE_REGEX.match(external_id) is not None
+
+
 def get_project_id(properties: Dict[str, Any]) -> str:
     """Get project ID associated with tissue."""
     if is_benchmarking(properties):

--- a/src/encoded/schemas/donor.json
+++ b/src/encoded/schemas/donor.json
@@ -5,6 +5,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "required": [
+        "external_id",
         "age",
         "sex",
         "submission_centers",
@@ -54,7 +55,8 @@
             "accessionType": "DO"
         },
         "external_id": {
-            "submissionComment": "For donors from the TPC, this should be the TPC donor ID. Otherwise, the submitter's internal identifier can be used."
+            "submissionComment": "For donors from the TPC, this should be the TPC donor ID. Otherwise, the submitter's internal identifier can be used.",
+            "pattern": "^[A-Za-z0-9-_]{2,}$"
         },
         "schema_version": {
             "default": "1"

--- a/src/encoded/schemas/non_brain_pathology_report.json
+++ b/src/encoded/schemas/non_brain_pathology_report.json
@@ -1,5 +1,5 @@
 {
-    "title": "Non-Brain Pathology Report",
+    "title": "Non Brain Pathology Report",
     "description": "A pathology report for a non-brain tissue sample",
     "$id": "/profiles/non_brain_pathology_report.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/src/encoded/schemas/ontology_term.json
+++ b/src/encoded/schemas/ontology_term.json
@@ -108,6 +108,14 @@
             "description": "Ontology term that this term is grouped under - less specific term used in search",
             "type": "string",
             "linkTo": "OntologyTerm"
+        },
+        "valid_protocol_ids":{
+            "title": "Valid Protocol IDs",
+            "description": "Tissue protocol IDs that are valid for the ontology term - used to check that Uberon IDs are correctly linked to tissue items.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
         }
     },
     "columns": {

--- a/src/encoded/tests/data/workbook-inserts/donor.json
+++ b/src/encoded/tests/data/workbook-inserts/donor.json
@@ -28,6 +28,7 @@
         "submission_centers": [
             "smaht"
         ],
+        "external_id": "ALT1",
         "age": 89,
         "sex": "Male",
         "tpc_submitted": "False"

--- a/src/encoded/tests/data/workbook-inserts/ontology_term.json
+++ b/src/encoded/tests/data/workbook-inserts/ontology_term.json
@@ -37,7 +37,8 @@
         "tags":[
             "test_terms",
             "test_top_terms-Lung"
-        ]
+        ],
+        "valid_protocol_ids": ["3Q","3R","1D"]
     },
     {
         "uuid": "90118425-2a51-475a-b6ef-ecf1accd0304",
@@ -55,6 +56,7 @@
         "title": "brain",
         "consortia": [
             "smaht"
-        ]
+        ],
+        "valid_protocol_ids": ["3AJ"]
     }
 ]

--- a/src/encoded/tests/datafixtures.py
+++ b/src/encoded/tests/datafixtures.py
@@ -441,7 +441,8 @@ def donor_properties(test_second_submission_center: Dict[str, Any]) -> Dict[str,
         "submitted_id": f"{TEST_SECOND_CENTER_SUBMITTED_ID_CODE}_DONOR_1234",
         "age": 35,
         "sex": "Male",
-        "tpc_submitted": "False"
+        "tpc_submitted": "False",
+        "external_id": "1234"
     }
 
 

--- a/src/encoded/tests/test_permissions.py
+++ b/src/encoded/tests/test_permissions.py
@@ -325,14 +325,16 @@ class TestSubmissionCenterPermissions(TestPermissionsHelper):
             'sex': 'Female',
             'submission_centers': [test_submission_center['uuid']],
             'submitted_id': 'TEST_DONOR_ABCD',
-            "tpc_submitted": "False"
+            "tpc_submitted": "False",
+            "external_id": "ABCD"
         }, status=403)
         submission_center_user_app.post_json('/Donor', {  # cannot submit a donor under a diferrent center
             'age': 37,
             'sex': 'Female',
             'submission_centers': [test_second_submission_center['uuid']],
             'submitted_id': 'SECONDTEST_DONOR_ABCD',
-            "tpc_submitted": "False"
+            "tpc_submitted": "False",
+            "external_id": "ABCD"
         }, status=403)
         submission_center_user_app.post_json('/AccessKey', {  # can still create an access key
             'user': smaht_gcc_user['@id'],
@@ -348,14 +350,16 @@ class TestSubmissionCenterPermissions(TestPermissionsHelper):
             'sex': 'Female',
             'submission_centers': [test_second_submission_center['uuid']],
             'submitted_id': 'SECONDTEST_DONOR_ABCD',
-            "tpc_submitted": "False"
+            "tpc_submitted": "False",
+            "external_id": "ABCD"
         }, status=403)
         submission_center2_user_app.post_json('/Donor', {  # cannot submit a donor on opposing center
             'age': 37,
             'sex': 'Female',
             'submission_centers': [test_submission_center['uuid']],
             'submitted_id': 'TEST_DONOR_ABCD',
-            "tpc_submitted": "False"
+            "tpc_submitted": "False",
+            "external_id": "ABCD"
         }, status=403)
 
     @staticmethod

--- a/src/encoded/tests/test_types_donor.py
+++ b/src/encoded/tests/test_types_donor.py
@@ -1,0 +1,71 @@
+from typing import Dict, Any
+import pytest
+from webtest import TestApp
+
+from ..item_utils import (
+    item as item_utils,
+    donor as donor_utils,
+)
+
+from .utils import (
+    get_item,
+    patch_item,
+    post_item,
+)
+
+@pytest.mark.workbook
+@pytest.mark.parametrize(
+    "patch_body,expected_status", [
+        ({"external_id": "ST001","tpc_submitted": "True"}, 200),
+        ({"external_id": "HG002","tpc_submitted": "True"}, 422),
+
+    ]
+)
+def test_validate_external_id_on_edit(
+    es_testapp: TestApp,
+    workbook: None,
+    patch_body: Dict[str, Any],
+    expected_status: int
+    ) -> None:
+    """Ensure external_id validator works for TPC-submitted donors."""
+    uuid =  item_utils.get_uuid(
+        get_item(
+            es_testapp,
+            "TEST_DONOR_MALE",
+            collection="Donor"
+        )
+    )
+    patch_item(es_testapp, patch_body, uuid, status=expected_status)
+
+
+@pytest.mark.workbook
+@pytest.mark.parametrize(
+    "patch_body,expected_status,index", [
+        ({"external_id": "ST001","tpc_submitted": "True"}, 201, 1),
+        ({"external_id": "SMHT001","tpc_submitted": "True"}, 201, 2),
+        ({"external_id": "SN001","tpc_submitted": "True"}, 201, 3),
+        ({"external_id": "HG002","tpc_submitted": "False"}, 201, 4),
+        ({"external_id": "HG002","tpc_submitted": "True"}, 422, 5),
+    ]
+)
+def test_validate_external_id_on_add(
+    es_testapp: TestApp,
+    workbook: None,
+    patch_body: Dict[str, Any],
+    expected_status: int,
+    index: int
+    ) -> None:
+    """Ensure external_id validator works for TPC-submitted donors."""
+    insert = get_item(
+            es_testapp,
+            "TEST_DONOR_MALE",
+            collection="Donor"
+        )
+    post_body = {
+        **patch_body,
+        "submitted_id": f"{item_utils.get_submitted_id(insert)}_{index}",
+        'submission_centers': item_utils.get_submission_centers(insert),
+        'age': donor_utils.get_age(insert),
+        'sex': donor_utils.get_sex(insert)
+    }
+    post_item(es_testapp, post_body, 'donor', status=expected_status)

--- a/src/encoded/tests/test_types_tissue.py
+++ b/src/encoded/tests/test_types_tissue.py
@@ -26,9 +26,10 @@ def test_submitted_id_resource_path(es_testapp: TestApp, workbook: None) -> None
 @pytest.mark.workbook
 @pytest.mark.parametrize(
     "patch_body,expected_status", [
-        ({"donor": "TEST_DONOR_ALT1", "external_id": "ST001-1D"}, 200),
-        ({"donor": "TEST_DONOR_FEMALE", "external_id": "ST001-1D"}, 422),
-        ({"donor": "TEST_DONOR_MALE", "external_id": "ST001-1D"}, 200),
+        ({"donor": "TEST_DONOR_ALT1", "external_id": "ST001-1D", "uberon_id": "UBERON:0008952"}, 200),
+        ({"donor": "TEST_DONOR_FEMALE", "external_id": "ST001-1D", "uberon_id": "UBERON:0008952"}, 422),
+        ({"donor": "TEST_DONOR_MALE", "external_id": "ST001-1D", "uberon_id": "UBERON:0008952"}, 200),
+        ({"donor": "TEST_DONOR_MALE", "external_id": "ST001-1D", "uberon_id": "UBERON:0000955"}, 422),
     ]
 )
 def test_validate_external_id_on_edit(
@@ -37,7 +38,7 @@ def test_validate_external_id_on_edit(
     patch_body: Dict[str, Any],
     expected_status: int
     ) -> None:
-    """Ensure external_id matches donor external_id if Benchmarking or Production on edit."""
+    """Ensure external_id matches donor external_id and uberon_id if Benchmarking or Production on edit."""
     uuid =  item_utils.get_uuid(get_item_from_search(es_testapp, "Tissue"))
     patch_item(es_testapp, patch_body, uuid, status=expected_status)
 
@@ -45,9 +46,11 @@ def test_validate_external_id_on_edit(
 @pytest.mark.workbook
 @pytest.mark.parametrize(
     "patch_body,expected_status,index", [
-        ({"donor": "TEST_DONOR_ALT1", "external_id": "ST001-1D"}, 201, 1),
-        ({"donor": "TEST_DONOR_FEMALE", "external_id": "ST001-1D"}, 422, 2),
-        ({"donor": "TEST_DONOR_MALE", "external_id": "ST001-1D"}, 201, 3),
+        ({"donor": "TEST_DONOR_ALT1", "external_id": "ST001-1D", "uberon_id": "UBERON:0008952"}, 201, 1),
+        ({"donor": "TEST_DONOR_FEMALE", "external_id": "ST001-1D", "uberon_id": "UBERON:0008952"}, 422, 2),
+        ({"donor": "TEST_DONOR_MALE", "external_id": "ST001-1D", "uberon_id": "UBERON:0008952"}, 201, 3),
+        ({"donor": "TEST_DONOR_MALE", "external_id": "ST001-1D", "uberon_id": "UBERON:0000955"}, 422, 4),
+
     ]
 )
 def test_validate_external_id_on_add(
@@ -57,12 +60,11 @@ def test_validate_external_id_on_add(
     expected_status: int,
     index: int
 ) -> None:
-    """Ensure external_id matches donor external_id if Benchmarking or Production on add."""
+    """Ensure external_id matches donor external_id and uberon_id if Benchmarking or Production on add."""
     insert = get_item_from_search(es_testapp, "Tissue")
     post_body = {
         **patch_body,
         "submitted_id": f"{item_utils.get_submitted_id(insert)}_{index}",
         'submission_centers': item_utils.get_submission_centers(insert),
-        "uberon_id": tissue_utils.get_uberon_id(insert)
     }
     post_item(es_testapp, post_body, 'tissue', status=expected_status)

--- a/src/encoded/tests/test_types_tissue.py
+++ b/src/encoded/tests/test_types_tissue.py
@@ -30,6 +30,7 @@ def test_submitted_id_resource_path(es_testapp: TestApp, workbook: None) -> None
         ({"donor": "TEST_DONOR_FEMALE", "external_id": "ST001-1D", "uberon_id": "UBERON:0008952"}, 422),
         ({"donor": "TEST_DONOR_MALE", "external_id": "ST001-1D", "uberon_id": "UBERON:0008952"}, 200),
         ({"donor": "TEST_DONOR_MALE", "external_id": "ST001-1D", "uberon_id": "UBERON:0000955"}, 422),
+        ({"donor": "TEST_DONOR_FEMALE", "external_id": "SL001-1D", "uberon_id": "UBERON:0008952"}, 422),
     ]
 )
 def test_validate_external_id_on_edit(
@@ -50,6 +51,7 @@ def test_validate_external_id_on_edit(
         ({"donor": "TEST_DONOR_FEMALE", "external_id": "ST001-1D", "uberon_id": "UBERON:0008952"}, 422, 2),
         ({"donor": "TEST_DONOR_MALE", "external_id": "ST001-1D", "uberon_id": "UBERON:0008952"}, 201, 3),
         ({"donor": "TEST_DONOR_MALE", "external_id": "ST001-1D", "uberon_id": "UBERON:0000955"}, 422, 4),
+        ({"donor": "TEST_DONOR_FEMALE", "external_id": "SL001-1D", "uberon_id": "UBERON:0008952"}, 422, 5),
 
     ]
 )

--- a/src/encoded/types/donor.py
+++ b/src/encoded/types/donor.py
@@ -1,9 +1,29 @@
 from typing import List, Union
 
 from pyramid.request import Request
+from pyramid.view import view_config
 from snovault import calculated_property, collection, load_schema
+from snovault.util import debug_log
 
 from .submitted_item import SubmittedItem
+
+from .base import (
+    collection_add,
+    item_edit,
+    Item
+)
+from .utils import (
+    get_properties,
+    get_property_for_validation,
+)
+from .submitted_item import (
+    SUBMITTED_ITEM_ADD_VALIDATORS,
+    SUBMITTED_ITEM_EDIT_PATCH_VALIDATORS,
+    SUBMITTED_ITEM_EDIT_PUT_VALIDATORS,
+)
+from ..item_utils import (
+    donor as donor_utils
+)
 
 
 @collection(
@@ -17,6 +37,10 @@ class Donor(SubmittedItem):
     item_type = "donor"
     schema = load_schema("encoded:schemas/donor.json")
     embedded_list = []
+
+    class Collection(Item.Collection):
+        pass
+
     rev = {
         "tissues": ("Tissue", "donor"),
     }
@@ -36,3 +60,74 @@ class Donor(SubmittedItem):
         if result:
             return result
         return
+
+
+def validate_external_id_on_add(context, request):
+    """Check that external_id is valid if it is a TPC-submitted donor on add."""
+    data = request.json
+    external_id = data['external_id']
+    if donor_utils.is_tpc_submitted(data):
+        if not assert_valid_external_id(external_id):
+            msg = f"external_id {external_id} does not match TPC donor nomenclature."
+            return request.errors.add('body', 'Donor: invalid property', msg)
+        else:
+            return request.validated.update({})
+
+
+def validate_external_id_on_edit(context, request):
+    """Check that external_id is valid if it is a TPC-submitted donor on edit."""
+    existing_properties = get_properties(context)
+    properties_to_update = get_properties(request)
+    tpc_submitted = get_property_for_validation('tpc_submitted', existing_properties, properties_to_update)
+    external_id = get_property_for_validation('external_id', existing_properties, properties_to_update)
+    if tpc_submitted == "True":
+        if not assert_valid_external_id(external_id):
+            msg = f"external_id {external_id} does not match TPC donor nomenclature."
+            return request.errors.add('body', 'Donor: invalid property', msg)
+        else:
+            return request.validated.update({}) 
+
+
+def assert_valid_external_id(external_id: str):
+    """Check if donor external_id matches Benchmarking or Production."""
+    return donor_utils.is_valid_external_id(external_id)
+
+
+DONOR_ADD_VALIDATORS = SUBMITTED_ITEM_ADD_VALIDATORS + [
+    validate_external_id_on_add
+]
+
+@view_config(
+    context=Donor.Collection,
+    permission='add',
+    request_method='POST',
+    validators=DONOR_ADD_VALIDATORS,
+)
+@debug_log
+def donor_add(context, request, render=None):
+    return collection_add(context, request, render)
+
+
+DONOR_EDIT_PATCH_VALIDATORS = SUBMITTED_ITEM_EDIT_PATCH_VALIDATORS + [
+    validate_external_id_on_edit
+]
+
+DONOR_EDIT_PUT_VALIDATORS = SUBMITTED_ITEM_EDIT_PUT_VALIDATORS + [
+    validate_external_id_on_edit
+]
+
+@view_config(
+    context=Donor,
+    permission='edit',
+    request_method='PUT',
+    validators=DONOR_EDIT_PUT_VALIDATORS,
+)
+@view_config(
+    context=Donor,
+    permission='edit',
+    request_method='PATCH',
+    validators=DONOR_EDIT_PATCH_VALIDATORS,
+)
+@debug_log
+def donor_edit(context, request, render=None):
+    return item_edit(context, request, render)

--- a/src/encoded/types/tissue.py
+++ b/src/encoded/types/tissue.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Dict, Any
 
 from snovault import collection, load_schema
 from snovault.util import debug_log, get_item_or_none
@@ -23,7 +23,8 @@ from .sample_source import SampleSource
 from ..item_utils import (
     tissue as tissue_utils,
     donor as donor_utils,
-    item as item_utils
+    item as item_utils,
+    ontology_term as ot_utils,
 )
 
 def _build_tissue_embedded_list() -> List[str]:
@@ -58,9 +59,14 @@ def validate_external_id_on_add(context, request):
     external_id = data['external_id']
     donor = data["donor"]
     donor_item = get_item_or_none(request, donor, 'donors')
+    uberon_id = data["uberon_id"]
+    uberon_item = get_item_or_none(request, uberon_id, 'ontology-terms')
     if (study := donor_utils.get_study(donor_item)):
         if not assert_external_id_donor_match(external_id, donor_item):
             msg = f"external_id {external_id} does not match Donor external_id {item_utils.get_external_id(donor_item)}."
+            return request.errors.add('body', 'Tissue: invalid link', msg)
+        if not assert_uberon_id_external_id_match(external_id, uberon_item):
+            msg = f"external_id {external_id} does not match valid ids for Uberon ID {item_utils.get_identifier(uberon_item)}:{item_utils.get_display_title(uberon_item)}."
             return request.errors.add('body', 'Tissue: invalid link', msg)
         else:
             return request.validated.update({}) 
@@ -71,12 +77,17 @@ def validate_external_id_on_edit(context, request):
     """Check that `external_id` matches linked donor `external_id` if Benchmarking or Production tissue on edit."""
     existing_properties = get_properties(context)
     properties_to_update = get_properties(request)
-    donor = get_property_for_validation('donor',existing_properties,properties_to_update)
-    external_id = get_property_for_validation('external_id',existing_properties,properties_to_update)
+    donor = get_property_for_validation('donor', existing_properties, properties_to_update)
+    external_id = get_property_for_validation('external_id', existing_properties, properties_to_update)
     donor_item = get_item_or_none(request, donor, 'sample-sources')
+    uberon_id = get_property_for_validation('uberon_id', existing_properties, properties_to_update)
+    uberon_item = get_item_or_none(request, uberon_id, 'ontology-terms')
     if (study:=donor_utils.get_study(donor_item)):
         if not assert_external_id_donor_match(external_id, donor_item):
             msg = f"external_id {external_id} does not match Donor external_id {item_utils.get_external_id(donor_item)}."
+            return request.errors.add('body', 'Tissue: invalid link', msg)
+        if not assert_uberon_id_external_id_match(external_id, uberon_item):
+            msg = f"external_id {external_id} does not match valid ids for Uberon ID {item_utils.get_identifier(uberon_item)}:{item_utils.get_display_title(uberon_item)}."
             return request.errors.add('body', 'Tissue: invalid link', msg)
         else:
             return request.validated.update({})
@@ -87,6 +98,14 @@ def assert_external_id_donor_match(external_id, donor):
     donor_id = item_utils.get_external_id(donor)
     tissue_kit_id = tissue_utils.get_donor_id_from_external_id(external_id)
     return donor_id == tissue_kit_id
+
+
+def assert_uberon_id_external_id_match(external_id: str, uberon_item: Dict[str, Any]):
+    """Check that the protocol id of the external_id is in valid_protocol_ids for uberon_id."""
+    protocol_id = tissue_utils.get_protocol_id_from_external_id(external_id)
+    if (valid_ids := ot_utils.get_valid_protocol_ids(uberon_item)):
+        return protocol_id in valid_ids
+    return True
 
 
 TISSUE_ADD_VALIDATORS = SUBMITTED_ITEM_ADD_VALIDATORS + [


### PR DESCRIPTION
- Add property `valid_protocol_ids` to OntologyTerm that is a list of protocol IDs (e.g. 1D, 3A), the portion of `external_id` indicating tissue types defined [here](https://staging.smaht.org/docs/additional-resources/sample-file-nomenclature)
- Add a check to Tissue ensuring that the protocol ID in `external_id` is among the `valid_protocol_ids` for the OntologyTerm linked with `uberon_id`
- Add checks to Donor and Tissue ensuring that `external_id` matches expected format for Benchmarking and Production
- Makes `external_id` a required property for Donor