### PR TITLE
SN Fix validator error message

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Change Log
 =======
 `PR 415 SN Fix validator error message <https://github.com/smaht-dac/smaht-portal/pull/415>`
 
-* Fix the TissueSample custom validator for valid combination of `external_id` and `category` to print out the expected `category` value
+* Fix the TissueSample custom validator for valid combination of `external_id` and `category` to print out the expected `category` value in the error message 
 * Add `link_related_validator` decorator to the custom validator for fastq read pairs being linked to the same FileSet
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ smaht-portal
 Change Log
 ----------
 
+0.168.3
+=======
+`PR 415 SN Fix validator error message <https://github.com/smaht-dac/smaht-portal/pull/415>`
+
+* Fix the TissueSample custom validator for valid combination of `external_id` and `category` to print out the expected `category` value
+* Add `link_related_validator` decorator to the custom validator for fastq read pairs being linked to the same FileSet
+
+
 0.168.2
 =======
 `PR 410 fix: use retraction_reason in file view alert <https://github.com/smaht-dac/smaht-portal/pull/410>`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.168.2"
+version = "0.168.3"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/types/tissue_sample.py
+++ b/src/encoded/types/tissue_sample.py
@@ -76,15 +76,16 @@ def validate_external_id_on_add(context, request):
     submission_centers = data['submission_centers']
     is_tpc_submitted = "ndri_tpc" in [ item_utils.get_identifier(get_item_or_none(request, submission_center, 'submission-centers')) for submission_center in submission_centers ]
     if (study := tissue_utils.get_study(tissue)):
+        tissue_category_match =  assert_tissue_category_match(category, external_id)
         if is_tpc_submitted and not assert_external_id_category_match(external_id, category):
             msg = f"external_id {external_id} does not match {study} nomenclature for {category} samples."
+            return request.errors.add('body', 'TissueSample: invalid property', msg)
+        elif not tissue_category_match[0]:
+            msg = f"category {category} should be {tissue_category_match[1]} for TissueSample items with external_id {tissue_sample_utils.get_protocol_id_from_external_id(external_id)}."
             return request.errors.add('body', 'TissueSample: invalid property', msg)
         elif not assert_external_id_tissue_match(external_id, tissue):
             msg = f"external_id {external_id} does not match Tissue external_id {item_utils.get_external_id(tissue)}."
             return request.errors.add('body', 'TissueSample: invalid link', msg)
-        elif not assert_tissue_category_match(category, external_id):
-            msg = f"category {category} should be Liquid for TissueSample items with external_id {tissue_sample_utils.get_protocol_id_from_external_id(external_id)}."
-            return request.errors.add('body', 'TissueSample: invalid property', msg)
         else:
             return request.validated.update({}) 
 
@@ -108,15 +109,16 @@ def validate_external_id_on_edit(context, request):
     submission_centers = get_property_for_validation('submission_centers', existing_properties, properties_to_update)
     is_tpc_submitted = "ndri_tpc" in [ item_utils.get_identifier(get_item_or_none(request, submission_center, 'submission-centers')) for submission_center in submission_centers ]
     if (study:=tissue_utils.get_study(tissue)):
+        tissue_category_match =  assert_tissue_category_match(category, external_id)
         if is_tpc_submitted and not assert_external_id_category_match(external_id, category):
             msg = f"external_id {external_id} does not match {study} nomenclature for {category} samples."
+            return request.errors.add('body', 'TissueSample: invalid property', msg)
+        elif not tissue_category_match[0]:
+            msg = f"category {category} should be {tissue_category_match[1]} for TissueSample items with external_id {tissue_sample_utils.get_protocol_id_from_external_id(external_id)}."
             return request.errors.add('body', 'TissueSample: invalid property', msg)
         elif not assert_external_id_tissue_match(external_id, tissue):
             msg = f"external_id {external_id} does not match Tissue external_id {item_utils.get_external_id(tissue)}."
             return request.errors.add('body', 'TissueSample: invalid link', msg)
-        elif not assert_tissue_category_match(category, external_id):
-            msg = f"category {category} should be Liquid for TissueSample items with external_id {tissue_sample_utils.get_protocol_id_from_external_id(external_id)}."
-            return request.errors.add('body', 'TissueSample: invalid property', msg)
         else:
             return request.validated.update({})
 
@@ -141,12 +143,16 @@ def assert_tissue_category_match(category: str, external_id: str):
     """
     liquid_protocol_ids = ["3A", "3B"]
     cells_protocol_ids = ["3AC"]
+    match = True
+    correct_category = None
     protocol_id = tissue_sample_utils.get_protocol_id_from_external_id(external_id)
     if protocol_id in liquid_protocol_ids:
-        return category == "Liquid"
+        correct_category = "Liquid"
+        match = category == correct_category
     elif protocol_id in cells_protocol_ids:
-        return category == "Cells"
-    return True
+        correct_category = "Cells"
+        match = category == correct_category
+    return match, correct_category
 
 
 def assert_external_id_tissue_match(external_id: str, tissue: Dict[str, Any]):

--- a/src/encoded/types/tissue_sample.py
+++ b/src/encoded/types/tissue_sample.py
@@ -136,7 +136,7 @@ def assert_external_id_category_match(external_id: str, category: str):
 
 
 def assert_tissue_category_match(category: str, external_id: str):
-    """git s
+    """
     Check that category is Liquid or Cells if protocol id of external_id is among certain types.
     
     Current types are blood, buccal swab (both Liquid), and fibroblast cell culture (Cells).

--- a/src/encoded/types/tissue_sample.py
+++ b/src/encoded/types/tissue_sample.py
@@ -81,7 +81,7 @@ def validate_external_id_on_add(context, request):
             msg = f"external_id {external_id} does not match {study} nomenclature for {category} samples."
             return request.errors.add('body', 'TissueSample: invalid property', msg)
         elif not tissue_category_match[0]:
-            msg = f"category {category} should be {tissue_category_match[1]} for TissueSample items with external_id {tissue_sample_utils.get_protocol_id_from_external_id(external_id)}."
+            msg = f"category {category} should be {tissue_category_match[1]} for TissueSample items with protocol ID: {tissue_sample_utils.get_protocol_id_from_external_id(external_id)}."
             return request.errors.add('body', 'TissueSample: invalid property', msg)
         elif not assert_external_id_tissue_match(external_id, tissue):
             msg = f"external_id {external_id} does not match Tissue external_id {item_utils.get_external_id(tissue)}."
@@ -114,7 +114,7 @@ def validate_external_id_on_edit(context, request):
             msg = f"external_id {external_id} does not match {study} nomenclature for {category} samples."
             return request.errors.add('body', 'TissueSample: invalid property', msg)
         elif not tissue_category_match[0]:
-            msg = f"category {category} should be {tissue_category_match[1]} for TissueSample items with external_id {tissue_sample_utils.get_protocol_id_from_external_id(external_id)}."
+            msg = f"category {category} should be {tissue_category_match[1]} for TissueSample items with protocol ID: {tissue_sample_utils.get_protocol_id_from_external_id(external_id)}."
             return request.errors.add('body', 'TissueSample: invalid property', msg)
         elif not assert_external_id_tissue_match(external_id, tissue):
             msg = f"external_id {external_id} does not match Tissue external_id {item_utils.get_external_id(tissue)}."
@@ -136,7 +136,7 @@ def assert_external_id_category_match(external_id: str, category: str):
 
 
 def assert_tissue_category_match(category: str, external_id: str):
-    """
+    """git s
     Check that category is Liquid or Cells if protocol id of external_id is among certain types.
     
     Current types are blood, buccal swab (both Liquid), and fibroblast cell culture (Cells).

--- a/src/encoded/types/unaligned_reads.py
+++ b/src/encoded/types/unaligned_reads.py
@@ -95,6 +95,7 @@ def check_read_pairs_paired_with(request, submitted_id: str, paired_with: Union[
         return request.validated.update({})
 
 
+@link_related_validator
 def validate_read_pairs_in_file_sets_on_add(context, request):
     """Check that the R1 and R2 files are linked to the same FileSet on add."""
     data = request.json
@@ -103,6 +104,7 @@ def validate_read_pairs_in_file_sets_on_add(context, request):
     return check_read_pairs_in_file_sets(request, data['submitted_id'], paired_with, file_sets)
 
 
+@link_related_validator
 def validate_read_pairs_in_file_sets_on_edit(context, request):
     """Check that the R1 and R2 files are linked to the same FileSet on edit."""
     existing_properties = get_properties(context)


### PR DESCRIPTION
- Fix the TissueSample custom validator for valid combination of `external_id` and `category` to print out the expected `category` value in the error message
- Add `link_related_validator` decorator to the custom validator for fastq read pairs being linked to the same FileSet