### PR TITLE
Fix Page Title Registry for /browse

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ smaht-portal
 Change Log
 ----------
 
+0.150.1
+=======
+`PR 386: Fix page title registry for /browse <https://github.com/smaht-dac/smaht-portal/pull/386>`_
+
+* Fix broken page title in Browse View
+
+
 0.150.0
 =======
 `PR 375: SN gpu upgrade <https://github.com/smaht-dac/smaht-portal/pull/375>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.150.0"
+version = "0.150.1"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/PageTitleSection.js
+++ b/src/encoded/static/components/PageTitleSection.js
@@ -36,8 +36,10 @@ export const pageTitleViews = new Registry();
 export const PageTitleSection = React.memo(function PageTitle(props) {
     const { context, currentAction, schemas, alerts, session, href } = props;
 
+    const lookupContext = toRegistryLookupContext(context);
+
     // See if any views register their own custom-er title view.
-    const FoundTitleView = pageTitleViews.lookup(context, currentAction);
+    const FoundTitleView = pageTitleViews.lookup(lookupContext, currentAction);
     if (typeof FoundTitleView !== 'undefined') {
         // `null` considered as conscious lack of title
         return <FoundTitleView {...props} />;
@@ -539,3 +541,18 @@ export class StaticPageBreadcrumbs extends React.Component {
         );
     }
 }
+
+/**
+ * Hack for associating the /browse/ searches with BrowseView.
+ * Otherwise it will use FileSearchView since Registry.lookup checks for first matching view 
+ */
+export const toRegistryLookupContext = memoize(function (context) {
+    const browseIdx = context?.['@type']?.indexOf('Browse') || -1;
+    if (browseIdx > -1) {
+        const cloned = context['@type'].slice();
+        cloned.splice(browseIdx, 1);
+        cloned.unshift('Browse');
+        return { '@type': cloned };
+    }
+    return context;
+});

--- a/src/encoded/static/components/app.js
+++ b/src/encoded/static/components/app.js
@@ -37,7 +37,7 @@ import { Schemas, SEO, typedefs, navigate } from './util';
 import { responsiveGridState, DeferMount } from './util/layout';
 import { requestAnimationFrame as raf } from '@hms-dbmi-bgm/shared-portal-components/es/components/viz/utilities';
 
-import { PageTitleSection } from './PageTitleSection';
+import { PageTitleSection, toRegistryLookupContext } from './PageTitleSection';
 
 // import './encoded/static/scss/style.css'; // @TODO: currently not resolving; need to fix
 // import './encoded/static/scss/print.css';
@@ -1669,16 +1669,7 @@ const ContentRenderer = React.memo(function ContentRenderer(props) {
         // error catching
         content = <ErrorPage currRoute={routeLeaf} status={status} />;
     } else if (context) {
-        // Hack for associating the /browse/ searches with BrowseView.
-        // Otherwise it will use FileSearchView since Registry.lookup checks for first matching view 
-        let lookupContext = context;
-        const browseIdx = context?.['@type']?.indexOf('Browse') || -1;
-        if (browseIdx > -1) {
-            const cloned = context['@type'].slice();
-            cloned.splice(browseIdx, 1);
-            cloned.unshift('Browse');
-            lookupContext = { '@type': cloned };
-        }
+        const lookupContext =  toRegistryLookupContext(context);
         // What should occur (success)
         const ContentView = (contentViews || globalContentViews).lookup(
             lookupContext,


### PR DESCRIPTION
/browse page titile looks broken and displays "Search for File" instead of "SMaHT Production Data". This bug occurred upon FileSearchView’s custom page title for released files [added](https://github.com/smaht-dac/smaht-portal/pull/381).