### PR TITLE
Add RIN and tissue types to Submission Status

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ smaht-portal
 Change Log
 ----------
 
+0.189.1
+=======
+`PR 476: Add RIN and tissue types to Submission Status <https://github.com/smaht-dac/smaht-portal/pull/476>`_
+
+* Add RIN values of the analyte and tissue types of a fileset to the Submission Status page
+* Exclude Single-Cell PTA data from generating warnings in the sample identity check on the QC metrics page
+
+
 0.189.0
 =======
 `PR 473: SN Add additional notes to exp manifest file <https://github.com/smaht-dac/smaht-portal/pull/473>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.189.0"
+version = "0.189.1"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/static-pages/components/internal/SubmissionStatus.js
+++ b/src/encoded/static/components/static-pages/components/internal/SubmissionStatus.js
@@ -405,6 +405,9 @@ class SubmissionStatusComponent extends React.PureComponent {
     getSubmissionTableBody = () => {
         const tbody = this.state.fileSets.map((fs) => {
             const sequencer = fs.sequencing?.sequencer;
+            const tissueTypes = fs.tissue_types && fs.tissue_types.length
+                ? '(' + fs.tissue_types.join(', ') + ')'
+                : null;
             const targetCoverage = getTargetCoverage(fs.sequencing);
             const status_badge_type =
                 fs.status == 'released' ? 'success' : 'warning';
@@ -424,19 +427,30 @@ class SubmissionStatusComponent extends React.PureComponent {
                         Library: {getLink(lib.uuid, lib.display_title)}
                     </li>
                 );
+                const rin_number = [];
                 lib.analytes?.forEach((analyte) => {
+                    if (analyte.rna_integrity_number) {
+                        rin_number.push(analyte.rna_integrity_number);
+                    }
                     analyte.samples?.forEach((sample) => {
+                        
                         fs_details.push(
                             <li className="ss-line-height-140">
                                 Sample:{' '}
-                                {getLink(sample.uuid, sample.display_title)}
+                                {getLink(sample.uuid, sample.display_title)} {tissueTypes}
                             </li>
                         );
                     });
                 });
+                
+                const rin_details =
+                    rin_number.length > 0
+                        ? `– RIN: ${rin_number.join(', ')}`
+                        : '';
+
                 fs_details.push(
                     <li className="ss-line-height-140">
-                        Assay: {lib.assay?.display_title}
+                        Assay: {lib.assay?.display_title} {rin_details}
                     </li>
                 );
             });

--- a/src/encoded/submission_status.py
+++ b/src/encoded/submission_status.py
@@ -233,6 +233,8 @@ def get_submission_status(context, request):
             if "file_group" in file_set:
                 fg = file_set["file_group"]
                 fg_str = f"{fg['submission_center']}_{fg['sample_source']}_{fg['sequencing']}_{fg['assay']}"
+                if 'group_tag' in fg and fg['group_tag']:
+                    fg_str += f"_{fg['group_tag']}"
                 file_set["file_group_str"] = fg_str
                 file_set["file_group"] = fg
                 # Place holder that will be replaced in the next step

--- a/src/encoded/types/file_set.py
+++ b/src/encoded/types/file_set.py
@@ -53,6 +53,7 @@ def _build_file_set_embedded_list():
         "libraries.analytes.accession",
         "libraries.analytes.samples.accession",
         "libraries.analytes.samples.sample_sources.donor.accession",
+        "libraries.analytes.rna_integrity_number",
         "libraries.a260_a280_ratio",
         "libraries.adapter_name",
         "libraries.adapter_sequence",


### PR DESCRIPTION
This PR
- Adds RIN values of the analyte and tissue types of a fileset to the Submission Status page
- Excludes Single-Cell PTA data from generating warnings in the sample identity check on the QC metrics page