### PR TITLE
SN Update MWFR outputs calcprop

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ smaht-portal
 Change Log
 ----------
 
+0.155.0
+=======
+`PR 395: SN Update MWFR outputs calcprop <https://github.com/smaht-dac/smaht-portal/pull/395>`_
+
+* In the revlink calcprop `meta_workflow_run_outputs`, filter out MetaWorkflowRun items with `status` "deleted"
+
+
 0.154.0
 =======
 `PR 389: SN Update treatment <https://github.com/smaht-dac/smaht-portal/pull/389>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.154.0"
+version = "0.155.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -656,7 +656,16 @@ class File(Item, CoreFile):
     def meta_workflow_run_outputs(self, request: Request) -> Union[List[str], None]:
         result = self.rev_link_atids(request, "meta_workflow_run_outputs")
         if result:
-            return result
+            request_handler = RequestHandler(request = request)
+            mwfrs=[ 
+                mwfr for mwfr in result
+                if get_property_value_from_identifier(
+                    request_handler,
+                    mwfr,
+                    item_utils.get_status
+                ) != "deleted"
+            ]
+            return mwfrs if mwfrs else None
         return
 
     @calculated_property(schema=CalcPropConstants.LIBRARIES_SCHEMA)


### PR DESCRIPTION
- In the revlink calcprop `meta_workflow_run_outputs`, filter out MetaWorkflowRun items with `status` "deleted"