### PR TITLE
Add Not Logged In Alerts While Navigating

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,9 +7,17 @@ smaht-portal
 Change Log
 ----------
 
+0.143.3
+=======
+`PR 377: Add not logged in alerts while navigating <https://github.com/smaht-dac/smaht-portal/pull/377>`_
+
+* Adds "Not Logged In" alert to /search and /qc-metrics pages when navigated from another page like home page notifications or documentation pages
+* Adds login popup link to logging in text in "Access was denied to this resource" alert
+
+
 0.143.2
 =======
-`PR 374: Cypress Test.04 - search view updates  <https://github.com/smaht-dac/smaht-portal/pull/374>`_
+`PR 374: Cypress Test.04 - search view updates <https://github.com/smaht-dac/smaht-portal/pull/374>`_
 
 * Updates 04a_search_views_local.cy.js upon recent file search view and other search view changes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.143.2"
+version = "0.143.3"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -442,14 +442,10 @@ export default class App extends React.PureComponent {
             // Add a debounce so it runs again after a delay, so other components get a chance to mount.
             App.debouncedOnNavigationTooltipRebuild();
 
-            if (!session && href) {
-                const hrefParts = memoizedUrlParse(href);
-                const routeList = hrefParts.pathname.split('/');
-                const routeLeaf = routeList[routeList.length - 1];
-
+            if (!session && href && typeof href === "string") {
                 // show not logged in alert for pages that are public but require session to display the results
                 // (mostly) redirects from notification pane in home page 
-                if (routeLeaf === 'qc-metrics' || routeLeaf === 'search') {
+                if (href.indexOf('/qc-metrics') > -1 || href.indexOf('/search/') > -1) {
                     Alerts.queue(NotLoggedInAlert);
                 }
             }

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -1547,9 +1547,9 @@ export default class App extends React.PureComponent {
                     <link rel="canonical" href={canonical} />
                     {/* <script data-prop-name="inline" type="application/javascript" charSet="utf-8" dangerouslySetInnerHTML={{__html: this.props.inline}}/> <-- SAVED FOR REFERENCE */}
                 </head>
-                <React.Fragment>
+                <React.StrictMode>
                     <BodyElement {...bodyElementProps} />
-                </React.Fragment>
+                </React.StrictMode>
             </html>
         );
     }

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -441,6 +441,18 @@ export default class App extends React.PureComponent {
             // We need to rebuild tooltips after navigation to a different page.
             // Add a debounce so it runs again after a delay, so other components get a chance to mount.
             App.debouncedOnNavigationTooltipRebuild();
+
+            if (!session && href) {
+                const hrefParts = memoizedUrlParse(href);
+                const routeList = hrefParts.pathname.split('/');
+                const routeLeaf = routeList[routeList.length - 1];
+
+                // show not logged in alert for pages that are public but require session to display the results
+                // (mostly) redirects from notification pane in home page 
+                if (routeLeaf === 'qc-metrics' || routeLeaf === 'search') {
+                    Alerts.queue(NotLoggedInAlert);
+                }
+            }
         }
 
         // We can skip doing this unless debugging on localhost-
@@ -1535,9 +1547,9 @@ export default class App extends React.PureComponent {
                     <link rel="canonical" href={canonical} />
                     {/* <script data-prop-name="inline" type="application/javascript" charSet="utf-8" dangerouslySetInnerHTML={{__html: this.props.inline}}/> <-- SAVED FOR REFERENCE */}
                 </head>
-                <React.StrictMode>
+                <React.Fragment>
                     <BodyElement {...bodyElementProps} />
-                </React.StrictMode>
+                </React.Fragment>
             </html>
         );
     }

--- a/src/encoded/static/components/browse/SearchView.js
+++ b/src/encoded/static/components/browse/SearchView.js
@@ -204,9 +204,10 @@ const SearchViewPageTitle = React.memo(function SearchViewPageTitle(props) {
 
     return (
         <PageTitleContainer
-            alerts={[]}
+            alerts={alerts}
             className="container-wide pb-2 mb-2"
-            alertsBelowTitleContainer>
+            alertsBelowTitleContainer
+            alertsContainerClassName="container-wide">
             <div className="container-wide m-auto p-xl-0">
                 {/* Using static breadcrumbs here, but will likely need its own component in future */}
                 <div className="static-page-breadcrumbs clearfix mx-0 px-0">

--- a/src/encoded/static/components/static-pages/ErrorPage.js
+++ b/src/encoded/static/components/static-pages/ErrorPage.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import { onAlertLoginClick } from '../navigation/components/LoginNavItem';
 
 /**
  * Render a simple static error page with a link to return to the homepage.
@@ -101,7 +102,7 @@ const HTTPForbiddenView = React.memo(function HTTPForbiddenView(props) {
                 Access was denied to this resource.
             </h4>
             <p className="mb-0 mt-0">
-                If you have an account, please try logging in or return to the{' '}
+                If you have an account, please try <a onClick={onAlertLoginClick} href="#loginbtn" className="link-underline-hover">logging in</a> or return to the{' '}
                 <a href="/" className="link-underline-hover">
                     homepage
                 </a>


### PR DESCRIPTION
available in [devtest](https://devtest.smaht.org/)

- Adds "Not Logged In" alert to /search and /qc-metrics pages when navigated from another page like home page [notifications](https://data.smaht.org/) or [documentation pages](https://data.smaht.org/docs/submission/links-to-existing-data)
- Adds login popup link to `logging in` text in "Access was denied to this resource" alert.

<img width="1890" alt="Screenshot 2025-03-12 at 23 26 41" src="https://github.com/user-attachments/assets/9812f446-b720-4a24-a541-0dec5574ce90" />


<img width="1610" alt="Screenshot 2025-03-12 at 23 34 50" src="https://github.com/user-attachments/assets/7305d090-52c0-4332-8bd6-b342226a31b6" />
