### PR TITLE
SN Fix release tracker calcprop

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ smaht-portal
 Change Log
 ----------
 
+0.151.0
+=======
+`PR 385: SN Fix release tracker calcprop <https://github.com/smaht-dac/smaht-portal/pull/385>`_
+
+* Fix the `release_tracker_title` and `release_tracker_description` calcprops to have the override property function in the case of having multiple values from `file_sets`
+* Make `file_sets` a required property for SupplementaryFile, as it is for all other SubmittedFile types, so that the File Overview display and Manifest File generation work properly
+
+
 0.150.1
 =======
 `PR 386: Fix page title registry for /browse <https://github.com/smaht-dac/smaht-portal/pull/386>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.150.1"
+version = "0.151.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/supplementary_file.json
+++ b/src/encoded/schemas/supplementary_file.json
@@ -11,7 +11,8 @@
         "submitted_id",
         "software",
         "data_type",
-        "data_category"
+        "data_category",
+        "file_sets"
     ],
     "identifyingProperties": [
         "accession",

--- a/src/encoded/tests/data/workbook-inserts/output_file.json
+++ b/src/encoded/tests/data/workbook-inserts/output_file.json
@@ -79,7 +79,7 @@
         "tags": [
             "test_release_tracker",
             "release_tracker_title-ST001-1D",
-            "release_tracker_description-BulkWGSPacBioReviobam"
+            "release_tracker_description-Fiber-SeqPacBioRevioBAM"
         ]
     }
 ]

--- a/src/encoded/tests/data/workbook-inserts/supplementary_file.json
+++ b/src/encoded/tests/data/workbook-inserts/supplementary_file.json
@@ -10,6 +10,10 @@
         ],
         "filename": "test_DSA_to_GRCh38.chain.gz",
         "file_format": "CHAIN",
+        "file_sets": [
+            "TEST_FILE-SET_HELA-HEK293-DNA",
+            "TEST_FILE-SET_HELA_ONLY-RNA"
+        ],
         "submission_centers": [
             "smaht"
         ],
@@ -36,7 +40,8 @@
         "filename": "test_hela.fasta",
         "file_format": "FASTA",
         "file_sets": [
-            "TEST_FILE-SET_HELA-HEK293-DNA"
+            "TEST_FILE-SET_HELA-HEK293-DNA",
+            "TEST_FILE-SET_HELA_ONLY-RNA"
         ],
         "submission_centers": [
             "smaht"

--- a/src/encoded/tests/data/workbook-inserts/supplementary_file.json
+++ b/src/encoded/tests/data/workbook-inserts/supplementary_file.json
@@ -30,7 +30,7 @@
         "tags": [
             "test_release_tracker",
             "release_tracker_title-HELA",
-            "release_tracker_description-DSAchain"
+            "release_tracker_description-DSACHAIN"
         ]
     },
     {
@@ -63,7 +63,7 @@
         "tags": [
             "test_release_tracker",
             "release_tracker_title-HELA",
-            "release_tracker_description-DSAfa"
+            "release_tracker_description-DSAFASTA"
         ]
     }
 ]

--- a/src/encoded/tests/data/workbook-inserts/unaligned_reads.json
+++ b/src/encoded/tests/data/workbook-inserts/unaligned_reads.json
@@ -93,7 +93,7 @@
         "tags": [
             "test_release_tracker",
             "release_tracker_title-HELA",
-            "release_tracker_description-RNA-SeqIlluminaNovaSeqXfastq_gz"
+            "release_tracker_description-MAS-ISO-SeqPacBioRevioFASTQ"
         ]
     },
     {
@@ -118,7 +118,7 @@
         "tags": [
             "test_release_tracker",
             "release_tracker_title-HELA",
-            "release_tracker_description-RNA-SeqIlluminaNovaSeqXfastq_gz"
+            "release_tracker_description-MAS-ISO-SeqPacBioRevioFASTQ"
         ]
     },
     {

--- a/src/encoded/tests/data/workbook-inserts/variant_calls.json
+++ b/src/encoded/tests/data/workbook-inserts/variant_calls.json
@@ -24,7 +24,7 @@
         "tags": [
             "test_release_tracker",
             "release_tracker_title-SMHT001-1A",
-            "release_tracker_description-BulkWGSIlluminaNovaSeqXvcf"
+            "release_tracker_description-BulkWGSIlluminaNovaSeqXVCF"
         ]
     },
     {
@@ -60,7 +60,7 @@
         "tags": [
             "test_release_tracker",
             "release_tracker_title-HELAHEK293",
-            "release_tracker_description-BulkWGSONTPromethION24vcf"
+            "release_tracker_description-Cas9TargetedNanoporeSequencingONTPromethION24VCF"
         ]
     }
 ]

--- a/src/encoded/tests/datafixtures.py
+++ b/src/encoded/tests/datafixtures.py
@@ -757,6 +757,7 @@ def test_chain_file(
     testapp,
     test_submission_center,
     file_formats,
+    test_fileset,
     test_software,
     donor_specific_assembly
 ):
@@ -770,6 +771,9 @@ def test_chain_file(
         ],
         "filename": "test_DSA_to_GRCh38.chain.gz",
         "file_format": file_formats.get("CHAIN", {}).get("uuid", ""),
+        "file_sets": [
+            test_fileset["uuid"]
+        ],
         "submission_centers": [
             test_submission_center["uuid"]
         ],
@@ -790,6 +794,7 @@ def test_sequence_file(
     testapp,
     test_submission_center,
     file_formats,
+    test_fileset,
     test_software,
     donor_specific_assembly
 ):
@@ -803,6 +808,9 @@ def test_sequence_file(
         ],
         "filename": "test_hela.fasta",
         "file_format": file_formats.get("FASTA", {}).get("uuid", ""),
+        "file_sets": [
+            test_fileset["uuid"]
+        ],
          "submission_centers": [
             test_submission_center["uuid"]
         ],

--- a/src/encoded/tests/test_types_file.py
+++ b/src/encoded/tests/test_types_file.py
@@ -1236,9 +1236,19 @@ def test_release_tracker_description(es_testapp: TestApp, workbook: None) -> Non
 
 def assert_release_tracker_description_matches_expected(file: Dict[str, Any], es_testapp: TestApp):
     """Assert release_tracker_description calcprop matches expected."""
-    release_tracker_description = file_utils.get_release_tracker_title(file)
+    release_tracker_description = file_utils.get_release_tracker_description(file)
     description_from_tags = get_expected_release_tracker_description(file)
-    assert release_tracker_description.strip() == description_from_tags[0]
+    assert release_tracker_description.replace(" ", "") == description_from_tags
+
+
+def get_expected_release_tracker_description(sample: Dict[str, Any]) -> List[str]:
+    """Get expected release_tracker_description from the file from tags."""
+    expected_release_tracker_description_tag_start = "release_tracker_description-"
+    tags = item_utils.get_tags(sample)
+    expected_description_tags = [
+        tag for tag in tags if tag.startswith(expected_release_tracker_description_tag_start)
+    ]
+    return expected_description_tags[0].split(expected_release_tracker_description_tag_start)[1]
 
 
 @pytest.mark.workbook
@@ -1250,44 +1260,26 @@ def test_release_tracker_title(es_testapp: TestApp, workbook: None) -> None:
     """
     
     search = "tags=test_release_tracker"
-    files_with_release_tracker_description = get_search(es_testapp, search)
-    for file in files_with_release_tracker_description:
-        assert_release_tracker_description_matches_expected(file, es_testapp)
+    files_with_release_tracker_title = get_search(es_testapp, search)
+    for file in files_with_release_tracker_title:
+        assert_release_tracker_title_matches_expected(file, es_testapp)
 
 
 def assert_release_tracker_title_matches_expected(file: Dict[str, Any], request_handler: RequestHandler):
     """Assert release_tracker_title calcprop matches expected."""
     release_tracker_title = file_utils.get_release_tracker_title(file)
     title_from_tags = get_expected_release_tracker_title(file)
-    assert release_tracker_title.strip() == title_from_tags[0]
+    assert release_tracker_title.replace(" ", "") == title_from_tags
 
 
 def get_expected_release_tracker_title(file: Dict[str, Any]) -> List[str]:
     """Get expected release_tracker_title from the file from tags."""
     expected_release_tracker_title_tag_start = "release_tracker_title-"
     tags = item_utils.get_tags(file)
-    expected_sample_name_tags = [
+    expected_title_tags = [
         tag for tag in tags if tag.startswith(expected_release_tracker_title_tag_start)
     ]
-    return [
-        value
-        for tag in expected_sample_name_tags
-        for value in tag.split(expected_release_tracker_title_tag_start)[1]
-    ]
-
-
-def get_expected_release_tracker_description(sample: Dict[str, Any]) -> List[str]:
-    """Get expected release_tracker_description from the file from tags."""
-    expected_release_tracker_description_tag_start = "release_tracker_title-"
-    tags = item_utils.get_tags(sample)
-    expected_sample_name_tags = [
-        tag for tag in tags if tag.startswith(expected_release_tracker_description_tag_start)
-    ]
-    return [
-        value
-        for tag in expected_sample_name_tags
-        for value in tag.split(expected_release_tracker_description_tag_start)[1]
-    ]
+    return expected_title_tags[0].split(expected_release_tracker_title_tag_start)[1]
 
 
 @pytest.mark.workbook

--- a/src/encoded/tests/test_types_file.py
+++ b/src/encoded/tests/test_types_file.py
@@ -1221,9 +1221,9 @@ def assert_analysis_software_matches_expected(
 
 
 @pytest.mark.workbook
-def test_release_tracker_description(es_testapp: TestApp, workbook: None) -> None:
+def test_release_tracker(es_testapp: TestApp, workbook: None) -> None:
     """
-    Ensure 'release_tracker_description' calcprop fields correct for inserts.
+    Ensure  `release_tracker_title` and 'release_tracker_description' calcprops field correct for inserts.
 
     Checks fields present on inserts match values expected by parsing tags.
     """
@@ -1231,7 +1231,9 @@ def test_release_tracker_description(es_testapp: TestApp, workbook: None) -> Non
     search = "tags=test_release_tracker"
     files_with_release_tracker_description = get_search(es_testapp, search)
     for file in files_with_release_tracker_description:
+        assert_release_tracker_title_matches_expected(file, es_testapp)
         assert_release_tracker_description_matches_expected(file, es_testapp)
+
 
 
 def assert_release_tracker_description_matches_expected(file: Dict[str, Any], es_testapp: TestApp):
@@ -1249,20 +1251,6 @@ def get_expected_release_tracker_description(sample: Dict[str, Any]) -> List[str
         tag for tag in tags if tag.startswith(expected_release_tracker_description_tag_start)
     ]
     return expected_description_tags[0].split(expected_release_tracker_description_tag_start)[1]
-
-
-@pytest.mark.workbook
-def test_release_tracker_title(es_testapp: TestApp, workbook: None) -> None:
-    """
-    Ensure 'release_tracker_title' calcprop fields correct for inserts.
-
-    Checks fields present on inserts match values expected by parsing tags.
-    """
-    
-    search = "tags=test_release_tracker"
-    files_with_release_tracker_title = get_search(es_testapp, search)
-    for file in files_with_release_tracker_title:
-        assert_release_tracker_title_matches_expected(file, es_testapp)
 
 
 def assert_release_tracker_title_matches_expected(file: Dict[str, Any], request_handler: RequestHandler):

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -946,7 +946,7 @@ class File(Item, CoreFile):
         return {
             key: value for key, value in to_include.items() if value
         }
-    
+
     def _get_group_coverage(
         self, request_handler: Request, file_properties: Optional[List[str]] = None
     ) -> Union[List[str], None]:
@@ -1067,7 +1067,7 @@ class File(Item, CoreFile):
             ),
         }
         return {key: value for key, value in to_include.items() if value}
-    
+
     def _get_release_tracker_title(
             self,
             request_handler: RequestHandler,
@@ -1081,26 +1081,19 @@ class File(Item, CoreFile):
                     file_utils.get_cell_culture_mixtures(file_properties, request_handler)),
                     item_utils.get_code,
             )):
-                if len(cell_culture_mixture_title) > 1:
-                    return None
-                to_include = cell_culture_mixture_title[0]
+                to_include = None if len(cell_culture_mixture_title) > 1 else cell_culture_mixture_title[0]
             elif (cell_line_title := request_handler.get_items(
                 file_utils.get_cell_lines(file_properties, request_handler)
             )):
-                if len(cell_culture_mixture_title) > 1:
-                    return None
-                to_include = item_utils.get_code(cell_line_title[0])
+                to_include = None if len(cell_line_title) > 1 else item_utils.get_code(cell_line_title[0])
             elif (tissue_title := request_handler.get_items(
                 file_utils.get_tissues(file_properties, request_handler)
             )):
-                if len(tissue_title) > 1:
-                    return None
-                to_include = item_utils.get_display_title(tissue_title[0])   
+                to_include - None if len(tissue_title) > 1 else item_utils.get_display_title(tissue_title[0]) 
         if "override_release_tracker_title" in file_properties:
             to_include = file_utils.get_override_release_tracker_title(file_properties)
-        if to_include:
-            return to_include
-    
+        return to_include
+
     def _get_release_tracker_description(
             self,
             request_handler: RequestHandler,
@@ -1113,6 +1106,12 @@ class File(Item, CoreFile):
             file_utils.get_file_format(file_properties),
             item_utils.get_display_title,
         )
+        if "override_release_tracker_description" in file_properties:
+            to_include = [
+                file_utils.get_override_release_tracker_description(file_properties),
+                file_format_title
+            ]
+            return " ".join(to_include)
         if "file_sets" in file_properties:
             assay_title= get_unique_values(
                 request_handler.get_items(file_utils.get_assays(file_properties, request_handler)),
@@ -1132,11 +1131,6 @@ class File(Item, CoreFile):
             to_include = [
                 assay_title[0],
                 sequencer_title[0],
-                file_format_title
-            ]
-        if "override_release_tracker_description" in file_properties:
-            to_include = [
-                file_utils.get_override_release_tracker_description(file_properties),
                 file_format_title
             ]
         if to_include:

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -1089,7 +1089,7 @@ class File(Item, CoreFile):
             elif (tissue_title := request_handler.get_items(
                 file_utils.get_tissues(file_properties, request_handler)
             )):
-                to_include - None if len(tissue_title) > 1 else item_utils.get_display_title(tissue_title[0]) 
+                to_include = None if len(tissue_title) > 1 else item_utils.get_display_title(tissue_title[0])
         if "override_release_tracker_title" in file_properties:
             to_include = file_utils.get_override_release_tracker_title(file_properties)
         return to_include


### PR DESCRIPTION
- Fix the `release_tracker_title` and `release_tracker_description` calcprops  to have the override property function in the case of having multiple values from `file_sets`
- Make `file_sets` a required property for SupplementaryFile, as it is for all other SubmittedFile types, so that the File Overview display and Manifest File generation work properly