### PR TITLE
Fix: Re-include ingestion_processors in app config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ smaht-portal
 Change Log
 ----------
 
+
+1.1.5
+=======
+
+* Re-include ingestion_processors in app config
+
+
 1.1.4
 =======
 `PR 521: Modify production tissues in Submission Status page <https://github.com/smaht-dac/smaht-portal/pull/521>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Change Log
 
 1.1.5
 =======
+`PR 525: Fix: Re-include ingestion_processors in app config <https://github.com/smaht-dac/smaht-portal/pull/525>`_
 
 * Re-include ingestion_processors in app config
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "1.1.4"
+version = "1.1.5"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/__init__.py
+++ b/src/encoded/__init__.py
@@ -97,7 +97,7 @@ def include_snovault(config: Configurator) -> None:
     config.include('snovault.server_defaults')
     config.include('snovault.renderers')
     config.include('snovault.ingestion.ingestion_listener')
-    config.include('encoded.ingestion.ingestion_processors')
+    config.include('encoded.ingestion.ingestion_processors') # needed by Submitr
     config.include('snovault.ingestion.ingestion_message_handler_default')
     config.include('snovault.routes')
     # configure redis server in production.ini

--- a/src/encoded/__init__.py
+++ b/src/encoded/__init__.py
@@ -97,6 +97,7 @@ def include_snovault(config: Configurator) -> None:
     config.include('snovault.server_defaults')
     config.include('snovault.renderers')
     config.include('snovault.ingestion.ingestion_listener')
+    config.include('encoded.ingestion.ingestion_processors')
     config.include('snovault.ingestion.ingestion_message_handler_default')
     config.include('snovault.routes')
     # configure redis server in production.ini


### PR DESCRIPTION
Added 'encoded.ingestion.ingestion_processors' to the application configuration to ensure ingestion processors are included during setup.