### PR TITLE
Home and Search Page Updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,17 @@ smaht-portal
 Change Log
 ----------
 
+0.149.0
+=======
+`PR 381: Home and Search Page Updates <https://github.com/smaht-dac/smaht-portal/pull/381>`_
+
+* Enables the previously disabled data release tracker links on the home page
+* Adds date for announcements on the home page when applicable
+* Fixes overflow/overlapping issues in the facet date range
+* Replaces erroneously displayed date_created under the Released column with file_tracking_status.released_date in file tables
+* Updates data retraction notice in the COLO829 benchmarking page
+* Makes the released files title in file search view more prominent
+
 
 0.148.2
 =======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -87,7 +87,7 @@ Change Log
 =======
 `PR 309: SN validate external_id <https://github.com/smaht-dac/smaht-portal/pull/309>`_
 
-*  Add a custom validator to TissueSample that ensures the `external_id` for items from benchmarking and production Donors matches the pattern expected for category (currently only applied to TPC submitted items)
+* Add a custom validator to TissueSample that ensures the `external_id` for items from benchmarking and production Donors matches the pattern expected for category (currently only applied to TPC submitted items)
 * Make `tpc_submitted` a required property for Donor
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@gmod/tabix": "^1.5.3",
         "@gmod/vcf": "^5.0.6",
         "@hms-dbmi-bgm/react-workflow-viz": "0.1.11",
-        "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.93",
+        "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.94b1",
         "@reduxjs/toolkit": "^2.2.6",
         "auth0-lock": "^12.5.1",
         "d3": "^7.8.5",
@@ -2512,8 +2512,8 @@
       }
     },
     "node_modules/@hms-dbmi-bgm/shared-portal-components": {
-      "version": "0.1.93",
-      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#f44b2806a4ab447368dfb7f8a3070f5d5a1b8f1b",
+      "version": "0.1.94",
+      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#15f88ace102a7f128f62165293a81f92466f22f9",
       "license": "MIT",
       "dependencies": {
         "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",
@@ -4429,9 +4429,9 @@
       "integrity": "sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ=="
     },
     "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -6370,9 +6370,9 @@
       }
     },
     "node_modules/cypress/node_modules/ci-info": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.1.0.tgz",
-      "integrity": "sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.2.0.tgz",
+      "integrity": "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@gmod/tabix": "^1.5.3",
         "@gmod/vcf": "^5.0.6",
         "@hms-dbmi-bgm/react-workflow-viz": "0.1.11",
-        "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.94b1",
+        "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.94",
         "@reduxjs/toolkit": "^2.2.6",
         "auth0-lock": "^12.5.1",
         "d3": "^7.8.5",
@@ -2513,7 +2513,7 @@
     },
     "node_modules/@hms-dbmi-bgm/shared-portal-components": {
       "version": "0.1.94",
-      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#15f88ace102a7f128f62165293a81f92466f22f9",
+      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#c7b972a80dfe6b9b166d58ed92e593787705ef6d",
       "license": "MIT",
       "dependencies": {
         "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@gmod/tabix": "^1.5.3",
         "@gmod/vcf": "^5.0.6",
         "@hms-dbmi-bgm/react-workflow-viz": "0.1.11",
-        "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.94",
+        "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.95b1",
         "@reduxjs/toolkit": "^2.2.6",
         "auth0-lock": "^12.5.1",
         "d3": "^7.8.5",
@@ -2512,8 +2512,8 @@
       }
     },
     "node_modules/@hms-dbmi-bgm/shared-portal-components": {
-      "version": "0.1.94",
-      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#c7b972a80dfe6b9b166d58ed92e593787705ef6d",
+      "version": "0.1.95",
+      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#f920ec97b1082b86fefad6ae319c9ce6a44eade5",
       "license": "MIT",
       "dependencies": {
         "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@gmod/tabix": "^1.5.3",
         "@gmod/vcf": "^5.0.6",
         "@hms-dbmi-bgm/react-workflow-viz": "0.1.11",
-        "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.95b1",
+        "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.95",
         "@reduxjs/toolkit": "^2.2.6",
         "auth0-lock": "^12.5.1",
         "d3": "^7.8.5",
@@ -2513,7 +2513,7 @@
     },
     "node_modules/@hms-dbmi-bgm/shared-portal-components": {
       "version": "0.1.95",
-      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#f920ec97b1082b86fefad6ae319c9ce6a44eade5",
+      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#409000f7ffaf24fce142ce155976c6cbcefd2cf1",
       "license": "MIT",
       "dependencies": {
         "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@gmod/tabix": "^1.5.3",
     "@gmod/vcf": "^5.0.6",
     "@hms-dbmi-bgm/react-workflow-viz": "0.1.11",
-    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.94b1",
+    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.94",
     "@reduxjs/toolkit": "^2.2.6",
     "auth0-lock": "^12.5.1",
     "d3": "^7.8.5",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@gmod/tabix": "^1.5.3",
     "@gmod/vcf": "^5.0.6",
     "@hms-dbmi-bgm/react-workflow-viz": "0.1.11",
-    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.94",
+    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.95b1",
     "@reduxjs/toolkit": "^2.2.6",
     "auth0-lock": "^12.5.1",
     "d3": "^7.8.5",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@gmod/tabix": "^1.5.3",
     "@gmod/vcf": "^5.0.6",
     "@hms-dbmi-bgm/react-workflow-viz": "0.1.11",
-    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.95b1",
+    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.95",
     "@reduxjs/toolkit": "^2.2.6",
     "auth0-lock": "^12.5.1",
     "d3": "^7.8.5",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@gmod/tabix": "^1.5.3",
     "@gmod/vcf": "^5.0.6",
     "@hms-dbmi-bgm/react-workflow-viz": "0.1.11",
-    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.93",
+    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.94b1",
     "@reduxjs/toolkit": "^2.2.6",
     "auth0-lock": "^12.5.1",
     "d3": "^7.8.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.148.2"
+version = "0.149.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/assay.json
+++ b/src/encoded/schemas/assay.json
@@ -172,6 +172,10 @@
         },
         "code": {
             "title": "Code"
+        },
+        "category": {
+            "title": "Category",
+            "default_hidden": true
         }
     }
 }

--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -304,7 +304,7 @@
         "data_type": {
             "title": "Data Type"
         },
-        "file_status_tracking.released_date": {
+        "file_status_tracking.released": {
             "title" : "Release Date",
             "aggregation_type" : "stats"
         },

--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -290,7 +290,8 @@
         "file_sets.libraries.assay.display_title": {
             "title": "Experimental Assay",
             "search_type": "sayt",
-            "sayt_item_type": "Donor"
+            "sayt_item_type": "Assay",
+            "group_by_field": "file_sets.libraries.assay.category"
         },
         "file_sets.sequencing.sequencer.display_title": {
             "title": "Sequencing Platform"

--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -289,7 +289,7 @@
         },
         "file_sets.libraries.assay.display_title": {
             "title": "Experimental Assay",
-            "search_type": "sayt",
+            "search_type": "basic",
             "sayt_item_type": "Assay",
             "group_by_field": "file_sets.libraries.assay.category"
         },

--- a/src/encoded/static/components/browse/BrowseView.js
+++ b/src/encoded/static/components/browse/BrowseView.js
@@ -428,14 +428,11 @@ export function createBrowseColumnExtensionMap({ selectedItems, onSelectItem, on
             colTitle: 'Released',
             widthMap: { lg: 115, md: 115, sm: 115 },
             render: function (result, parentProps) {
-                const value = result?.file_status_tracking?.released;
+                const value = result?.file_status_tracking?.released_date;
                 if (!value) return null;
                 return (
                     <span className="value text-end">
-                        <LocalizedTime
-                            timestamp={value}
-                            formatType="date-file"
-                        />
+                    {value}
                     </span>
                 );
             },

--- a/src/encoded/static/components/browse/BrowseView.js
+++ b/src/encoded/static/components/browse/BrowseView.js
@@ -424,11 +424,11 @@ export function createBrowseColumnExtensionMap({ selectedItems, onSelectItem, on
             },
         },
         // Released
-        date_created: {
+        'file_status_tracking.released_date': {
             colTitle: 'Released',
             widthMap: { lg: 115, md: 115, sm: 115 },
             render: function (result, parentProps) {
-                const value = result?.date_created;
+                const value = result?.file_status_tracking?.released;
                 if (!value) return null;
                 return (
                     <span className="value text-end">
@@ -451,6 +451,23 @@ export function createBrowseColumnExtensionMap({ selectedItems, onSelectItem, on
         // Software
         'software.display_title': {
             widthMap: { lg: 151, md: 151, sm: 151 },
+        },
+        // Date Created
+        'date_created': {
+            widthMap: { lg: 151, md: 151, sm: 151 },
+            default_hidden: true,
+            render: function (result, parentProps) {
+                const value = result?.date_created;
+                if (!value) return null;
+                return (
+                    <span className="value text-end">
+                        <LocalizedTime
+                            timestamp={value}
+                            formatType="date-file"
+                        />
+                    </span>
+                );
+            }
         },
     };
 
@@ -476,8 +493,7 @@ export function createBrowseColumnExtensionMap({ selectedItems, onSelectItem, on
         file_size: {
             title: 'File Size',
         },
-        date_created: {
-            // TODO: is this correct?
+        'file_status_tracking.released_date': {
             title: 'Release Date',
         },
         'file_sets.sequencing.sequencer.display_title': {
@@ -492,6 +508,9 @@ export function createBrowseColumnExtensionMap({ selectedItems, onSelectItem, on
         'software.display_title': {
             title: 'Software',
         },
+        date_created: {
+            title: 'Date Created'
+        }
     };
 
     const hideFacets = [

--- a/src/encoded/static/components/browse/FileSearchView.js
+++ b/src/encoded/static/components/browse/FileSearchView.js
@@ -6,6 +6,7 @@ import memoize from 'memoize-one';
 import _ from 'underscore';
 import { SearchView as CommonSearchView } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/SearchView';
 import { SelectedItemsController } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/SelectedItemsController';
+import { SelectedItemsController } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/SelectedItemsController';
 import { console } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
 import { navigate, Schemas } from './../util';
 import { columnExtensionMap as originalColExtMap } from './columnExtensionMap';
@@ -37,8 +38,10 @@ function FileTableWithSelectedFilesCheckboxes(props){
         toggleFullScreen, isFullscreen, session,
         selectedItems, onSelectItem, selectItem, onResetSelectedItems,
         columnExtensionMap: propColumnExtensionMap = originalColExtMap,
+        columnExtensionMap: propColumnExtensionMap = originalColExtMap,
         currentAction
     } = props;
+ 
  
     const facets = useMemo(function(){
         return transformedFacets(context, currentAction, schemas);

--- a/src/encoded/static/components/browse/FileSearchView.js
+++ b/src/encoded/static/components/browse/FileSearchView.js
@@ -38,7 +38,6 @@ function FileTableWithSelectedFilesCheckboxes(props){
         toggleFullScreen, isFullscreen, session,
         selectedItems, onSelectItem, selectItem, onResetSelectedItems,
         columnExtensionMap: propColumnExtensionMap = originalColExtMap,
-        columnExtensionMap: propColumnExtensionMap = originalColExtMap,
         currentAction
     } = props;
  
@@ -54,9 +53,9 @@ function FileTableWithSelectedFilesCheckboxes(props){
     };
 
     const { columnExtensionMap, columns, hideFacets } = useMemo(function () {
-        let { columnExtensionMap, columns } = createBrowseColumnExtensionMap(selectedFileProps);
+        let { columnExtensionMap, columns, hideFacets } = createBrowseColumnExtensionMap(selectedFileProps);
         columnExtensionMap = _.extend({}, propColumnExtensionMap, columnExtensionMap);
-        return { columnExtensionMap, columns };
+        return { columnExtensionMap, columns, hideFacets };
     }, [propColumnExtensionMap, selectedFileProps]);
 
     const tableColumnClassName = 'results-column col';

--- a/src/encoded/static/components/browse/FileSearchView.js
+++ b/src/encoded/static/components/browse/FileSearchView.js
@@ -9,10 +9,11 @@ import { SelectedItemsController } from '@hms-dbmi-bgm/shared-portal-components/
 import { console } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
 import { navigate, Schemas } from './../util';
 import { columnExtensionMap as originalColExtMap } from './columnExtensionMap';
-import { transformedFacets } from './SearchView';
+import { transformedFacets, SearchViewPageTitle } from './SearchView';
 import { BrowseViewAboveSearchTableControls } from './browse-view/BrowseViewAboveSearchTableControls';
 import { SelectAllFilesButton, SelectedItemsDownloadButton } from '../static-pages/components/SelectAllAboveTableComponent';
 import { createBrowseColumnExtensionMap } from './BrowseView';
+import { pageTitleViews, PageTitleContainer, TitleAndSubtitleBeside } from '../PageTitleSection';
 
 
 
@@ -142,3 +143,115 @@ function AboveFacetList({ context, currentAction }){
         </div>
     );
 }
+
+/**
+ * Generates a dynamic title based on an array of filter objects.
+ *
+ * This function uses a reduce method to process the filters in a single pass and extract:
+ * - An array of all "status" terms.
+ * - The first occurrence of the "file_status_tracking.released.from" term as the start date.
+ * - The first occurrence of the "file_status_tracking.released.to" term as the end date.
+ *
+ * It then performs the following validations:
+ * 1. There is at least one "status" filter, and all "status" filters must have the term "released".
+ * 2. Both start (from) and end (to) dates are available.
+ * 3. The start date must be the first day of a month.
+ * 4. The end date must be the last day of the same month and year.
+ *
+ * If all conditions are met, the function returns a title in the format:
+ *    "Released Files in <ShortMonth> <Year>"
+ * Otherwise, it returns a fallback title.
+ *
+ * @param {Array} filters - An array of filter objects, each containing a 'field', 'term', and 'remove' property.
+ * @returns {string} The generated title or the fallback title if validations fail.
+ */
+const FileSearchViewPageTitle = React.memo(function FileSearchViewPageTitle(props) {
+    const { context, alerts } = props;
+    const { filters = [] } = context || {};
+
+    const fallbackTitle = (<SearchViewPageTitle {...props} />);
+
+    if (!Array.isArray(filters) || filters.length === 0) {
+        return fallbackTitle;
+    }
+
+    // Use reduce to aggregate the required values in one pass.
+    const { statuses, from, to } = filters.reduce(
+        (acc, filter) => {
+            if (filter.field === 'status') {
+                acc.statuses.push(filter.term);
+            } else if (filter.field === 'file_status_tracking.released.from' && !acc.from) {
+                acc.from = filter.term;
+            } else if (filter.field === 'file_status_tracking.released.to' && !acc.to) {
+                acc.to = filter.term;
+            }
+            return acc;
+        },
+        { statuses: [], from: null, to: null }
+    );
+
+    // Check that there is at least one status and that all status values are "released".
+    if (statuses.length === 0 || statuses.some(term => term !== 'released')) {
+        return fallbackTitle;
+    }
+
+    // Ensure both from and to dates are present.
+    if (!from || !to) {
+        return fallbackTitle;
+    }
+
+    const fromDate = new Date(from);
+    const toDate = new Date(to);
+
+    // Check if the fromDate is the first day of the month.
+    if (fromDate.getDate() !== 1) {
+        return fallbackTitle;
+    }
+
+    // Calculate the last day of the month for fromDate.
+    const lastDayOfMonth = new Date(fromDate.getFullYear(), fromDate.getMonth() + 1, 0).getDate();
+
+    // Validate that toDate is the last day of the same month and year.
+    if (toDate.getDate() !== lastDayOfMonth || fromDate.getFullYear() !== toDate.getFullYear() || fromDate.getMonth() !== toDate.getMonth()) {
+        return fallbackTitle;
+    }
+
+    const monthName = fromDate.toLocaleString('default', { month: 'short' });
+    const subtitle = (
+        <span>
+            <small className="text-300">in</small> {`${monthName} ${fromDate.getFullYear()}`}
+        </span>
+    );
+
+    return (
+        <PageTitleContainer
+            alerts={alerts}
+            className="container-wide pb-2 mb-2"
+            alertsBelowTitleContainer
+            alertsContainerClassName="container-wide">
+            <div className="container-wide m-auto p-xl-0">
+                {/* Using static breadcrumbs here, but will likely need its own component in future */}
+                <div className="static-page-breadcrumbs clearfix mx-0 px-0">
+                    <div className="static-breadcrumb" data-name="Home" key="/">
+                        <a href="/" className="link-underline-hover">
+                            Home
+                        </a>
+                        <i className="icon icon-fw icon-angle-right fas" />
+                    </div>
+                    <div
+                        className="static-breadcrumb nonclickable"
+                        data-name="Search"
+                        key="/search">
+                        <span>Search</span>
+                    </div>
+                </div>
+                <TitleAndSubtitleBeside subtitle={subtitle}>
+                    Released Files
+                </TitleAndSubtitleBeside>
+            </div>
+        </PageTitleContainer>
+    );
+});
+
+pageTitleViews.register(FileSearchViewPageTitle, 'FileSearchResults');
+pageTitleViews.register(FileSearchViewPageTitle, 'SubmittedFileSearchResults');

--- a/src/encoded/static/components/browse/FileSearchView.js
+++ b/src/encoded/static/components/browse/FileSearchView.js
@@ -6,7 +6,6 @@ import memoize from 'memoize-one';
 import _ from 'underscore';
 import { SearchView as CommonSearchView } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/SearchView';
 import { SelectedItemsController } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/SelectedItemsController';
-import { SelectedItemsController } from '@hms-dbmi-bgm/shared-portal-components/es/components/browse/components/SelectedItemsController';
 import { console } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
 import { navigate, Schemas } from './../util';
 import { columnExtensionMap as originalColExtMap } from './columnExtensionMap';
@@ -40,7 +39,6 @@ function FileTableWithSelectedFilesCheckboxes(props){
         columnExtensionMap: propColumnExtensionMap = originalColExtMap,
         currentAction
     } = props;
- 
  
     const facets = useMemo(function(){
         return transformedFacets(context, currentAction, schemas);

--- a/src/encoded/static/components/browse/SearchView.js
+++ b/src/encoded/static/components/browse/SearchView.js
@@ -170,7 +170,7 @@ export class SearchViewBody extends React.PureComponent {
     }
 }
 
-const SearchViewPageTitle = React.memo(function SearchViewPageTitle(props) {
+export const SearchViewPageTitle = React.memo(function SearchViewPageTitle(props) {
     const { context, schemas, currentAction, alerts } = props;
 
     if (currentAction === 'add') {

--- a/src/encoded/static/components/static-pages/components/NotificationsPanel.js
+++ b/src/encoded/static/components/static-pages/components/NotificationsPanel.js
@@ -90,16 +90,16 @@ const DataReleaseItem = ({ data, releaseItemIndex }) => {
                                 isExpanded ? 'minus' : 'plus'
                             }`}></i>
                     </button>
-                    <div className="header-link">
+                    <a className="header-link" href={query}>
                         <span>
                             {releaseItemIndex === 0 ? 'Latest: ' : ''}
                             {month} {year}
                         </span>
                         <span className="count">
                             {count} {count > 1 ? 'Files' : 'File'}
-                            {/* <i className="icon icon-arrow-right"></i> */}
+                            <i className="icon icon-arrow-right"></i>
                         </span>
-                    </div>
+                    </a>
                 </div>
                 <div className="body">
                     {sample_groups.map((sample_group, i) => {
@@ -121,7 +121,7 @@ const DataReleaseItem = ({ data, releaseItemIndex }) => {
 
                         return (
                             <div className="release-item" key={i}>
-                                <div className="title">
+                                <a className="title" href={sample_group.query}>
                                     {sample_group_title}
                                     <svg
                                         width="22"
@@ -130,15 +130,15 @@ const DataReleaseItem = ({ data, releaseItemIndex }) => {
                                         xmlns="http://www.w3.org/2000/svg">
                                         <path d="M1 7C0.447715 7 0 7.44772 0 8C0 8.55228 0.447715 9 1 9V7ZM21.7071 8.70711C22.0976 8.31658 22.0976 7.68342 21.7071 7.29289L15.3431 0.928932C14.9526 0.538408 14.3195 0.538408 13.9289 0.928932C13.5384 1.31946 13.5384 1.95262 13.9289 2.34315L19.5858 8L13.9289 13.6569C13.5384 14.0474 13.5384 14.6805 13.9289 15.0711C14.3195 15.4616 14.9526 15.4616 15.3431 15.0711L21.7071 8.70711ZM1 9H21V7H1V9Z" />
                                     </svg>
-                                </div>
+                                </a>
                                 <ul>
                                     {sample_group.items.map((item, i) => {
-                                        const { value, count } = item;
+                                        const { value, count, query } = item;
                                         return (
                                             <li key={i}>
-                                                <div>
+                                                <a href={query}>
                                                     {count} {value}
-                                                </div>
+                                                </a>
                                             </li>
                                         );
                                     })}

--- a/src/encoded/static/components/static-pages/components/NotificationsPanel.js
+++ b/src/encoded/static/components/static-pages/components/NotificationsPanel.js
@@ -1,10 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { ajax } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
+import { LocalizedTime } from '@hms-dbmi-bgm/shared-portal-components/es/components/ui/LocalizedTime';
 
 const announcements = [
     {
         type: 'warning',
         title: 'Data Retraction',
+        date: '2025-03-10',
         body: (
             <span>
                 One WGS ONT PromethION 24 BAM from COLO829-BLT50,{' '}
@@ -18,6 +20,7 @@ const announcements = [
     {
         type: 'info',
         title: 'New Features',
+        date: '2025-01-25',
         body: (
             <span>
                 Explore the <a href="/qc-metrics">Interactive QC Assessment</a>{' '}
@@ -54,10 +57,10 @@ const announcements = [
     },
 ];
 
-const AnnouncementCard = ({ title = '', body = '', type = 'info' }) => {
+const AnnouncementCard = ({ title = '', body = '', type = 'info', date = null }) => {
     return (
         <div className={`announcement-container ${type}`}>
-            <h5 className="header">{title}</h5>
+            <h5 className="header">{title}{date ? <span className='text-muted'><LocalizedTime timestamp={new Date(date)} formatType='date-sm' /></span> : null}</h5>
             <div className="body">{body}</div>
         </div>
     );
@@ -205,6 +208,7 @@ export const NotificationsPanel = () => {
                                     title={announcement.title}
                                     body={announcement.body}
                                     type={announcement.type}
+                                    date={announcement.date}
                                 />
                             );
                         })}

--- a/src/encoded/static/components/static-pages/components/NotificationsPanel.js
+++ b/src/encoded/static/components/static-pages/components/NotificationsPanel.js
@@ -60,7 +60,10 @@ const announcements = [
 const AnnouncementCard = ({ title = '', body = '', type = 'info', date = null }) => {
     return (
         <div className={`announcement-container ${type}`}>
-            <h5 className="header">{title}{date ? <span className='text-muted'><LocalizedTime timestamp={new Date(date)} formatType='date-sm' /></span> : null}</h5>
+            <h5 className="header">
+                {title}
+                {date ? <LocalizedTime timestamp={new Date(date)} formatType='date-sm-compact' /> : null}
+            </h5>
             <div className="body">{body}</div>
         </div>
     );

--- a/src/encoded/static/components/static-pages/components/benchmarking/BenchmarkingDataMap.js
+++ b/src/encoded/static/components/static-pages/components/benchmarking/BenchmarkingDataMap.js
@@ -122,7 +122,7 @@ export const BenchmarkingDataMap = {
                     <span className="flag">Data Retraction Notice: </span>
                     <ul>
                         <li>
-                            One WGS ONT PromethION 24 BAM from COLO829-BLT50, <a href="/SMAFI557D2E7" target="_blank" rel="noreferrer noopener" className="link-underline-hover">SMAFIPHR8QOG</a>, has been retracted due to <strong>sample swap</strong>. The replacement BAM from the correct COLO829-BLT50 sample will be made available soon.
+                            One WGS ONT PromethION 24 BAM from COLO829-BLT50, <a href="/SMAFIPHR8QOG" target="_blank" rel="noreferrer noopener" className="link-underline-hover">SMAFIPHR8QOG</a>, has been retracted due to <strong>sample swap</strong>. The replacement BAM from the correct COLO829-BLT50 sample will be made available soon.
                         </li>
                         <li>
                             The <a href="/SMAFI557D2E7" target="_blank" rel="noreferrer noopener" className="link-underline-hover"> original BAM file</a> of COLO829-T standard ONT WGS data was retracted due to <strong>missing methylation tags</strong>. The replacement BAM with proper tags is made <a href="/SMAFIB6EQLZM" target="_blank" rel="noreferrer noopener" className="link-underline-hover"> available here.</a>

--- a/src/encoded/static/components/static-pages/components/benchmarking/BenchmarkingDataMap.js
+++ b/src/encoded/static/components/static-pages/components/benchmarking/BenchmarkingDataMap.js
@@ -119,27 +119,16 @@ export const BenchmarkingDataMap = {
         callout: (
             <div className="callout warning">
                 <p className="callout-text">
-                    <span className="flag">Attention: </span>
-                    The{' '}
-                    <a
-                        href="/SMAFI557D2E7"
-                        target="_blank"
-                        rel="noreferrer noopener"
-                        className="link-underline-hover">
-                        original BAM file
-                    </a>{' '}
-                    of COLO829-T standard ONT WGS data{' '}
-                    <strong>
-                        was retracted due to missing methylation tags
-                    </strong>
-                    . The replacement BAM with proper tags is made{' '}
-                    <a
-                        href="/SMAFIB6EQLZM"
-                        target="_blank"
-                        rel="noreferrer noopener"
-                        className="link-underline-hover">
-                        available here.
-                    </a>
+                    <span className="flag">Data Retraction Notice: </span>
+                    <ul>
+                        <li>
+                            One WGS ONT PromethION 24 BAM from COLO829-BLT50, <a href="/SMAFI557D2E7" target="_blank" rel="noreferrer noopener" className="link-underline-hover">SMAFIPHR8QOG</a>, has been retracted due to <strong>sample swap</strong>. The replacement BAM from the correct COLO829-BLT50 sample will be made available soon.
+                        </li>
+                        <li>
+                            The <a href="/SMAFI557D2E7" target="_blank" rel="noreferrer noopener" className="link-underline-hover"> original BAM file</a> of COLO829-T standard ONT WGS data was retracted due to <strong>missing methylation tags</strong>. The replacement BAM with proper tags is made <a href="/SMAFIB6EQLZM" target="_blank" rel="noreferrer noopener" className="link-underline-hover"> available here.</a>
+                        </li>
+                    </ul>
+
                 </p>
             </div>
         ),

--- a/src/encoded/static/scss/encoded/modules/_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_search.scss
@@ -273,6 +273,10 @@ $facetlist-excluding: #450000;
 						padding-bottom: 4px;
 						margin-left: 0px !important;
 					}
+
+					.rcol.dropdown {
+						min-width: 90%;
+					}
 				}
 			}
 		}

--- a/src/encoded/static/scss/encoded/modules/_search.scss
+++ b/src/encoded/static/scss/encoded/modules/_search.scss
@@ -260,6 +260,21 @@ $facetlist-excluding: #450000;
 					font-weight: 600;
 				}
 			}
+
+			&.range-facet {
+				.facet-list .range-drop {
+					flex-direction: column;
+					align-items: start !important;
+
+					label {
+						text-align-last: left !important;
+						font-size: 0.75rem;
+						font-weight: 450;
+						padding-bottom: 4px;
+						margin-left: 0px !important;
+					}
+				}
+			}
 		}
 	}
 }

--- a/src/encoded/static/scss/encoded/modules/_static-pages.scss
+++ b/src/encoded/static/scss/encoded/modules/_static-pages.scss
@@ -880,11 +880,11 @@ body[data-path="/"]>#application>#layout {
 											border-radius: inherit;
 											align-items: baseline;
 
-											// &:hover {
-											// 	background-color: #d3dff7;
-											// 	transition: border-color 50ms;
-											// 	border: 1px solid hsla(241, 84%, 40%, 0.6);
-											// }
+											&:hover {
+												background-color: #d3dff7;
+												transition: border-color 50ms;
+												border: 1px solid hsla(241, 84%, 40%, 0.6);
+											}
 
 										}
 										&:hover {
@@ -938,18 +938,18 @@ body[data-path="/"]>#application>#layout {
 													display: none;
 												}
 	
-												// &:hover {
-												// 	display: flex;
-												// 	cursor: pointer;
-												// 	color: #3C71F9;
+												&:hover {
+													display: flex;
+													cursor: pointer;
+													color: #3C71F9;
 	
-												// 	svg {
-												// 		display: flex;
-												// 		fill: #3C71F9;
-												// 		width: 12px;
-												// 		margin-left: 4px;
-												// 	}
-												// }
+													svg {
+														display: flex;
+														fill: #3C71F9;
+														width: 12px;
+														margin-left: 4px;
+													}
+												}
 											}
 	
 											ul {
@@ -996,10 +996,10 @@ body[data-path="/"]>#application>#layout {
 											&-link {
 												color: #014B11;
 												
-												// &:hover {
-												// 	background-color: rgba(168, 247, 200, 0.5);
-												// 	border: 1px solid rgb(1 75 17 / 75%);
-												// }
+												&:hover {
+													background-color: rgba(168, 247, 200, 0.5);
+													border: 1px solid rgb(1 75 17 / 75%);
+												}
 											}
 											.count {
 												color: rgb(1 75 17 / 75%);

--- a/src/encoded/static/scss/encoded/modules/_static-pages.scss
+++ b/src/encoded/static/scss/encoded/modules/_static-pages.scss
@@ -1090,7 +1090,9 @@ body[data-path="/"]>#application>#layout {
 										text-transform: none;
 										font-weight: 500;
 										margin-left: 8px;
-										// font-size: 90%;
+										font-size: 0.65rem;
+										color: #90a2cd;
+										float: right !important;
 									}
 								}
 								.body {

--- a/src/encoded/static/scss/encoded/modules/_static-pages.scss
+++ b/src/encoded/static/scss/encoded/modules/_static-pages.scss
@@ -1085,6 +1085,13 @@ body[data-path="/"]>#application>#layout {
 									margin-top: 0px;
 									margin-bottom: 5px;
 									text-transform: uppercase;
+
+									.localized-date-time {
+										text-transform: none;
+										font-weight: 500;
+										margin-left: 8px;
+										// font-size: 90%;
+									}
 								}
 								.body {
 									font-size: 0.75rem;

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -429,10 +429,15 @@ class File(Item, CoreFile):
     STATUS_TO_CHECK_REVISIONS = [
         'uploading',
         'uploaded',
+        'retracted',
         'in review',
         'released',
         'restricted',
         'public'
+    ]
+    STATUS_TO_REVISION_DATE_CONVERSION = [
+        'retracted',
+        'released'
     ]
 
     Item.SUBMISSION_CENTER_STATUS_ACL.update({
@@ -542,6 +547,10 @@ class File(Item, CoreFile):
                     "type": "string",
                     "format": "date-time"
                 },
+                "retracted": {
+                    "type": "string",
+                    "format": "date-time"
+                },
                 "in review": {
                     "type": "string",
                     "format": "date-time"
@@ -606,10 +615,12 @@ class File(Item, CoreFile):
                         last_modified = revision.get('last_modified')
                         if last_modified:
                             result[status] = last_modified['date_modified']
-            if "released" in result:
-                result["released_date"] = self.get_date_from_datetime(
-                    result["released"]
-                )
+
+            # add date converted values for selected status
+            for status in self.STATUS_TO_REVISION_DATE_CONVERSION:
+                if status in result:
+                    result[status + "_date"] = self.get_date_from_datetime(result[status])
+
             return result
 
     @staticmethod

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -547,6 +547,7 @@ class File(Item, CoreFile):
                     "format": "date-time"
                 },
                 "released": {
+                    "title": "Release Date",
                     "type": "string",
                     "format": "date-time"
                 },


### PR DESCRIPTION
This PR,

- Enables the previously disabled data release tracker links on the home page
- Adds date for announcements on the home page when applicable ([screenshot](https://i.gyazo.com/f581687abc2a28c4d35774cd009e8aec.png))
- Fixes overflow/overlapping issues in the facet date range ([screenshot](https://i.gyazo.com/d88a9d86fd8abea34b6c3e6ce7310a82.png))
- Replaces erroneously displayed `date_created` under the Released column with `file_tracking_status.released_date` in file tables (`date_created` is moved to hidden columns that can be enabled by customize columns visibility panel)
- Updates data retraction notice in the COLO829 benchmarking page ([screenshot](https://i.gyazo.com/36e8a99fa3e9d5863c2b578bf13b6190.png))
- Makes the released files title in file search view more prominent ([screenshot](https://i.gyazo.com/481c10582ddb6d4b97b34cd72c2361e2.png))

PS: updates are available in [devtest](https://devtest.smaht.org/)
Related SPC PR: https://github.com/4dn-dcic/shared-portal-components/pull/266

