### PR TITLE
SN Reference genome preferred_name

### DIFF
--- a/src/encoded/item_utils/item.py
+++ b/src/encoded/item_utils/item.py
@@ -101,3 +101,8 @@ def get_version(properties: Dict[str, Any]) -> str:
 def is_released(properties: Dict[str, Any]) -> bool:
     """Check if item is released."""
     return get_status(properties) == item_constants.STATUS_RELEASED
+
+
+def get_preferred_name(properties: Dict[str, Any]) -> str:
+    """Get preferred name from properties."""
+    return properties.get("preferred_name", "")

--- a/src/encoded/schemas/mixins.json
+++ b/src/encoded/schemas/mixins.json
@@ -740,6 +740,13 @@
             }
         }
     },
+    "preferred_name": {
+        "preferred_name": {
+            "title": "Display name",
+            "description": "A preferred name (possibly shortened or simpler version) for the item - can be used for submission or retrieval.",
+            "type": "string"
+        }
+    },
     "preservation_medium": {
         "preservation_medium": {
             "title": "Preservation Medium",

--- a/src/encoded/schemas/ontology_term.json
+++ b/src/encoded/schemas/ontology_term.json
@@ -43,6 +43,9 @@
             "$ref": "mixins.json#/modified"
         },
         {
+            "$ref": "mixins.json#/preferred_name"
+        },
+        {
             "$ref": "mixins.json#/schema_version"
         },
         {
@@ -94,11 +97,6 @@
                 "type": "string",
                 "linkTo": "Ontology"
             }
-        },
-        "preferred_name": {
-          "title": "Display name",
-          "description": "A preferred name (possibly shortened or simpler version) for the ontology term - can be used for submission or retrieval.",
-          "type": "string"
         },
         "url": {
             "description": "The url that uniquely identifies term - often purl."

--- a/src/encoded/schemas/reference_genome.json
+++ b/src/encoded/schemas/reference_genome.json
@@ -46,6 +46,9 @@
             "$ref": "mixins.json#/modified"
         },
         {
+            "$ref": "mixins.json#/preferred_name"
+        },
+        {
             "$ref": "mixins.json#/schema_version"
         },
         {

--- a/src/encoded/tests/data/workbook-inserts/reference_genome.json
+++ b/src/encoded/tests/data/workbook-inserts/reference_genome.json
@@ -2,9 +2,10 @@
     {
         "identifier": "GRCh38",
         "title": "GRCh38",
-	"code": "GRCh38",
+	    "code": "GRCh38",
         "consortia": [
             "smaht"
-        ]
+        ],
+        "preferred_name": "GRCh38 [Official]"
     }
 ]

--- a/src/encoded/types/reference_genome.py
+++ b/src/encoded/types/reference_genome.py
@@ -1,4 +1,11 @@
-from snovault import collection, load_schema
+from typing import Optional, Union
+from snovault import(
+    collection,
+    load_schema,
+    calculated_property,
+    display_title_schema,
+)
+from pyramid.request import Request
 
 from .base import Item
 
@@ -19,3 +26,20 @@ class ReferenceGenome(Item):
     item_type = "reference_genome"
     schema = load_schema("encoded:schemas/reference_genome.json")
     embedded_list = _build_reference_genome_embedded_list()
+
+    @calculated_property(schema=display_title_schema)
+    def display_title(
+        self,
+        request: Request,
+        preferred_name: Optional[str] = None,
+        title: Optional[str] = None,
+        name: Optional[str] = None,
+        external_id: Optional[str] = None,
+        identifier: Optional[str] = None,
+        submitted_id: Optional[str] = None,
+        accession: Optional[str] = None,
+        uuid: Optional[str] = None,
+    ) -> Union[str, None]:
+        if preferred_name:
+            return preferred_name
+        return Item.display_title(self, request, title, name, external_id, identifier, submitted_id, accession, uuid)


### PR DESCRIPTION
- Add `preferred_name` property to ReferenceGenome to override `title` in the `display_title` if present
- Justification is we want to change the `display_title` of the official GRCh38 reference genome item in the File Browse page to "GRCh38 [Official]" without interfering with bioinformatics' current use of the `title` "GRCh38 [GCA_000001405.15]" and `alias` smaht:ReferenceGenome-GRCh38_GCA_000001405.15