### PR TITLE
Apply facet label overrides in browse facet charts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,14 @@ Change Log
 ----------
 
 
+1.21.2
+======
+
+`PR 630: Apply facet label overrides in browse facet charts <https://github.com/smaht-dac/smaht-portal/pull/630>`_
+
+* Use facet term label overrides for facet charts in file/donor browse views
+
+
 1.21.1
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "1.21.1"
+version = "1.21.2"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/browse/components/FacetCharts.js
+++ b/src/encoded/static/components/browse/components/FacetCharts.js
@@ -16,6 +16,9 @@ function termTransformFxnWithChartAliases(facets = null){
     const getCandidateFields = (field) => {
         if (typeof field !== 'string') return [];
 
+        // Bar plot aggregation fields do not always match the browse facet field exactly
+        // (e.g. `sequencing.*` in the chart vs `file_sets.sequencing.*` in facets). Match
+        // by equivalent trailing path so chart labels can still use facet label_overrides.
         const matchingFields = facets
             .map(({ field: facetField }) => facetField)
             .filter((facetField) => {
@@ -39,6 +42,8 @@ function termTransformFxnWithChartAliases(facets = null){
         const candidateFields = getCandidateFields(field);
         for (let i = 0; i < candidateFields.length; i++) {
             const candidateField = candidateFields[i];
+            // Read label overrides directly here so this stays scoped to facet charts and
+            // does not broaden behavior of the shared browse/search term transformer.
             const override = facets.find(
                 (f) => f.field === candidateField
             )?.label_overrides?.[key];
@@ -281,6 +286,8 @@ export class FacetCharts extends React.PureComponent {
         const cursorDetailActions = this.cursorDetailActions();
         const browseBaseParams = navigate.getBrowseBaseParams(null, mapping);
         const donorFilters = searchFilters.contextFiltersToExpSetFilters(context && context.filters, browseBaseParams);
+        // Use a chart-local term resolver so facet label_overrides are applied in chart bars,
+        // popovers, and legend even when chart aggregation fields use an alias of the facet field.
         const termLabelTransform = termTransformFxnWithChartAliases((context && context.facets) || []);
         let height = show === 'small' ? (mapping === 'all' ? 330 : 370) : 370;
         let width;

--- a/src/encoded/static/components/browse/components/FacetCharts.js
+++ b/src/encoded/static/components/browse/components/FacetCharts.js
@@ -8,6 +8,47 @@ import { object, layout, ajax, console, isServerSide, analytics, searchFilters, 
 import { navigate } from './../../util';
 import { ChartDataController } from './../../viz/chart-data-controller';
 import * as BarPlot from './../../viz/BarPlot';
+import { termTransformFxnWithOverrides } from './../SearchView';
+
+function termTransformFxnWithChartAliases(facets = null){
+    const baseTransform = termTransformFxnWithOverrides(facets);
+
+    const getCandidateFields = (field) => {
+        if (typeof field !== 'string') return [];
+
+        const matchingFields = facets
+            .map(({ field: facetField }) => facetField)
+            .filter((facetField) => {
+                if (typeof facetField !== 'string') return false;
+                return (
+                    facetField === field ||
+                    facetField.endsWith(`.${field}`) ||
+                    field.endsWith(`.${facetField}`)
+                );
+            })
+            .sort((a, b) => {
+                if (a === field) return -1;
+                if (b === field) return 1;
+                return a.length - b.length;
+            });
+
+        return matchingFields.length > 0 ? matchingFields : [field];
+    };
+
+    return function(field, key){
+        const candidateFields = getCandidateFields(field);
+        for (let i = 0; i < candidateFields.length; i++) {
+            const candidateField = candidateFields[i];
+            const override = facets.find(
+                (f) => f.field === candidateField
+            )?.label_overrides?.[key];
+            if (typeof override !== 'undefined') {
+                return override;
+            }
+        }
+        return baseTransform(field, key);
+    };
+}
 
 
 /**
@@ -240,6 +281,7 @@ export class FacetCharts extends React.PureComponent {
         const cursorDetailActions = this.cursorDetailActions();
         const browseBaseParams = navigate.getBrowseBaseParams(null, mapping);
         const donorFilters = searchFilters.contextFiltersToExpSetFilters(context && context.filters, browseBaseParams);
+        const termLabelTransform = termTransformFxnWithChartAliases((context && context.facets) || []);
         let height = show === 'small' ? (mapping === 'all' ? 330 : 370) : 370;
         let width;
 
@@ -278,8 +320,8 @@ export class FacetCharts extends React.PureComponent {
         return (
             <div className={"facet-charts show-" + show} key="facet-charts">
                 <ChartDataController.Provider id={"barplot-" + mapping}>
-                    <BarPlot.UIControlsWrapper legend chartHeight={height} {...{ href, windowWidth, cursorDetailActions, donorFilters, mapping, subBarLayout }}>
-                        <BarPlot.Chart {...{ width, height, schemas, windowWidth, href, cursorDetailActions, context }} />
+                    <BarPlot.UIControlsWrapper legend chartHeight={height} {...{ href, windowWidth, cursorDetailActions, donorFilters, mapping, subBarLayout, termLabelTransform }}>
+                        <BarPlot.Chart {...{ width, height, schemas, windowWidth, href, cursorDetailActions, context, termLabelTransform }} />
                     </BarPlot.UIControlsWrapper>
                 </ChartDataController.Provider>
             </div>

--- a/src/encoded/static/components/viz/BarPlot/Chart.js
+++ b/src/encoded/static/components/viz/BarPlot/Chart.js
@@ -72,6 +72,8 @@ export function genChartBarDims(
                 }
                 const maxYForBar = parent ? parent.count : largestExpCountForATerm;
                 const barHeight = maxYForBar === 0 ? 0 : (termCount / maxYForBar) * outerDims.height;
+                // Prefer facet label_overrides when provided so bar labels and popovers
+                // match the browse facet list.
                 const defaultTermName = typeof termLabelTransform === 'function'
                     ? (termLabelTransform(fieldObj.field, termKey) || Schemas.Term.toName(fieldObj.field, termKey))
                     : Schemas.Term.toName(fieldObj.field, termKey);

--- a/src/encoded/static/components/viz/BarPlot/Chart.js
+++ b/src/encoded/static/components/viz/BarPlot/Chart.js
@@ -35,6 +35,7 @@ export function genChartBarDims(
     aggregateType           = 'files',
     useOnlyPopulatedFields  = false,
     fullHeightCount         = null,
+    termLabelTransform      = null,
     xAxisTermLabelMapper    = null
 ){
 
@@ -71,7 +72,9 @@ export function genChartBarDims(
                 }
                 const maxYForBar = parent ? parent.count : largestExpCountForATerm;
                 const barHeight = maxYForBar === 0 ? 0 : (termCount / maxYForBar) * outerDims.height;
-                const defaultTermName = Schemas.Term.toName(fieldObj.field, termKey);
+                const defaultTermName = typeof termLabelTransform === 'function'
+                    ? (termLabelTransform(fieldObj.field, termKey) || Schemas.Term.toName(fieldObj.field, termKey))
+                    : Schemas.Term.toName(fieldObj.field, termKey);
                 const axisLabel = (!parent && typeof xAxisTermLabelMapper === 'function')
                     ? (xAxisTermLabelMapper(termKey, defaultTermName) || defaultTermName)
                     : defaultTermName;
@@ -251,6 +254,7 @@ export class Chart extends React.PureComponent {
         'height'        : PropTypes.number,
         'width'         : PropTypes.number,
         'subBarLayout'  : PropTypes.oneOf(['stacked', 'grouped']),
+        'termLabelTransform': PropTypes.func,
         'xAxisTermLabelMapper': PropTypes.func,
         'useOnlyPopulatedFields' : PropTypes.bool,
         'showType'      : PropTypes.oneOf(['all', 'filtered', 'both']),
@@ -400,7 +404,7 @@ export class Chart extends React.PureComponent {
 
         const {
             width, height, showType, barplot_data_unfiltered, barplot_data_filtered, context,
-            aggregateType, useOnlyPopulatedFields, cursorDetailActions, href, schemas, mapping, subBarLayout, xAxisTermLabelMapper
+            aggregateType, useOnlyPopulatedFields, cursorDetailActions, href, schemas, mapping, subBarLayout, termLabelTransform, xAxisTermLabelMapper
         } = this.props;
 
         const topLevelField = (showType === 'all' ? barplot_data_unfiltered : barplot_data_filtered) || barplot_data_unfiltered;
@@ -415,6 +419,7 @@ export class Chart extends React.PureComponent {
             aggregateType,
             useOnlyPopulatedFields,
             null,
+            termLabelTransform,
             xAxisTermLabelMapper
         );
 

--- a/src/encoded/static/components/viz/BarPlot/UIControlsWrapper.js
+++ b/src/encoded/static/components/viz/BarPlot/UIControlsWrapper.js
@@ -262,7 +262,7 @@ export class UIControlsWrapper extends React.PureComponent {
      * @returns {React.Component} Cloned & extended props.children.
      */
     adjustedChildChart() {
-        const { children, barplot_data_fields } = this.props;
+        const { children, barplot_data_fields, termLabelTransform } = this.props;
         const { showState, aggregateType, tissueCategoryFilter } = this.state;
         const { barplot_data_unfiltered, barplot_data_filtered } = this.getBarplotDataForTissueCategory();
         const isTissueXAxis = Array.isArray(barplot_data_fields) && barplot_data_fields[0] === UIControlsWrapper.TISSUE_FIELD;
@@ -282,6 +282,7 @@ export class UIControlsWrapper extends React.PureComponent {
                 'aggregateType': aggregateType,
                 'barplot_data_unfiltered': barplot_data_unfiltered,
                 'barplot_data_filtered': barplot_data_filtered,
+                'termLabelTransform': termLabelTransform,
                 'xAxisTermLabelMapper': xAxisTermLabelMapper
             }
         ));
@@ -596,6 +597,7 @@ export class UIControlsWrapper extends React.PureComponent {
                                 height={legendContainerHeight}
                                 barplot_data_filtered={barplotDataFiltered}
                                 barplot_data_unfiltered={barplotDataUnfiltered}
+                                termLabelTransform={this.props.termLabelTransform}
                                 field={_.findWhere(availableFields_Subdivision, { 'field': barplot_data_fields[1] }) || null}
                                 showType={showState} />
                         </div>
@@ -668,14 +670,16 @@ export class AggregatedLegend extends React.Component {
     }
 
     getFieldForLegend() {
-        const { field, barplot_data_unfiltered, barplot_data_filtered, aggregateType, showType } = this.props;
+        const { field, barplot_data_unfiltered, barplot_data_filtered, aggregateType, showType, termLabelTransform } = this.props;
         return Legend.barPlotFieldDataToLegendFieldsData(
             AggregatedLegend.collectSubDivisionFieldTermCounts(
                 showType === 'all' ? barplot_data_unfiltered : barplot_data_filtered || barplot_data_unfiltered,
                 aggregateType || 'files',
                 field
             ),
-            function (term) { return typeof term[aggregateType] === 'number' ? -term[aggregateType] : 'term'; }
+            function (term) { return typeof term[aggregateType] === 'number' ? -term[aggregateType] : 'term'; },
+            undefined,
+            termLabelTransform
         );
     }
 

--- a/src/encoded/static/components/viz/BarPlot/UIControlsWrapper.js
+++ b/src/encoded/static/components/viz/BarPlot/UIControlsWrapper.js
@@ -597,6 +597,7 @@ export class UIControlsWrapper extends React.PureComponent {
                                 height={legendContainerHeight}
                                 barplot_data_filtered={barplotDataFiltered}
                                 barplot_data_unfiltered={barplotDataUnfiltered}
+                                // Keep legend labels aligned with chart bar/popover labels.
                                 termLabelTransform={this.props.termLabelTransform}
                                 field={_.findWhere(availableFields_Subdivision, { 'field': barplot_data_fields[1] }) || null}
                                 showType={showState} />

--- a/src/encoded/static/components/viz/ChartDetailCursor/ChartDetailCursor.js
+++ b/src/encoded/static/components/viz/ChartDetailCursor/ChartDetailCursor.js
@@ -175,7 +175,7 @@ class Body extends React.PureComponent {
                         <i className="term-color-indicator icon icon-circle fas"
                             style={{ color: leafNode.color || barplot_color_cycler.colorForNode(leafNode) }}
                         />
-                        <span>{Schemas.Term.toName(leafNode.field, leafNode.term)}</span>
+                        <span>{leafNode.name || Schemas.Term.toName(leafNode.field, leafNode.term)}</span>
                     </span>
                     <span className="col-4 text-end">
                         {this.primaryCount(leafNode)}

--- a/src/encoded/static/components/viz/components/Legend.js
+++ b/src/encoded/static/components/viz/components/Legend.js
@@ -192,15 +192,17 @@ export class Legend extends React.PureComponent {
     static Term = Term;
     static Field = Field;
 
-    static barPlotFieldDataToLegendFieldsData(field, sortBy = null, colorCycler = barplot_color_cycler){
+    static barPlotFieldDataToLegendFieldsData(field, sortBy = null, colorCycler = barplot_color_cycler, termLabelTransform = null){
         if (Array.isArray(field) && field.length > 0 && field[0] && typeof field[0] === 'object'){
-            return field.map(function(f){ return Legend.barPlotFieldDataToLegendFieldsData(f, sortBy); });
+            return field.map(function(f){ return Legend.barPlotFieldDataToLegendFieldsData(f, sortBy, colorCycler, termLabelTransform); });
         }
         if (!field) return null;
         var terms = _.pairs(field.terms).map(function(p){ // p[0] = term, p[1] = term counts
             return {
                 'field' : field.field,
-                'name' : Schemas.Term.toName(field.field, p[0]),
+                'name' : (typeof termLabelTransform === 'function'
+                    ? (termLabelTransform(field.field, p[0]) || Schemas.Term.toName(field.field, p[0]))
+                    : Schemas.Term.toName(field.field, p[0])),
                 'term' : p[0],
                 'color' : barplot_color_cycler.colorForNode({
                     'term' : p[0],

--- a/src/encoded/static/components/viz/components/Legend.js
+++ b/src/encoded/static/components/viz/components/Legend.js
@@ -200,6 +200,7 @@ export class Legend extends React.PureComponent {
         var terms = _.pairs(field.terms).map(function(p){ // p[0] = term, p[1] = term counts
             return {
                 'field' : field.field,
+                // Reuse the same term transform as the chart so legend terminology stays consistent.
                 'name' : (typeof termLabelTransform === 'function'
                     ? (termLabelTransform(field.field, p[0]) || Schemas.Term.toName(field.field, p[0]))
                     : Schemas.Term.toName(field.field, p[0])),


### PR DESCRIPTION
This pull request enhances the labeling of terms in bar plots and legends throughout the browse and visualization components. The main improvement is the introduction of a new `termLabelTransform` function that allows for dynamic, context-aware term labeling, including support for field aliases and label overrides. This function is now consistently passed through the relevant charting and legend components to ensure accurate and user-friendly labeling.

**Before:**
<img width="2404" height="849" alt="image" src="https://github.com/user-attachments/assets/5e36c8b5-6281-4485-b605-f6307f343d33" />

**After:**
<img width="2404" height="849" alt="image" src="https://github.com/user-attachments/assets/51ab3c87-7284-4d21-b518-6a702f331113" />

**Before:**
<img width="1029" height="849" alt="image" src="https://github.com/user-attachments/assets/430e0511-c932-41dd-8140-32672febb310" />


**After:**
<img width="1029" height="849" alt="image" src="https://github.com/user-attachments/assets/37ac2e4e-0095-475f-92e4-d374947cb352" />


**Dynamic Term Labeling Improvements:**

* Added `termTransformFxnWithChartAliases` in `FacetCharts.js`, which generates a label transformation function that supports field aliases and label overrides for chart terms. This ensures that term labels in charts reflect any customizations or overrides defined in the facet configuration.
* Updated `FacetCharts` to generate and pass the `termLabelTransform` function to both the `BarPlot.UIControlsWrapper` and `BarPlot.Chart` components, ensuring consistent term labeling throughout the chart UI. [[1]](diffhunk://#diff-da17ebfd02437c606ce9509dd5ace3d471f2a71d31908c2c4f9a255402829d7bR284) [[2]](diffhunk://#diff-da17ebfd02437c606ce9509dd5ace3d471f2a71d31908c2c4f9a255402829d7bL281-R324)

**Bar Plot and Legend Integration:**

* Modified `BarPlot.Chart` and its `genChartBarDims` helper to accept and utilize the `termLabelTransform` function for generating term labels, falling back to default names when no override is present. Prop types were updated accordingly. [[1]](diffhunk://#diff-077229e7d69d0b93738eb37664ae1a668764f8795ee79f16760c0dc53a0c014aR38) [[2]](diffhunk://#diff-077229e7d69d0b93738eb37664ae1a668764f8795ee79f16760c0dc53a0c014aL74-R77) [[3]](diffhunk://#diff-077229e7d69d0b93738eb37664ae1a668764f8795ee79f16760c0dc53a0c014aR257) [[4]](diffhunk://#diff-077229e7d69d0b93738eb37664ae1a668764f8795ee79f16760c0dc53a0c014aL403-R407) [[5]](diffhunk://#diff-077229e7d69d0b93738eb37664ae1a668764f8795ee79f16760c0dc53a0c014aR422)
* Updated `BarPlot.UIControlsWrapper` and its child components to accept and propagate the `termLabelTransform` prop, ensuring that the legend and all chart elements use the transformed labels. [[1]](diffhunk://#diff-a85f4a0231be16b6227e5baad2771143d40c077286c7017ae3527120362d593aL265-R265) [[2]](diffhunk://#diff-a85f4a0231be16b6227e5baad2771143d40c077286c7017ae3527120362d593aR285) [[3]](diffhunk://#diff-a85f4a0231be16b6227e5baad2771143d40c077286c7017ae3527120362d593aR600) [[4]](diffhunk://#diff-a85f4a0231be16b6227e5baad2771143d40c077286c7017ae3527120362d593aL671-R682)
* Enhanced the `Legend` component's `barPlotFieldDataToLegendFieldsData` method to use the `termLabelTransform` function for legend entries, supporting accurate and override-aware term display in legends.