### PR TITLE
fix: update qc-page content uuid

### DIFF
--- a/src/encoded/tests/data/master-inserts/page.json
+++ b/src/encoded/tests/data/master-inserts/page.json
@@ -1028,7 +1028,7 @@
         "uuid": "9069da47-819f-4f49-bd94-2a4cabb0e727",
         "status": "in review",
         "content": [
-            "68271697-2726-4bbf-9243-1c2ae9553c80"
+            "27d09f44-44ca-466e-ade6-6d5a5a81c99c"
         ],
         "table-of-contents": {
             "enabled": false


### PR DESCRIPTION
Fix for updating the uuid in the qc-metrics content field in master-inserts