### PR TITLE
Updates to QC metrics and Submission Status page

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,17 @@ smaht-portal
 Change Log
 ----------
 
+0.192.8
+=======
+`PR 493: AV Updates to QC metrics and Submission Status page <http://github.com/smaht-dac/smaht-portal/pull/493>`_
+
+* Update thresholds in the QC overview generation script
+* Remove table from sample identity tab in QC metrics page
+* Indictate retracted files on the Submission Status page
+* Add copy button for group coverage on the Submission Status page
+* Add retry logic when getting the QC overview data
+
+
 0.192.7
 =======
 `PR 492: feat: add new announcement to homepage <https://github.com/smaht-dac/smaht-portal/pull/492>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,17 @@ smaht-portal
 Change Log
 ----------
 
+0.192.4
+=======
+`PR 493: AV Updates to QC metrics and Submission Status page <http://github.com/smaht-dac/smaht-portal/pull/493>`_
+
+* Update thresholds in the QC overview generation script
+* Remove table from sample identity tab in QC metrics page
+* Indictate retracted files on the Submission Status page
+* Add copy button for group coverage on the Submission Status page
+* Add retry logic when getting the QC overview data
+
+
 0.192.3
 =======
 `PR 486: SN Sequencing center patching for submitted files <http://github.com/smaht-dac/smaht-portal/pull/486>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.192.7"
+version = "0.192.8"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.192.3"
+version = "0.192.4"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/qc_overview.py
+++ b/src/encoded/qc_overview.py
@@ -70,4 +70,5 @@ def get_qc_overview(context, request):
 
     except Exception as e:
         response["error_msg"] = f"Error when trying to get QC overview data: {str(e)}"
+        request.response.status_code = 500
         return response

--- a/src/encoded/static/components/static-pages/components/internal/SubmissionStatusFileGroupQcModal.js
+++ b/src/encoded/static/components/static-pages/components/internal/SubmissionStatusFileGroupQcModal.js
@@ -5,6 +5,7 @@ import Modal from 'react-bootstrap/esm/Modal';
 import Form from 'react-bootstrap/Form';
 import Tab from 'react-bootstrap/Tab';
 import Tabs from 'react-bootstrap/Tabs';
+import * as d3 from 'd3';
 import { ajax } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
 import { object } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
 
@@ -224,13 +225,17 @@ class FileGroupQCModalComponent extends React.PureComponent {
             if (!this.state.visibleFileSets.includes(file.fileset_uuid)) {
                 return;
             }
+            const retracted =
+                file.status === 'retracted'
+                    ? <span className="ps-1">{createBadge('danger', 'Retracted')}</span>
+                    : '';
             const tags = this.state.isUserAdmin
                 ? this.getFileSetTags(file.fileset_uuid)
                 : '';
             header.push(
                 <th>
                     <span className="text-wrap" title={file.display_title}>
-                        {file.accession}
+                        {file.accession} {retracted}
                     </span>
                     <br />
                     <small
@@ -412,6 +417,11 @@ class FileGroupQCModalComponent extends React.PureComponent {
 
         const targetCoverage = getTargetCoverage(currentFileSet.sequencing);
 
+        const estimatedTotalCoverageCopyString =
+            this.state.estimatedTotalCoverage !== 'NA'
+                ? d3.format(',.1f')(this.state.estimatedTotalCoverage) + 'X'
+                : '';
+
         const estimatedCoverage =
             this.state.estimatedTotalCoverage === 'NA' ? (
                 ''
@@ -419,6 +429,14 @@ class FileGroupQCModalComponent extends React.PureComponent {
                 <span>
                     , Calculated coverage:{' '}
                     <strong>{this.state.estimatedTotalCoverage}x</strong>
+                    <object.CopyWrapper
+                        value={estimatedTotalCoverageCopyString}
+                        className=""
+                        data-tip={'Click to copy group coverage'}
+                        wrapperElement="span"
+                        iconProps={{
+                            style: { fontSize: '0.875rem', marginLeft: 3 },
+                        }}></object.CopyWrapper>
                 </span>
             );
 

--- a/src/encoded/static/components/static-pages/components/internal/submissionStatusUtils.js
+++ b/src/encoded/static/components/static-pages/components/internal/submissionStatusUtils.js
@@ -44,9 +44,13 @@ function isFloat(num) {
     return Number(num) === num && num % 1 !== 0;
 }
 
-export const createBadge = (type, description, tooltip="") => {
+export const createBadge = (type, description, tooltip = '') => {
     const cn = 'badge text-white bg-' + type;
-    return <span className={cn} data-tip={tooltip}>{description}</span>;
+    return (
+        <span className={cn} data-tip={tooltip}>
+            {description}
+        </span>
+    );
 };
 
 export const createQcBadgeLink = (type, identifier, description) => {
@@ -78,14 +82,22 @@ export const fallbackCallback = (errResp, xhr) => {
 
 export const getTargetCoverage = (sequencing) => {
     let targeCoverage = <span>Target coverage: NAx</span>;
-    if(sequencing?.target_coverage){
-        targeCoverage = <span>Target coverage: <strong>{sequencing?.target_coverage}x</strong></span>;
-    }else if (sequencing?.target_read_count){
+    if (sequencing?.target_coverage) {
+        targeCoverage = (
+            <span>
+                Target coverage: <strong>{sequencing?.target_coverage}x</strong>
+            </span>
+        );
+    } else if (sequencing?.target_read_count) {
         const readCount = d3.format(',')(sequencing?.target_read_count);
-        targeCoverage = <span>Target read count: <strong>{readCount}</strong></span>;
+        targeCoverage = (
+            <span>
+                Target read count: <strong>{readCount}</strong>
+            </span>
+        );
     }
     return targeCoverage;
-}
+};
 
 export const getQcBagdeType = (flag) => {
     let badgeType = 'secondary';
@@ -111,6 +123,10 @@ export const getQcResults = (qc_results, showCopyBtn = false) => {
             return createQcBadgeLink(badgeType, qc_uuid, overallQualityStatus);
         });
         const href = '/' + qc_info.uuid;
+        const retracted =
+            qc_info.status === 'retracted'
+                ? <span className="ps-1">{createBadge('danger', 'Retracted')}</span>
+                : '';
         const copyBtn = showCopyBtn ? (
             <object.CopyWrapper
                 value={qc_info.accession}
@@ -128,6 +144,7 @@ export const getQcResults = (qc_results, showCopyBtn = false) => {
                 <a href={href} target="_blank" data-tip={qc_info.display_title}>
                     {qc_info.accession}
                 </a>
+                {retracted}
                 {copyBtn}
                 <span className="ps-1">{qcTags}</span>
             </div>
@@ -164,7 +181,7 @@ export const getCommentsList = (
     fsComments,
     isUserAdmin,
     removeCommentFct,
-    prefix = "",
+    prefix = ''
 ) => {
     if (!fsComments) {
         return;
@@ -180,7 +197,8 @@ export const getCommentsList = (
         );
         comments.push(
             <li className="ss-line-height-140">
-                {prefix}<strong>{c}</strong>
+                {prefix}
+                <strong>{c}</strong>
                 {trashSymbol}
             </li>
         );

--- a/src/encoded/static/components/viz/QualityMetricVisualizations/SampleContamination.js
+++ b/src/encoded/static/components/viz/QualityMetricVisualizations/SampleContamination.js
@@ -148,7 +148,8 @@ export const SampleContamination = ({ qcData, preselectedFile }) => {
                             somalierResults[selectedDonor['value']]['results']
                         }></SampleContaminationHeatmap>
                 </div>
-                <div className="col-12">
+                {/* Disable the table for now, as it is not as useful as the heatmap */}
+                {/* <div className="col-12">
                     <div className="pt-5 h4">Somalier results</div>
                     <div>
                         <SampleContaminationDataTable
@@ -156,7 +157,7 @@ export const SampleContamination = ({ qcData, preselectedFile }) => {
                                 somalierResults[selectedDonor['value']]
                             }></SampleContaminationDataTable>
                     </div>
-                </div>
+                </div> */}
             </div>
         </>
     );

--- a/src/encoded/submission_status.py
+++ b/src/encoded/submission_status.py
@@ -150,6 +150,7 @@ def get_file_group_qc(context, request):
                     files_with_qcs.append(
                         {
                             "accession": f["accession"],
+                            "status": f["status"],
                             "display_title": f["display_title"],
                             "is_output_file": f["is_output_file"],
                             "fileset_submitted_id": fs.get("submitted_id"),
@@ -446,6 +447,7 @@ def get_qc_result(file, is_output_file):
     qc_result = {
         DISPLAY_TITLE: file[DISPLAY_TITLE],
         UUID: file[UUID],
+        STATUS: file[STATUS],
         ACCESSION: file[ACCESSION],
         QUALITY_METRICS: [],
         "is_output_file": is_output_file,


### PR DESCRIPTION
* Update thresholds in the QC overview generation script
* Remove table from sample identity tab in QC metrics page
* Indictate retracted files on the Submission Status page
* Add copy button for group coverage on the Submission Status page
* Add retry logic when getting the QC overview data