### PR TITLE
SN Update category

### DIFF
--- a/src/encoded/tests/data/workbook-inserts/ontology_term.json
+++ b/src/encoded/tests/data/workbook-inserts/ontology_term.json
@@ -143,5 +143,29 @@
         "tags": [
             "germ_layer"
         ]
+    },
+    {
+        "uuid": "598eefe7-6ea0-4f39-8a7a-dd986b2030a7",
+        "identifier": "UBERON:0000473",
+        "ontologies": ["UBERON"],
+        "title": "testis",
+        "preferred_name": "Testis",
+        "consortia": [
+            "smaht"
+        ],
+        "tags": [
+            "tissue_type"
+        ]
+    },
+    {
+        "uuid": "2070c3e5-a8be-4d20-85cd-85acaa8bd31c",
+        "identifier": "UBERON:0004533",
+        "ontologies": ["UBERON"],
+        "title": "left testis",
+        "preferred_name": "Left Testis",
+        "grouping_term": "UBERON:0000473",
+        "consortia": [
+            "smaht"
+        ]
     }
 ]

--- a/src/encoded/tests/data/workbook-inserts/tissue.json
+++ b/src/encoded/tests/data/workbook-inserts/tissue.json
@@ -80,5 +80,16 @@
         "donor": "TEST_DONOR_MALE",
         "uberon_id": "UBERON:0004264",
         "anatomical_location": "Fibroblast"
+    },
+    {
+        "uuid": "bc43628d-d879-4dc7-ae6b-10b96e43d5ba",
+        "submission_centers": [
+            "smaht"
+        ],
+        "submitted_id": "TEST_TISSUE_LEFT-TESTIS",
+        "external_id": "ST001-3V",
+        "donor": "TEST_DONOR_MALE",
+        "uberon_id": "UBERON:0004533",
+        "anatomical_location": "left testis"
     }
 ]

--- a/src/encoded/tests/test_types_tissue.py
+++ b/src/encoded/tests/test_types_tissue.py
@@ -84,7 +84,8 @@ def test_validate_external_id_on_add(
         ("TEST_TISSUE_LUNG", "Endoderm"),
         ("TEST_TISSUE_BLOOD", "Clinically Accessible"),
         ("TEST_TISSUE_BRAIN", "Ectoderm"),
-        ("TEST_TISSUE_FIBROBLAST", "Mesoderm")
+        ("TEST_TISSUE_FIBROBLAST", "Mesoderm"),
+        ("TEST_TISSUE_LEFT-TESTIS", "Germ Cells")
     ]
 )
 def test_category_calc_prop(

--- a/src/encoded/types/tissue.py
+++ b/src/encoded/types/tissue.py
@@ -70,10 +70,9 @@ class Tissue(SampleSource):
         Special case for Fibroblasts (3AC) as they are mostly Mesoderm but OntologyTerm links to Ectoderm for Skin.
         """
         request_handler = RequestHandler(request = request)
-        tissue_type = tissue_utils.get_grouping_term_from_tag(self.properties, request_handler=request_handler, tag="tissue_type")
-        if tissue_type in ["Testis", "Ovary"]:
+        if tissue_utils.get_protocol_id(self.properties) in ["3U", "3V","3W", "3X"]:
             return "Germ Cells"
-        elif tissue_type in ["Blood", "Buccal Swab"]:
+        elif tissue_utils.get_protocol_id(self.properties) in ["3A","3B"]:
             return "Clinically Accessible"
         elif tissue_utils.get_protocol_id(self.properties) == "3AC":
             return "Mesoderm"


### PR DESCRIPTION
- Update `category` calcProp in Tissue to use protocol_id rather than tissue name from OntologyTerm to separate clinically accessible and germ cell types