### PR TITLE
SN File QC notes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,14 +7,23 @@ smaht-portal
 Change Log
 ----------
 
+0.188.0
+`PR 468: SN File QC notes <https://github.com/smaht-dac/smaht-portal/pull/468>`_
+
+* Add `qc_notes` calc prop to QualityMetrics which uses `flag` to identify key metrics and build a concatenated string of Warn/Fail QC metrics
+* Embed `quality_metrics.qc_notes` on File
+* Add `quality_metrics.qc_notes` as column in File Manifest
+
+
 0.187.0
+=======
 `PR 463: SN File average coverage <https://github.com/smaht-dac/smaht-portal/pull/463>`_
 
 * Add `average_coverage` to the `data_generation_summary` calc prop on File, grabbed from `quality_metrics.coverage`
 * Add property `override_average_coverage` to File, which can override the `average_coverage` value if present
  
  
-=======
+
 0.186.2
 =======
 `PR 464 SN Add pluralize relatives <https://github.com/smaht-dac/smaht-portal/pull/464>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.187.0"
+version = "0.188.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/metadata.py
+++ b/src/encoded/metadata.py
@@ -25,6 +25,7 @@ def includeme(config):
     config.scan(__name__)
 
 
+TSV_WIDTH = 27 # There are 27 columns in the file manifest
 # Encode manifest file types
 FILE = 0
 CLINICAL = 1
@@ -523,8 +524,11 @@ def generate_other_manifest_header(manifest_enum):
 
 
 def generate_file_download_header(download_file_name: str, cli=False):
-    """ Helper function that generates a suitable header for the File download, generating 27 columns"""
-    header1 = ['###', 'Metadata TSV Download', 'Column Count', '27'] + ([''] * 23)  # length 27
+    """ Helper function that generates a suitable header for the File download.
+    
+        Number of columns generated set in TSV_WIDTH
+    """
+    header1 = ['###', 'Metadata TSV Download', 'Column Count', TSV_WIDTH] + ([''] * (TSV_WIDTH-4))  # length 27
     if cli:
         header2 = ['Suggested command to download: ', '', '',
                    (f'cut -f 1,3 ./{download_file_name} | tail -n +4 | grep -v ^# | '
@@ -535,12 +539,12 @@ def generate_file_download_header(download_file_name: str, cli=False):
                     f'&& export AWS_SECRET_ACCESS_KEY=$(echo $credentials | jq -r ".SecretAccessKey") '
                     f'&& export AWS_SESSION_TOKEN=$(echo $credentials | jq -r ".SessionToken") '
                     f'&& download_url=$(echo $credentials | jq -r ".download_url") '
-                    f'&& aws s3 cp "$download_url" "$1"')] + ([''] * 23)
+                    f'&& aws s3 cp "$download_url" "$1"')] + ([''] * (TSV_WIDTH-4))
     else:
         header2 = ['Suggested command to download: ', '', '',
                    "cut -f 1,3 ./{} | tail -n +4 | grep -v ^# | xargs -n 2 -L 1 sh -c 'curl -L "
                    "--user <access_key_id>:<access_key_secret> $0 --output $1'".format(download_file_name)] + (
-                              [''] * 23)
+                              [''] * (TSV_WIDTH-4))
     header3 = list(TSV_MAPPING[FILE].keys())
     return header1, header2, header3
 

--- a/src/encoded/metadata.py
+++ b/src/encoded/metadata.py
@@ -112,7 +112,7 @@ TSV_MAPPING = {
         'FileAccession': TSVDescriptor(field_type=FILE,
                                        field_name=['accession']),
         'FileName': TSVDescriptor(field_type=FILE,
-                                  field_name=['annotated_filename', 'filename', 'display_title']),
+                                  field_name=['annotated_filename', 'filename', 'display_title']), # NOTE: This row should not be changed. Needed for file download
         'FileSetAccession': TSVDescriptor(field_type=FILE,
                                           field_name=['file_sets.accession']),
         'AnalyteAccessions': TSVDescriptor(field_type=FILE,
@@ -171,6 +171,9 @@ TSV_MAPPING = {
                                        use_base_metadata=True),
         'QCComments': TSVDescriptor(field_type=FILE,
                                        field_name=['qc_comments'],
+                                       use_base_metadata=True),
+        'QCNotes': TSVDescriptor(field_type=FILE,
+                                       field_name=['quality_metrics.qc_notes'],
                                        use_base_metadata=True),
         FILE_GROUP: TSVDescriptor(field_type=FILE,
                                   field_name=['file_sets.file_group'],
@@ -520,8 +523,8 @@ def generate_other_manifest_header(manifest_enum):
 
 
 def generate_file_download_header(download_file_name: str, cli=False):
-    """ Helper function that generates a suitable header for the File download, generating 26 columns"""
-    header1 = ['###', 'Metadata TSV Download', 'Column Count', '26'] + ([''] * 22)  # length 26
+    """ Helper function that generates a suitable header for the File download, generating 27 columns"""
+    header1 = ['###', 'Metadata TSV Download', 'Column Count', '27'] + ([''] * 23)  # length 27
     if cli:
         header2 = ['Suggested command to download: ', '', '',
                    (f'cut -f 1,3 ./{download_file_name} | tail -n +4 | grep -v ^# | '
@@ -532,12 +535,12 @@ def generate_file_download_header(download_file_name: str, cli=False):
                     f'&& export AWS_SECRET_ACCESS_KEY=$(echo $credentials | jq -r ".SecretAccessKey") '
                     f'&& export AWS_SESSION_TOKEN=$(echo $credentials | jq -r ".SessionToken") '
                     f'&& download_url=$(echo $credentials | jq -r ".download_url") '
-                    f'&& aws s3 cp "$download_url" "$1"')] + ([''] * 22)
+                    f'&& aws s3 cp "$download_url" "$1"')] + ([''] * 23)
     else:
         header2 = ['Suggested command to download: ', '', '',
                    "cut -f 1,3 ./{} | tail -n +4 | grep -v ^# | xargs -n 2 -L 1 sh -c 'curl -L "
                    "--user <access_key_id>:<access_key_secret> $0 --output $1'".format(download_file_name)] + (
-                              [''] * 22)
+                              [''] * 23)
     header3 = list(TSV_MAPPING[FILE].keys())
     return header1, header2, header3
 

--- a/src/encoded/tests/data/workbook-inserts/output_file.json
+++ b/src/encoded/tests/data/workbook-inserts/output_file.json
@@ -34,6 +34,9 @@
         ],
         "file_size": 5000,
         "md5sum": "211e09ebf240c7256747d10e24cb99fd",
+        "quality_metrics": [
+            "a034802c-0bcf-4df9-97dd-dbab5c62a375"
+        ],
         "override_average_coverage": 80
     },
     {

--- a/src/encoded/tests/data/workbook-inserts/quality_metric.json
+++ b/src/encoded/tests/data/workbook-inserts/quality_metric.json
@@ -43,5 +43,44 @@
                 "derived_from": "mosdepth:total"
             }
         ]
+    },
+    {
+        "uuid": "a034802c-0bcf-4df9-97dd-dbab5c62a375",
+        "submission_centers": [
+            "smaht"
+        ],
+        "category": [
+            "Testing"
+        ],
+        "overall_quality_status": "Warn",
+        "qc_values": [
+            {
+                "key": "foo",
+                "value": "bar",
+                "flag": "Warn",
+                "tooltip": "Description of how foo was derived"
+            },
+            {
+                "key": "bar",
+                "value": 25
+            },
+            {
+                "key": "fu",
+                "value": 252.4
+            },
+            {
+                "key": "bur",
+                "value": false
+            },
+            {
+                "key": "baz",
+                "value": [
+                    "foo",
+                    5,
+                    true,
+                    -3.5
+                ]
+            }
+        ]
     }
 ]

--- a/src/encoded/tests/test_metadata_tsv_workbook.py
+++ b/src/encoded/tests/test_metadata_tsv_workbook.py
@@ -6,7 +6,7 @@ from ..metadata import descend_field
 
 class TestMetadataTSVHelper:
 
-    TSV_WIDTH = 26
+    TSV_WIDTH = 27
 
     @staticmethod
     def read_tsv_from_bytestream(bytestream):
@@ -142,7 +142,7 @@ class TestMetadataTSVWorkbook:
         # check an entire row that is mostly representative
         for row in parsed:
             if '303985cf-f1db-4dea-9782-2e68092d603d' in row[0]:  # this is the row
-                assert row[2] == 'SMHT-FOO-BAR-M45-B003-DAC_SMAURF3ETDQJ_bwamem0.1.2_GRCh38.aligned.sorted.bam'
+                assert row[2] == 'SMHT-FOO-BAR-M45-B003-DAC_SMAURF3ETDQJ_bwamem0.1.2_GRCh38.aligned.sorted.bam' # NOTE: This row should not be changed. Needed for file download
                 assert row[9] == '1000'  # size
                 assert row[11] == 'Aligned Reads'  # category
                 assert row[12] == 'BAM'  # format
@@ -156,7 +156,7 @@ class TestMetadataTSVWorkbook:
                 assert row[20] == 'Bulk WGS'  # assay
                 assert row[21] == 'VEP (3.1.1)'  # software
                 assert row[22] == 'GRCh38'  # reference genome
-                assert row[25] == 'smaht-TEST_TISSUE_LIVER-illumina_novaseqx-Paired-end-150-R9-bulk_wgs'  # merge grp
+                assert row[26] == 'smaht-TEST_TISSUE_LIVER-illumina_novaseqx-Paired-end-150-R9-bulk_wgs'  # merge grp
                 break
 
         # check download links are now download_cli

--- a/src/encoded/tests/test_metadata_tsv_workbook.py
+++ b/src/encoded/tests/test_metadata_tsv_workbook.py
@@ -1,12 +1,11 @@
 import pytest
 import io
 import csv
-from ..metadata import descend_field
+from ..metadata import descend_field, TSV_WIDTH
 
 
 class TestMetadataTSVHelper:
 
-    TSV_WIDTH = 27
 
     @staticmethod
     def read_tsv_from_bytestream(bytestream):
@@ -21,7 +20,7 @@ class TestMetadataTSVHelper:
     @classmethod
     def check_key_and_length(cls, part, expected_key):
         assert expected_key in part
-        assert len(part) == cls.TSV_WIDTH
+        assert len(part) == TSV_WIDTH
 
     @classmethod
     def check_type_length(cls, es_testapp, item_type, expected_count):
@@ -114,7 +113,7 @@ class TestMetadataTSVWorkbook:
         parsed = TestMetadataTSVHelper.read_tsv_from_bytestream(tsv)
         header1, header2, header3 = parsed[0], parsed[1], parsed[2]
         for row in parsed:  # check all rows got populated
-            assert len(row) == TestMetadataTSVHelper.TSV_WIDTH
+            assert len(row) == TSV_WIDTH
         TestMetadataTSVHelper.check_key_and_length(header1, 'Metadata TSV Download')
         TestMetadataTSVHelper.check_key_and_length(header2, 'Suggested command to download: ')
         TestMetadataTSVHelper.check_key_and_length(header3, 'FileDownloadURL')

--- a/src/encoded/tests/test_types_quality_metric.py
+++ b/src/encoded/tests/test_types_quality_metric.py
@@ -42,4 +42,16 @@ def test_coverage_calc_prop(es_testapp: TestApp, workbook: None) -> None:
         frame="object"
     )
     assert qm.get("coverage","") == 26.32
+
+
+@pytest.mark.workbook
+def test_qc_notes_calc_prop(es_testapp: TestApp, workbook: None) -> None:
+    """Ensure the coverage calc prop works."""
+    qm=get_item(
+        es_testapp,
+        "a034802c-0bcf-4df9-97dd-dbab5c62a375",
+        collection='QualityMetric',
+        frame="object"
+    )
+    assert qm.get("qc_notes","") == "Warn: foo has value bar"
     

--- a/src/encoded/types/file.py
+++ b/src/encoded/types/file.py
@@ -405,6 +405,7 @@ def _build_file_embedded_list() -> List[str]:
 
         "quality_metrics.overall_quality_status",
         "quality_metrics.coverage",
+        "quality_metrics.qc_notes",
         # For manifest
         "file_sets.accession",
         "file_sets.libraries.analytes.accession",

--- a/src/encoded/types/quality_metric.py
+++ b/src/encoded/types/quality_metric.py
@@ -7,6 +7,7 @@ from .acl import ONLY_ADMIN_VIEW_ACL
 from .base import Item
 
 COVERAGE_DERIVED_FROM = "mosdepth:total"
+FLAG_STATES = ["Warn", "Fail"]
 
 @collection(
     name='quality-metrics',
@@ -41,6 +42,22 @@ class QualityMetric(Item):
         for qc in qc_values:
             if qc.get("derived_from","") == COVERAGE_DERIVED_FROM:
                 return qc["value"]
+            
+    
+    @calculated_property(
+        schema={
+            "title": "QC Notes",
+            "type": "string",
+            "description": "Notes on key metrics that did not pass QC",
+        }
+    )
+    def qc_notes(self, request, qc_values: List[Dict[str, Any]]) -> str:
+        notes = []
+        for qc in qc_values:
+            if qc.get("flag","") in FLAG_STATES:
+                notes.append(f"{qc['flag']}: {qc['key']} has value {qc['value']}")
+        if notes:
+            return (";").join(notes)
 
 
 @view_config(name='download', context=QualityMetric, request_method='GET',


### PR DESCRIPTION
- Add `qc_notes` calc prop to QualityMetrics which uses `flag` to identify key metrics and build a concatenated string of Warn/Fail QC metrics
- Embed `quality_metrics.qc_notes` on File
- Add `quality_metrics.qc_notes` as column in File Manifest