### PR TITLE
SN Sequencing center patching for submitted files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ smaht-portal
 Change Log
 ----------
 
+0.191.0
+=======
+`PR 486: SN Sequencing center patching for submitted files <http://github.com/smaht-dac/smaht-portal/pull/486>`_
+
+* In `commands/release_file.py`, update the initial patch of the file to include the `sequencing center` as the `submission center` for SubmittedFiles (not OutputFiles)
+* In `commands/create_annotated_filenames.py`, for SubmittedFiles use the `submission center` as the `sequencing center` for the center code
+
+
 0.190.8
 =======
 `PR 482: SN Revert RIN minimum <http://github.com/smaht-dac/smaht-portal/pull/482>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.190.8"
+version = "0.191.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/commands/create_annotated_filenames.py
+++ b/src/encoded/commands/create_annotated_filenames.py
@@ -20,6 +20,7 @@ from encoded.item_utils import (
     sample as sample_utils,
     sample_source as sample_source_utils,
     supplementary_file as supp_file_utils,
+    submitted_file as submitted_file_utils,
     tissue as tissue_utils,
     tissue_sample as tissue_sample_utils,
     donor_specific_assembly as dsa_utils,
@@ -214,6 +215,8 @@ def get_sequencing_center(
     file: Dict[str, Any], request_handler: RequestHandler
 ) -> Dict[str, Any]:
     """Get sequencing center for file."""
+    if submitted_file_utils.is_submitted_file(file):
+        return get_items(item_utils.get_submission_centers(file), request_handler)[0]
     return get_item(file_utils.get_sequencing_center(file), request_handler)
 
 

--- a/src/encoded/commands/release_file.py
+++ b/src/encoded/commands/release_file.py
@@ -63,8 +63,7 @@ class AnnotatedFilenameInfo:
 
 
 # dataset is required but comes in through input args for now
-REQUIRED_FILE_PROPS = [file_constants.SEQUENCING_CENTER]
-SECONDARY_REQUIRED_FILE_PROPS = ["release_tracker_description", "release_tracker_title"]
+REQUIRED_FILE_PROPS = [file_constants.SEQUENCING_CENTER, "release_tracker_description", "release_tracker_title"]
 # This lists the MWFs that need to have run in addition to the regular Alignment and QC run
 REQUIRED_ADDITIONAL_QC_RUNS = ["sample_identity_check"]
 
@@ -502,7 +501,7 @@ class FileRelease:
         ]
         file_accession = item_utils.get_accession(file)
         annotated_filename_info = self.get_annotated_filename_info(file)
-        # Add file to file set and set status to released
+        # Add file to file set
         patch_body = {
             item_constants.UUID: item_utils.get_uuid(file),
             file_constants.DATASET: dataset,
@@ -524,8 +523,20 @@ class FileRelease:
                 f"File {warning_text(file_accession)} will be released as {warning_text(annotated_filename_info.filename)}"
             ]
         )
+        if submitted_file_utils.is_submitted_file(self.file):
+            # For submitted files, patch sequencing center
+            sequencing_center = item_utils.get_submission_centers(file)[0]
+            patch_body[file_constants.SEQUENCING_CENTER] = item_utils.get_uuid(sequencing_center)
+            self.patch_infos.extend(
+                [
+                    self.get_okay_message(
+                        file_constants.SEQUENCING_CENTER, item_utils.get_display_title(sequencing_center)
+                    ),
+                ]
+            )
 
         if patch_status:
+            # set file to released
             patch_body[item_constants.STATUS] = item_constants.STATUS_RELEASED
             self.patch_infos.extend(
                 [
@@ -737,14 +748,13 @@ class FileRelease:
         return access_statuses.pop()
 
     def validate_file(self) -> None:
-        self.validate_required_file_props()
         self.validate_required_qc_runs()
         self.validate_existing_file_sets()
         self.validate_file_output_status()
         self.validate_file_status()
 
     def validate_file_after_patch(self) -> None:
-        self.validate_secondary_required_file_props()
+        self.validate_required_file_props()
 
     def validate_required_file_props(self) -> None:
         for prop in REQUIRED_FILE_PROPS:
@@ -769,14 +779,6 @@ class FileRelease:
                     self.print_error_and_exit(
                         f"File {self.file_accession} is missing the required additional QC run {mwf_name}."
                     )
-
-    def validate_secondary_required_file_props(self) -> None:
-        for prop in SECONDARY_REQUIRED_FILE_PROPS:
-            if prop not in self.file:
-                self.print_error_and_exit(
-                    f"File {self.file_accession} does not have the required property"
-                    f" `{prop}`."
-                )
 
     def validate_existing_file_sets(self) -> None:
         existing_file_sets = file_utils.get_file_sets(self.file)

--- a/src/encoded/item_utils/submitted_file.py
+++ b/src/encoded/item_utils/submitted_file.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 
-from .item import get_type
+from .item import get_types
 
 
 def is_submitted_file(properties: Dict[str, Any]) -> bool:
-    return get_type(properties) == "SubmittedFile"
+    return "SubmittedFile" in get_types(properties)  


### PR DESCRIPTION
- In `commands/release_file.py`, update the initial patch of the file to include the sequencing center as the submission center for SubmittedFiles (not OutputFiles)
- In `commands/create_annotated_filenames.py`, for SubmittedFiles use the submission center as the sequencing center for the center code
- Update allows for faster release of Submitted Files (e.g. DuplexSeq variant calls) without having to manually patch `sequencing_center` for each file prior to release