### PR TITLE
Restricted + Public Restricted

### DIFF
--- a/deploy/docker/production/install_nginx_bullseye.sh
+++ b/deploy/docker/production/install_nginx_bullseye.sh
@@ -32,11 +32,11 @@ set -x \
     " \
     && case "$dpkgArch" in \
         amd64|arm64) \
-            echo "deb https://nginx.org/packages/mainline/debian/ bullseye nginx" >> /etc/apt/sources.list.d/nginx.list \
+            echo "deb [ trusted=yes ]  https://nginx.org/packages/mainline/debian/ bullseye nginx" >> /etc/apt/sources.list.d/nginx.list \
             && apt-get update \
             ;; \
         *) \
-            echo "deb-src https://nginx.org/packages/mainline/debian/ bullseye nginx" >> /etc/apt/sources.list.d/nginx.list \
+            echo "deb-src [ trusted=yes ]  https://nginx.org/packages/mainline/debian/ bullseye nginx" >> /etc/apt/sources.list.d/nginx.list \
             \
             && tempDir="$(mktemp -d)" \
             && chmod 777 "$tempDir" \

--- a/src/encoded/schemas/file.json
+++ b/src/encoded/schemas/file.json
@@ -82,7 +82,8 @@
                 "archived",
                 "deleted",
                 "public",
-                "restricted"
+                "restricted",
+                "public-restricted"
             ]
         },
         "external_quality_metrics": {

--- a/src/encoded/schemas/mixins.json
+++ b/src/encoded/schemas/mixins.json
@@ -898,7 +898,8 @@
                 "in review",
                 "obsolete",
                 "deleted",
-                "restricted"
+                "restricted",
+                "public-restricted"
             ]
         }
     },

--- a/src/encoded/schemas/protected_donor.json
+++ b/src/encoded/schemas/protected_donor.json
@@ -71,7 +71,8 @@
                 "in review",
                 "obsolete",
                 "deleted",
-                "restricted"
+                "restricted",
+                "public-restricted"
             ]
         }
     },

--- a/src/encoded/schemas/user.json
+++ b/src/encoded/schemas/user.json
@@ -52,7 +52,8 @@
                 "enum": [
                     "admin",
                     "read-only-admin",
-                    "dbgap"
+                    "dbgap",
+                    "public-dbgap"
                 ]
             }
         },

--- a/src/encoded/tests/datafixtures.py
+++ b/src/encoded/tests/datafixtures.py
@@ -163,6 +163,19 @@ def smaht_admin(testapp):
 
 
 @pytest.fixture
+def smaht_dbgap_user(testapp):
+    item = {
+        'first_name': 'Test',
+        'last_name': 'DBGAP',
+        'email': 'smaht_dbgap@example.org',
+        'groups': ['dbgap'],
+        'status': 'current'
+    }
+    # User @@object view has keys omitted.
+    return post_item_and_return_location(testapp, item, 'user')
+
+
+@pytest.fixture
 def blank_user(testapp):
     item = {
         'first_name': 'Unaffiliated',
@@ -300,6 +313,12 @@ def smaht_protected_gcc_user(testapp, test_submission_center, test_consortium, t
 def smaht_admin_app(testapp, smaht_admin):
     """ App associated with a consortia member who is a submitter """
     return remote_user_testapp(testapp.app, smaht_admin['uuid'])
+
+
+@pytest.fixture
+def smaht_dbgap_app(testapp, smaht_dbgap_user):
+    """ App associated with a consortia member who is a submitter """
+    return remote_user_testapp(testapp.app, smaht_dbgap_user['uuid'])
 
 
 @pytest.fixture
@@ -482,7 +501,7 @@ def test_tissue(
         "uberon_id": test_ontology_term["uuid"]
     }
     return post_item(testapp, item, "Tissue")
-    
+
 
 @pytest.fixture
 def test_tissue_sample(

--- a/src/encoded/tests/datafixtures.py
+++ b/src/encoded/tests/datafixtures.py
@@ -176,6 +176,19 @@ def smaht_dbgap_user(testapp):
 
 
 @pytest.fixture
+def smaht_public_dbgap_user(testapp):
+    item = {
+        'first_name': 'Test',
+        'last_name': 'Public DBGAP',
+        'email': 'smaht_public_dbgap@example.org',
+        'groups': ['public-dbgap'],
+        'status': 'current'
+    }
+    # User @@object view has keys omitted.
+    return post_item_and_return_location(testapp, item, 'user')
+
+
+@pytest.fixture
 def blank_user(testapp):
     item = {
         'first_name': 'Unaffiliated',
@@ -317,8 +330,14 @@ def smaht_admin_app(testapp, smaht_admin):
 
 @pytest.fixture
 def smaht_dbgap_app(testapp, smaht_dbgap_user):
-    """ App associated with a consortia member who is a submitter """
+    """ App associated with member of the public with the dbgap group (ie: expanded consortia) """
     return remote_user_testapp(testapp.app, smaht_dbgap_user['uuid'])
+
+
+@pytest.fixture
+def smaht_public_dbgap_app(testapp, smaht_public_dbgap_user):
+    """ App associated member of the public with the public dbgap group """
+    return remote_user_testapp(testapp.app, smaht_public_dbgap_user['uuid'])
 
 
 @pytest.fixture

--- a/src/encoded/tests/test_permissions.py
+++ b/src/encoded/tests/test_permissions.py
@@ -403,6 +403,7 @@ class TestSubmissionCenterPermissions(TestPermissionsHelper):
     @staticmethod
     def test_dbgap_group_with_restricted_status(submission_center_user_app, submission_center2_user_app, testapp,
                                                 protected_consortium_user_app, released_file, anontestapp,
+                                                smaht_public_dbgap_app,
                                                 authenticated_testapp):
         """ Tests that users with the dbgap group can download protected data while others cannot """
         atid = released_file['@id']
@@ -418,7 +419,32 @@ class TestSubmissionCenterPermissions(TestPermissionsHelper):
         submission_center2_user_app.get(f'/{atid}@@download', status=403)
         anontestapp.get(f'/{atid}@@download', status=403)
         authenticated_testapp.get(f'/{atid}@@download', status=403)
+        smaht_public_dbgap_app.get(f'/{atid}@@download', status=403)  # public dbGaP user can't aaccess
         protected_consortium_user_app.get(f'/{atid}@@download', status=307)
+        testapp.get(f'/{atid}@@download', status=307)  # admin as well
+
+    @staticmethod
+    def test_dbgap_group_with_public_restricted_status(submission_center_user_app, submission_center2_user_app, testapp,
+                                                protected_consortium_user_app, released_file, anontestapp,
+                                                smaht_public_dbgap_app,
+                                                authenticated_testapp):
+        """ Tests that users with the public-dbgap and dbgap group can download
+            public-protected data while others cannot """
+        atid = released_file['@id']
+        testapp.patch_json(f'/{atid}', {'status': 'public-restricted'})
+        # all can view
+        submission_center_user_app.get(f'/{atid}', status=200)
+        submission_center2_user_app.get(f'/{atid}', status=200)
+        protected_consortium_user_app.get(f'/{atid}', status=200)
+        anontestapp.get(f'/{atid}', status=200)
+        authenticated_testapp.get(f'/{atid}', status=200)
+        # but only dbGaP + public dbGaP + admin can download
+        submission_center_user_app.get(f'/{atid}@@download', status=403)
+        submission_center2_user_app.get(f'/{atid}@@download', status=403)
+        anontestapp.get(f'/{atid}@@download', status=403)
+        authenticated_testapp.get(f'/{atid}@@download', status=403)
+        protected_consortium_user_app.get(f'/{atid}@@download', status=307)
+        smaht_public_dbgap_app.get(f'/{atid}@@download', status=307)  # public dbGaP user can access
         testapp.get(f'/{atid}@@download', status=307)  # admin as well
 
 

--- a/src/encoded/types/abstract_donor.py
+++ b/src/encoded/types/abstract_donor.py
@@ -1,6 +1,7 @@
 from typing import List, Union
 
 from pyramid.request import Request
+from copy import deepcopy
 from pyramid.view import view_config
 from snovault import calculated_property, abstract_collection, load_schema
 from snovault.util import debug_log
@@ -50,6 +51,10 @@ class AbstractDonor(SubmittedItem):
 
     Collection = AbstractDonorCollection
 
+    # Overrides here necessary for referencing purposes downstream - Will Jul 8 25
+    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL)
+    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL)
+
     @calculated_property(
         schema={
             "title": "Study",
@@ -84,7 +89,7 @@ def validate_external_id_on_edit(context, request):
             msg = f"external_id {external_id} does not match TPC donor nomenclature."
             return request.errors.add('body', f"{context.type_info.name}: invalid property", msg)
         else:
-            return request.validated.update({}) 
+            return request.validated.update({})
 
 
 def assert_valid_external_id(external_id: str):

--- a/src/encoded/types/acl.py
+++ b/src/encoded/types/acl.py
@@ -41,6 +41,12 @@ ONLY_ADMIN_VIEW_ACL: Acl = [
 ]
 
 
+# This ACL allows only those who have the dbGaP group to view
+ONLY_DBGAP_VIEW_ACL: Acl = [
+    (Allow, 'group.dbgap', ['view', 'view_raw'])
+] + ONLY_ADMIN_VIEW_ACL
+
+
 # User ACLs
 ONLY_ADMIN_VIEW_USER_DETAILS_ACL = [
     (Allow, 'group.admin', ['view', 'view_raw', 'view_details', 'edit']),
@@ -162,5 +168,3 @@ ALLOW_CONSORTIUM_MEMBER_VIEW_ACL: Acl = SUBMISSION_CENTER_MEMBER_VIEW_ACL + CONS
 
 # Submission centers can be restricted to only those folks for view
 ALLOW_SUBMISSION_CENTER_MEMBER_VIEW_ACL: Acl = SUBMISSION_CENTER_MEMBER_VIEW_ACL + ONLY_ADMIN_VIEW_ACL
-
-

--- a/src/encoded/types/acl.py
+++ b/src/encoded/types/acl.py
@@ -47,6 +47,13 @@ ONLY_DBGAP_VIEW_ACL: Acl = [
 ] + ONLY_ADMIN_VIEW_ACL
 
 
+# Use this to denote data that can be accessed by users of the public who
+# have the dbGaP permission (and those with the internal dbgap group)
+ONLY_PUBLIC_DBGAP_VIEW_ACL: Acl = [
+    (Allow, 'group.public-dbgap', ['view', 'view_raw'])
+] + ONLY_DBGAP_VIEW_ACL
+
+
 # User ACLs
 ONLY_ADMIN_VIEW_USER_DETAILS_ACL = [
     (Allow, 'group.admin', ['view', 'view_raw', 'view_details', 'edit']),

--- a/src/encoded/types/base.py
+++ b/src/encoded/types/base.py
@@ -149,8 +149,10 @@ class Item(SnovaultItem):
         # Everyone can view - restricted to specific items via schemas.
         'public': acl.ALLOW_EVERYONE_VIEW_ACL,
         # Intended to do additional computation to determine if download
-        # is allowed if it's a downloadable file, otherwise same as "released"
+        # is allowed if it's a downloadable file, otherwise same as "released", similar for public-
+        # restricted except the group is different and view is "public"
         'restricted': acl.ALLOW_CONSORTIUM_MEMBER_VIEW_ACL,
+        'public-restricted': acl.ALLOW_EVERYONE_VIEW_ACL,
         # Intended to tag out-of-date data
         'obsolete': acl.ALLOW_CONSORTIUM_MEMBER_VIEW_ACL,
         'deleted': DELETED_ACL,
@@ -162,8 +164,10 @@ class Item(SnovaultItem):
         'released': acl.ALLOW_CONSORTIUM_MEMBER_VIEW_ACL,
         'public': acl.ALLOW_EVERYONE_VIEW_ACL,
         # Intended to do additional computation to determine if download
-        # is allowed if it's a downloadable file, otherwise same as "released"
+        # is allowed if it's a downloadable file, otherwise same as "released", similar for public-
+        # restricted except the group is different and view is "public"
         'restricted': acl.ALLOW_CONSORTIUM_MEMBER_VIEW_ACL,
+        'public-restricted': acl.ALLOW_EVERYONE_VIEW_ACL,
         'obsolete': acl.ALLOW_CONSORTIUM_MEMBER_VIEW_ACL,
         'deleted': DELETED_ACL
     }

--- a/src/encoded/types/death_circumstances.py
+++ b/src/encoded/types/death_circumstances.py
@@ -1,6 +1,8 @@
 from snovault import collection, load_schema
+from copy import deepcopy
 
 from .submitted_item import SubmittedItem
+from .acl import ONLY_DBGAP_VIEW_ACL
 
 
 @collection(
@@ -15,3 +17,13 @@ class DeathCircumstances(SubmittedItem):
     item_type = "death_circumstances"
     schema = load_schema("encoded:schemas/death_circumstances.json")
     embedded_list = []
+
+    class Collection(SubmittedItem.Collection):
+        pass
+
+    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL).update({
+        'restricted': ONLY_DBGAP_VIEW_ACL
+    })
+    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL).update({
+        'restricted': ONLY_DBGAP_VIEW_ACL
+    })

--- a/src/encoded/types/death_circumstances.py
+++ b/src/encoded/types/death_circumstances.py
@@ -2,7 +2,7 @@ from snovault import collection, load_schema
 from copy import deepcopy
 
 from .submitted_item import SubmittedItem
-from .acl import ONLY_DBGAP_VIEW_ACL
+from .acl import ONLY_DBGAP_VIEW_ACL, ONLY_PUBLIC_DBGAP_VIEW_ACL
 
 
 @collection(
@@ -21,9 +21,13 @@ class DeathCircumstances(SubmittedItem):
     class Collection(SubmittedItem.Collection):
         pass
 
-    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL).update({
-        'restricted': ONLY_DBGAP_VIEW_ACL
+    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL)
+    SUBMISSION_CENTER_STATUS_ACL.update({
+        'restricted': ONLY_DBGAP_VIEW_ACL,
+        'public-restricted': ONLY_PUBLIC_DBGAP_VIEW_ACL
     })
-    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL).update({
-        'restricted': ONLY_DBGAP_VIEW_ACL
+    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL)
+    CONSORTIUM_STATUS_ACL.update({
+        'restricted': ONLY_DBGAP_VIEW_ACL,
+        'public-restricted': ONLY_PUBLIC_DBGAP_VIEW_ACL
     })

--- a/src/encoded/types/demographic.py
+++ b/src/encoded/types/demographic.py
@@ -2,7 +2,7 @@ from snovault import collection, load_schema
 from copy import deepcopy
 
 from .submitted_item import SubmittedItem
-from .acl import ONLY_DBGAP_VIEW_ACL
+from .acl import ONLY_DBGAP_VIEW_ACL, ONLY_PUBLIC_DBGAP_VIEW_ACL
 
 
 @collection(
@@ -21,11 +21,15 @@ class Demographic(SubmittedItem):
     class Collection(SubmittedItem.Collection):
         pass
 
-    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL).update({
-        'restricted': ONLY_DBGAP_VIEW_ACL
+    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL)
+    SUBMISSION_CENTER_STATUS_ACL.update({
+        'restricted': ONLY_DBGAP_VIEW_ACL,
+        'public-restricted': ONLY_PUBLIC_DBGAP_VIEW_ACL
     })
-    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL).update({
-        'restricted': ONLY_DBGAP_VIEW_ACL
+    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL)
+    CONSORTIUM_STATUS_ACL.update({
+        'restricted': ONLY_DBGAP_VIEW_ACL,
+        'public-restricted': ONLY_PUBLIC_DBGAP_VIEW_ACL
     })
 
 

--- a/src/encoded/types/demographic.py
+++ b/src/encoded/types/demographic.py
@@ -1,6 +1,8 @@
 from snovault import collection, load_schema
+from copy import deepcopy
 
 from .submitted_item import SubmittedItem
+from .acl import ONLY_DBGAP_VIEW_ACL
 
 
 @collection(
@@ -15,3 +17,15 @@ class Demographic(SubmittedItem):
     item_type = "demographic"
     schema = load_schema("encoded:schemas/demographic.json")
     embedded_list = []
+
+    class Collection(SubmittedItem.Collection):
+        pass
+
+    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL).update({
+        'restricted': ONLY_DBGAP_VIEW_ACL
+    })
+    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL).update({
+        'restricted': ONLY_DBGAP_VIEW_ACL
+    })
+
+

--- a/src/encoded/types/diagnosis.py
+++ b/src/encoded/types/diagnosis.py
@@ -2,7 +2,7 @@ from snovault import collection, load_schema
 from copy import deepcopy
 
 from .submitted_item import SubmittedItem
-from .acl import ONLY_DBGAP_VIEW_ACL
+from .acl import ONLY_DBGAP_VIEW_ACL, ONLY_PUBLIC_DBGAP_VIEW_ACL
 
 
 @collection(
@@ -21,9 +21,13 @@ class Diagnosis(SubmittedItem):
     class Collection(SubmittedItem.Collection):
         pass
 
-    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL).update({
-        'restricted': ONLY_DBGAP_VIEW_ACL
+    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL)
+    SUBMISSION_CENTER_STATUS_ACL.update({
+        'restricted': ONLY_DBGAP_VIEW_ACL,
+        'public-restricted': ONLY_PUBLIC_DBGAP_VIEW_ACL
     })
-    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL).update({
-        'restricted': ONLY_DBGAP_VIEW_ACL
+    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL)
+    CONSORTIUM_STATUS_ACL.update({
+        'restricted': ONLY_DBGAP_VIEW_ACL,
+        'public-restricted': ONLY_PUBLIC_DBGAP_VIEW_ACL
     })

--- a/src/encoded/types/diagnosis.py
+++ b/src/encoded/types/diagnosis.py
@@ -1,6 +1,8 @@
 from snovault import collection, load_schema
+from copy import deepcopy
 
 from .submitted_item import SubmittedItem
+from .acl import ONLY_DBGAP_VIEW_ACL
 
 
 @collection(
@@ -15,3 +17,13 @@ class Diagnosis(SubmittedItem):
     item_type = "diagnosis"
     schema = load_schema("encoded:schemas/diagnosis.json")
     embedded_list = []
+
+    class Collection(SubmittedItem.Collection):
+        pass
+
+    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL).update({
+        'restricted': ONLY_DBGAP_VIEW_ACL
+    })
+    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL).update({
+        'restricted': ONLY_DBGAP_VIEW_ACL
+    })

--- a/src/encoded/types/exposure.py
+++ b/src/encoded/types/exposure.py
@@ -1,6 +1,8 @@
 from snovault import collection, load_schema
+from copy import deepcopy
 
 from .submitted_item import SubmittedItem
+from .acl import ONLY_DBGAP_VIEW_ACL
 
 
 @collection(
@@ -15,3 +17,13 @@ class Exposure(SubmittedItem):
     item_type = "exposure"
     schema = load_schema("encoded:schemas/exposure.json")
     embedded_list = []
+
+    class Collection(SubmittedItem.Collection):
+        pass
+
+    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL).update({
+        'restricted': ONLY_DBGAP_VIEW_ACL
+    })
+    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL).update({
+        'restricted': ONLY_DBGAP_VIEW_ACL
+    })

--- a/src/encoded/types/exposure.py
+++ b/src/encoded/types/exposure.py
@@ -2,7 +2,7 @@ from snovault import collection, load_schema
 from copy import deepcopy
 
 from .submitted_item import SubmittedItem
-from .acl import ONLY_DBGAP_VIEW_ACL
+from .acl import ONLY_DBGAP_VIEW_ACL, ONLY_PUBLIC_DBGAP_VIEW_ACL
 
 
 @collection(
@@ -21,9 +21,13 @@ class Exposure(SubmittedItem):
     class Collection(SubmittedItem.Collection):
         pass
 
-    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL).update({
-        'restricted': ONLY_DBGAP_VIEW_ACL
+    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL)
+    SUBMISSION_CENTER_STATUS_ACL.update({
+        'restricted': ONLY_DBGAP_VIEW_ACL,
+        'public-restricted': ONLY_PUBLIC_DBGAP_VIEW_ACL
     })
-    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL).update({
-        'restricted': ONLY_DBGAP_VIEW_ACL
+    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL)
+    CONSORTIUM_STATUS_ACL.update({
+        'restricted': ONLY_DBGAP_VIEW_ACL,
+        'public-restricted': ONLY_PUBLIC_DBGAP_VIEW_ACL
     })

--- a/src/encoded/types/family_history.py
+++ b/src/encoded/types/family_history.py
@@ -1,6 +1,8 @@
 from snovault import collection, load_schema
+from copy import deepcopy
 
 from .submitted_item import SubmittedItem
+from .acl import ONLY_DBGAP_VIEW_ACL
 
 
 @collection(
@@ -15,3 +17,13 @@ class FamilyHistory(SubmittedItem):
     item_type = "family_history"
     schema = load_schema("encoded:schemas/family_history.json")
     embedded_list = []
+
+    class Collection(SubmittedItem.Collection):
+        pass
+
+    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL).update({
+        'restricted': ONLY_DBGAP_VIEW_ACL
+    })
+    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL).update({
+        'restricted': ONLY_DBGAP_VIEW_ACL
+    })

--- a/src/encoded/types/family_history.py
+++ b/src/encoded/types/family_history.py
@@ -2,7 +2,7 @@ from snovault import collection, load_schema
 from copy import deepcopy
 
 from .submitted_item import SubmittedItem
-from .acl import ONLY_DBGAP_VIEW_ACL
+from .acl import ONLY_DBGAP_VIEW_ACL, ONLY_PUBLIC_DBGAP_VIEW_ACL
 
 
 @collection(
@@ -21,9 +21,13 @@ class FamilyHistory(SubmittedItem):
     class Collection(SubmittedItem.Collection):
         pass
 
-    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL).update({
-        'restricted': ONLY_DBGAP_VIEW_ACL
+    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL)
+    SUBMISSION_CENTER_STATUS_ACL.update({
+        'restricted': ONLY_DBGAP_VIEW_ACL,
+        'public-restricted': ONLY_PUBLIC_DBGAP_VIEW_ACL
     })
-    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL).update({
-        'restricted': ONLY_DBGAP_VIEW_ACL
+    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL)
+    CONSORTIUM_STATUS_ACL.update({
+        'restricted': ONLY_DBGAP_VIEW_ACL,
+        'public-restricted': ONLY_PUBLIC_DBGAP_VIEW_ACL
     })

--- a/src/encoded/types/medical_history.py
+++ b/src/encoded/types/medical_history.py
@@ -5,7 +5,7 @@ from snovault import collection, load_schema, calculated_property
 from pyramid.request import Request
 
 from .submitted_item import SubmittedItem
-from .acl import ONLY_DBGAP_VIEW_ACL
+from .acl import ONLY_DBGAP_VIEW_ACL, ONLY_PUBLIC_DBGAP_VIEW_ACL
 from ..item_utils.utils import (
     get_property_value_from_identifier,
     RequestHandler,
@@ -38,11 +38,15 @@ class MedicalHistory(SubmittedItem):
     class Collection(SubmittedItem.Collection):
         pass
 
-    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL).update({
-        'restricted': ONLY_DBGAP_VIEW_ACL
+    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL)
+    SUBMISSION_CENTER_STATUS_ACL.update({
+        'restricted': ONLY_DBGAP_VIEW_ACL,
+        'public-restricted': ONLY_PUBLIC_DBGAP_VIEW_ACL
     })
-    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL).update({
-        'restricted': ONLY_DBGAP_VIEW_ACL
+    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL)
+    CONSORTIUM_STATUS_ACL.update({
+        'restricted': ONLY_DBGAP_VIEW_ACL,
+        'public-restricted': ONLY_PUBLIC_DBGAP_VIEW_ACL
     })
 
     @calculated_property(

--- a/src/encoded/types/medical_history.py
+++ b/src/encoded/types/medical_history.py
@@ -1,9 +1,11 @@
 from typing import List, Union
+from copy import deepcopy
 
 from snovault import collection, load_schema, calculated_property
 from pyramid.request import Request
 
 from .submitted_item import SubmittedItem
+from .acl import ONLY_DBGAP_VIEW_ACL
 from ..item_utils.utils import (
     get_property_value_from_identifier,
     RequestHandler,
@@ -33,6 +35,16 @@ class MedicalHistory(SubmittedItem):
         "exposures": ("Exposure", "medical_history")
     }
 
+    class Collection(SubmittedItem.Collection):
+        pass
+
+    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL).update({
+        'restricted': ONLY_DBGAP_VIEW_ACL
+    })
+    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL).update({
+        'restricted': ONLY_DBGAP_VIEW_ACL
+    })
+
     @calculated_property(
         schema={
             "title": "Exposures",
@@ -48,7 +60,7 @@ class MedicalHistory(SubmittedItem):
         result = self.rev_link_atids(request, "exposures")
         request_handler = RequestHandler(request = request)
         categories = ["Alcohol", "Tobacco"]
-        valid_exposures = [ 
+        valid_exposures = [
             exp for exp in result
             if get_property_value_from_identifier(
                 request_handler,

--- a/src/encoded/types/medical_treatment.py
+++ b/src/encoded/types/medical_treatment.py
@@ -1,6 +1,8 @@
 from snovault import collection, load_schema
+from copy import deepcopy
 
 from .submitted_item import SubmittedItem
+from .acl import ONLY_DBGAP_VIEW_ACL
 
 
 @collection(
@@ -15,3 +17,13 @@ class MedicalTreatment(SubmittedItem):
     item_type = "medical_treatment"
     schema = load_schema("encoded:schemas/medical_treatment.json")
     embedded_list = []
+
+    class Collection(SubmittedItem.Collection):
+        pass
+
+    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL).update({
+        'restricted': ONLY_DBGAP_VIEW_ACL
+    })
+    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL).update({
+        'restricted': ONLY_DBGAP_VIEW_ACL
+    })

--- a/src/encoded/types/medical_treatment.py
+++ b/src/encoded/types/medical_treatment.py
@@ -2,7 +2,7 @@ from snovault import collection, load_schema
 from copy import deepcopy
 
 from .submitted_item import SubmittedItem
-from .acl import ONLY_DBGAP_VIEW_ACL
+from .acl import ONLY_DBGAP_VIEW_ACL, ONLY_PUBLIC_DBGAP_VIEW_ACL
 
 
 @collection(
@@ -21,9 +21,13 @@ class MedicalTreatment(SubmittedItem):
     class Collection(SubmittedItem.Collection):
         pass
 
-    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL).update({
-        'restricted': ONLY_DBGAP_VIEW_ACL
+    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL)
+    SUBMISSION_CENTER_STATUS_ACL.update({
+        'restricted': ONLY_DBGAP_VIEW_ACL,
+        'public-restricted': ONLY_PUBLIC_DBGAP_VIEW_ACL
     })
-    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL).update({
-        'restricted': ONLY_DBGAP_VIEW_ACL
+    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL)
+    CONSORTIUM_STATUS_ACL.update({
+        'restricted': ONLY_DBGAP_VIEW_ACL,
+        'public-restricted': ONLY_PUBLIC_DBGAP_VIEW_ACL
     })

--- a/src/encoded/types/protected_donor.py
+++ b/src/encoded/types/protected_donor.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 
 from pyramid.request import Request
 from snovault import calculated_property, collection, load_schema
-from .acl import ONLY_DBGAP_VIEW_ACL
+from .acl import ONLY_DBGAP_VIEW_ACL, ONLY_PUBLIC_DBGAP_VIEW_ACL
 
 from .abstract_donor import AbstractDonor
 
@@ -44,11 +44,15 @@ class ProtectedDonor(AbstractDonor):
         "medical_history": ("MedicalHistory", "donor"),
     }
 
-    SUBMISSION_CENTER_STATUS_ACL = deepcopy(AbstractDonor.SUBMISSION_CENTER_STATUS_ACL).update({
-        'restricted': ONLY_DBGAP_VIEW_ACL
+    SUBMISSION_CENTER_STATUS_ACL = deepcopy(AbstractDonor.SUBMISSION_CENTER_STATUS_ACL)
+    SUBMISSION_CENTER_STATUS_ACL.update({
+        'restricted': ONLY_DBGAP_VIEW_ACL,
+        'public-restricted': ONLY_PUBLIC_DBGAP_VIEW_ACL
     })
-    CONSORTIUM_STATUS_ACL = deepcopy(AbstractDonor.CONSORTIUM_STATUS_ACL).update({
-        'restricted': ONLY_DBGAP_VIEW_ACL
+    CONSORTIUM_STATUS_ACL = deepcopy(AbstractDonor.CONSORTIUM_STATUS_ACL)
+    CONSORTIUM_STATUS_ACL.update({
+        'restricted': ONLY_DBGAP_VIEW_ACL,
+        'public-restricted': ONLY_PUBLIC_DBGAP_VIEW_ACL
     })
 
     @calculated_property(

--- a/src/encoded/types/protected_donor.py
+++ b/src/encoded/types/protected_donor.py
@@ -1,7 +1,9 @@
 from typing import List, Union
+from copy import deepcopy
 
 from pyramid.request import Request
 from snovault import calculated_property, collection, load_schema
+from .acl import ONLY_DBGAP_VIEW_ACL
 
 from .abstract_donor import AbstractDonor
 
@@ -41,6 +43,13 @@ class ProtectedDonor(AbstractDonor):
     rev = {
         "medical_history": ("MedicalHistory", "donor"),
     }
+
+    SUBMISSION_CENTER_STATUS_ACL = deepcopy(AbstractDonor.SUBMISSION_CENTER_STATUS_ACL).update({
+        'restricted': ONLY_DBGAP_VIEW_ACL
+    })
+    CONSORTIUM_STATUS_ACL = deepcopy(AbstractDonor.CONSORTIUM_STATUS_ACL).update({
+        'restricted': ONLY_DBGAP_VIEW_ACL
+    })
 
     @calculated_property(
         schema={

--- a/src/encoded/types/tissue_collection.py
+++ b/src/encoded/types/tissue_collection.py
@@ -2,7 +2,7 @@ from snovault import collection, load_schema
 from copy import deepcopy
 
 from .submitted_item import SubmittedItem
-from .acl import ONLY_DBGAP_VIEW_ACL
+from .acl import ONLY_DBGAP_VIEW_ACL, ONLY_PUBLIC_DBGAP_VIEW_ACL
 
 
 @collection(
@@ -21,9 +21,13 @@ class TissueCollection(SubmittedItem):
     class Collection(SubmittedItem.Collection):
         pass
 
-    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL).update({
-        'restricted': ONLY_DBGAP_VIEW_ACL
+    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL)
+    SUBMISSION_CENTER_STATUS_ACL.update({
+        'restricted': ONLY_DBGAP_VIEW_ACL,
+        'public-restricted': ONLY_PUBLIC_DBGAP_VIEW_ACL
     })
-    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL).update({
-        'restricted': ONLY_DBGAP_VIEW_ACL
+    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL)
+    CONSORTIUM_STATUS_ACL.update({
+        'restricted': ONLY_DBGAP_VIEW_ACL,
+        'public-restricted': ONLY_PUBLIC_DBGAP_VIEW_ACL
     })

--- a/src/encoded/types/tissue_collection.py
+++ b/src/encoded/types/tissue_collection.py
@@ -1,6 +1,8 @@
 from snovault import collection, load_schema
+from copy import deepcopy
 
 from .submitted_item import SubmittedItem
+from .acl import ONLY_DBGAP_VIEW_ACL
 
 
 @collection(
@@ -15,3 +17,13 @@ class TissueCollection(SubmittedItem):
     item_type = "tissue_collection"
     schema = load_schema("encoded:schemas/tissue_collection.json")
     embedded_list = []
+
+    class Collection(SubmittedItem.Collection):
+        pass
+
+    SUBMISSION_CENTER_STATUS_ACL = deepcopy(SubmittedItem.SUBMISSION_CENTER_STATUS_ACL).update({
+        'restricted': ONLY_DBGAP_VIEW_ACL
+    })
+    CONSORTIUM_STATUS_ACL = deepcopy(SubmittedItem.CONSORTIUM_STATUS_ACL).update({
+        'restricted': ONLY_DBGAP_VIEW_ACL
+    })


### PR DESCRIPTION
- Adds two new ACLs for `restricted` and `public-restricted` that allows metadata items to be permissions via presence of the `dbgap` and `public-dbgap` groups
- Expands the `restricted` status to apply a global block on dbGaP permission for certain metadata items
- Allow the `public-restricted` status to function similarly to how `restricted` functions for non-file items ie: anyone can view, only protected users can download
- Tests for protected donor and medical history using the `restricted` and `public-restricted` statuses, along with tests for files as well utilizing the new groups