### PR TITLE
SN file merge group tag

### DIFF
--- a/src/encoded/item_utils/file_set.py
+++ b/src/encoded/item_utils/file_set.py
@@ -104,3 +104,8 @@ def get_tissues(
         for sample_source in sample_sources
         if isinstance(sample_source, dict) and tissue_utils.is_tissue(sample_source)
     ]
+
+
+def get_group_tag(properties: Dict[str, Any]) -> str:
+    """Get group tag connected to file set."""
+    return properties.get("group_tag", "")

--- a/src/encoded/metadata.py
+++ b/src/encoded/metadata.py
@@ -220,7 +220,10 @@ def handle_file_group(field: dict) -> str:
         sample_source_part = field['sample_source']
         sequencing_part = field['sequencing']
         assay_part = field['assay']
-        return f'{sc_part}-{sample_source_part}-{sequencing_part}-{assay_part}'
+        group_str = f'{sc_part}-{sample_source_part}-{sequencing_part}-{assay_part}'
+        if (group_tag := field['group_tag']):
+            group_str = group_str+f"-{group_tag}"
+        return group_str
     return ''
 
 

--- a/src/encoded/schemas/file_set.json
+++ b/src/encoded/schemas/file_set.json
@@ -65,6 +65,16 @@
             "description": "Additional comments on file set",
             "permission": "restricted_fields"
         },
+        "group_tag": {
+            "title": "Group Tag",
+            "description": "For use in file_group calculated property to make a file set part of a separate merge group",
+            "type": "string",
+            "suggested_enum": [
+                "group1",
+                "group2"
+            ],
+            "permission": "restricted_fields"
+        },
         "submitter_comments": {
             "title": "Submitter Comments",
             "description": "Submitter comments on data quality related to the file set",

--- a/src/encoded/tests/data/workbook-inserts/file_set.json
+++ b/src/encoded/tests/data/workbook-inserts/file_set.json
@@ -14,6 +14,21 @@
         ]
     },
     {
+        "uuid": "799ca2e9-f24a-4517-bb35-88945ed41047",
+        "submission_centers": [
+            "smaht"
+        ],
+        "submitted_id": "TEST_FILE-SET_LIVER-DNA_2",
+        "libraries": [
+            "TEST_LIBRARY_LIVER-DNA"
+        ],
+        "sequencing": "TEST_SEQUENCING_NOVASEQ-500X-DNA",
+        "samples": [
+            "TEST_CELL-SAMPLE_LIVER-CELL"
+        ],
+        "group_tag": "group1"
+    },
+    {
         "uuid": "6b6531f3-7512-4ed4-8d88-b0807579f883",
         "submission_centers": [
             "smaht"

--- a/src/encoded/tests/test_types_file_set.py
+++ b/src/encoded/tests/test_types_file_set.py
@@ -24,13 +24,26 @@ def test_files_rev_link(es_testapp: TestApp, workbook: None) -> None:
 
 
 @pytest.mark.workbook
-def test_file_set_group(es_testapp: TestApp, workbook: None) -> None:
+@pytest.mark.parametrize(
+    "file_set,group_tag", [
+        ('/file-sets/b98f9849-3b7f-4f2f-a58f-81100954e00d/', ''),
+        ('/file-sets/799ca2e9-f24a-4517-bb35-88945ed41047/', 'group1')
+    ]
+)
+def test_file_set_group(
+    es_testapp: TestApp,
+    workbook: None,
+    file_set: str,
+    group_tag: str
+) -> None:
     """ Ensure we generate a reasonable looking group when file set data is present """
-    res = es_testapp.get('/file-sets/b98f9849-3b7f-4f2f-a58f-81100954e00d/').json
+    res = es_testapp.get(file_set).json
     file_merge_group = res['file_group']
+    import pdb; pdb.set_trace()
     assert file_merge_group['sample_source'] == 'TEST_TISSUE-SAMPLE_LIVER'
     assert file_merge_group['sequencing'] == 'illumina_novaseqx-Paired-end-150-R9'
     assert file_merge_group['assay'] == 'bulk_wgs'
+    assert file_merge_group['group_tag'] == group_tag
 
 
 @pytest.mark.workbook

--- a/src/encoded/tests/test_types_file_set.py
+++ b/src/encoded/tests/test_types_file_set.py
@@ -39,7 +39,6 @@ def test_file_set_group(
     """ Ensure we generate a reasonable looking group when file set data is present """
     res = es_testapp.get(file_set).json
     file_merge_group = res['file_group']
-    import pdb; pdb.set_trace()
     assert file_merge_group['sample_source'] == 'TEST_TISSUE-SAMPLE_LIVER'
     assert file_merge_group['sequencing'] == 'illumina_novaseqx-Paired-end-150-R9'
     assert file_merge_group['assay'] == 'bulk_wgs'

--- a/src/encoded/types/file_set.py
+++ b/src/encoded/types/file_set.py
@@ -233,6 +233,10 @@ class FileSet(SubmittedItem):
                 "assay": {
                     "title": "Assay Tag",
                     "type": "string"
+                },
+                "flag": {
+                    "title": "Group Tag",
+                    "type": "string"
                 }
             }
         }
@@ -252,6 +256,8 @@ class FileSet(SubmittedItem):
                 * Various information on the sequencer: name, read type, target read length
                   and flow cell
                 * Assay identifier
+                * An optional flag to differentiate the group from ones that would otherwise be in the
+                same merge group, but should be kept separate for QC or other reasons
         """
         # NOTE: we assume the first library is representative if there are multiple
         # We also assume this will always be present, and if not we do not produce this property
@@ -285,12 +291,14 @@ class FileSet(SubmittedItem):
             item_utils.get_submission_centers(self.properties)[0],
             item_utils.get_identifier,
         )
+        group_tag_part = file_set_utils.get_group_tag(self.properties)
 
         return {
             'submission_center': sc_part,
             'sample_source': sample_source_part,
             'sequencing': sequencing_part,
-            'assay': assay_part
+            'assay': assay_part,
+            'group_tag': group_tag_part
         }
 
     @calculated_property(


### PR DESCRIPTION
- Add an optional part to the `file_group` calcprop in FileSet that is set by the property `group_tag`. If present, it is added to the `file_group` so that the FileSet is put in a different File Merge Group than other file sets.
- Purpose is to separate out problematic or otherwise different file sets so that they are not merged with others