### PR TITLE
SN Somatic VCF access status 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ smaht-portal
 Change Log
 ----------
 
+0.192.4
+=======
+`PR 494: SN Somatic VCF access status <http://github.com/smaht-dac/smaht-portal/pull/494>`_
+
+* In `commands/release_file.py`, update the `access_status` for somatic variant calls from tissues to be "Protected" instead of "Open"
+
+
 0.192.3
 =======
 `PR 486: SN Sequencing center patching for submitted files <http://github.com/smaht-dac/smaht-portal/pull/486>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "0.192.3"
+version = "0.192.4"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/commands/release_file.py
+++ b/src/encoded/commands/release_file.py
@@ -593,7 +593,7 @@ class FileRelease:
             Files with expression or epigenetic data = Open
         Tissues
             BAM, FASTQ = Protected
-            Files with somatic variants = Open
+            Files with somatic variants = Protected (until confident no germline variants are present)
             Files with germline variants = Protected
             Files with expression or epigenetic data = Open
 
@@ -655,7 +655,7 @@ class FileRelease:
                     file_constants.ACCESS_STATUS_PROTECTED
                 ),
                 file_constants.DATA_CATEGORY_SOMATIC_VARIANT_CALLS: (
-                    file_constants.ACCESS_STATUS_OPEN
+                    file_constants.ACCESS_STATUS_PROTECTED
                 ),
                 file_constants.DATA_CATEGORY_GENOME_ASSEMBLY: (
                     file_constants.ACCESS_STATUS_PROTECTED


### PR DESCRIPTION
- In `commands/release_file.py`, update the `access_status` for somatic variant calls from tissues to be "Protected" instead of "Open"
- Changing this at least for the time being because there may still be germline variants in these files 