### PR TITLE
Add phased analysis support and fix donor count logic

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,15 @@ Change Log
 ----------
 
 
+1.21.4
+======
+
+`PR 633: Add phased analysis support and fix donor count logic <https://github.com/smaht-dac/smaht-portal/pull/633>`_
+
+* Include phased analysis files in Variant Call Sets for the Production data matrix and donor-view data matrices.
+* Fix donor counts in Total Files summary popovers for DSA and Variant Call Sets.
+
+
 1.21.3
 ======
 

--- a/docs/public/data_matrix_comparison.jsx
+++ b/docs/public/data_matrix_comparison.jsx
@@ -58,7 +58,7 @@
             "matrixProps": {
                 "key": "data-matrix-production",
                 "query": {
-                    "url": "/data_matrix_aggregations/?type=File&sample_summary.studies=Production&dataset!=No+value&analysis_details=No+value&analysis_details=Filtered&status=open&status=open-early&status=open-network&status=protected&status=protected-early&status=protected-network&limit=all",
+                    "url": "/data_matrix_aggregations/?type=File&sample_summary.studies=Production&dataset!=No+value&analysis_details=No+value&analysis_details=Filtered&analysis_details=Phased&status=open&status=open-early&status=open-network&status=protected&status=protected-early&status=protected-network&limit=all",
                     "columnAggFields": [
                         "file_sets.libraries.assay.display_title",
                         "sequencing.sequencer.platform"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "1.21.3"
+version = "1.21.4"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/item-pages/ProtectedDonorView.js
+++ b/src/encoded/static/components/item-pages/ProtectedDonorView.js
@@ -218,7 +218,7 @@ const ProtectedDonorView = React.memo(function ProtectedDonorView(props) {
                                 <DataMatrix
                                     key="data-matrix-donor"
                                     query={{
-                                        url: `/data_matrix_aggregations/?type=File&${BROWSE_STATUS_FILTERS}&dataset!=No+value&analysis_details=No+value&analysis_details=Filtered&donors.display_title=${context.display_title}&limit=all`,
+                                        url: `/data_matrix_aggregations/?type=File&${BROWSE_STATUS_FILTERS}&dataset!=No+value&analysis_details=No+value&analysis_details=Filtered&analysis_details=Phased&donors.display_title=${context.display_title}&limit=all`,
                                         columnAggFields: [
                                             'file_sets.libraries.assay.display_title',
                                             'sequencing.sequencer.platform',

--- a/src/encoded/static/components/item-pages/PublicDonorView.js
+++ b/src/encoded/static/components/item-pages/PublicDonorView.js
@@ -306,7 +306,7 @@ const PublicDonorView = React.memo(function PublicDonorView(props) {
                                 <DataMatrix
                                     key="data-matrix-donor"
                                     query={{
-                                        url: `/data_matrix_aggregations/?type=File&${BROWSE_STATUS_FILTERS}&dataset!=No+value&analysis_details=No+value&analysis_details=Filtered&donors.display_title=${context.display_title}&limit=all`,
+                                        url: `/data_matrix_aggregations/?type=File&${BROWSE_STATUS_FILTERS}&dataset!=No+value&analysis_details=No+value&analysis_details=Filtered&analysis_details=Phased&donors.display_title=${context.display_title}&limit=all`,
                                         columnAggFields: [
                                             'file_sets.libraries.assay.display_title',
                                             'sequencing.sequencer.platform',

--- a/src/encoded/static/components/viz/Matrix/DataMatrix.js
+++ b/src/encoded/static/components/viz/Matrix/DataMatrix.js
@@ -1341,15 +1341,16 @@ DataMatrix.resultTransformedPostProcessFuncs = {
     "analysisDerivedColumns": function (data, groupingProperties, columnGrouping) {
         const dsaData = data.all.filter((row) => row['data_type'] === 'DSA' || row['data_type'] === 'Chain File' || row['data_type'] === 'Sequence Interval');
         const nonDsaData = data.all.filter((row) => row['data_type'] !== 'DSA' && row['data_type'] !== 'Chain File' && row['data_type'] !== 'Sequence Interval');
-        const snvData = nonDsaData.filter((row) => row['analysis_details'] === 'Filtered');
-        const nonDsaNonSnvData = nonDsaData.filter((row) => row['analysis_details'] !== 'Filtered');
+        const variantCallAnalysisDetails = ['Filtered', 'Phased'];
+        const variantCallSetData = nonDsaData.filter((row) => variantCallAnalysisDetails.includes(row['analysis_details']));
+        const nonDsaNonVariantCallSetData = nonDsaData.filter((row) => !variantCallAnalysisDetails.includes(row['analysis_details']));
 
         const transformedDsa = DataMatrix.transformDSA(nonDsaData, data.row_totals, dsaData, groupingProperties, columnGrouping);
-        const transformedSnv = DataMatrix.transformSNV(snvData, groupingProperties, columnGrouping);
+        const transformedSnv = DataMatrix.transformSNV(variantCallSetData, groupingProperties, columnGrouping);
 
         return {
             ...data,
-            all: nonDsaNonSnvData.concat(transformedDsa).concat(transformedSnv)
+            all: nonDsaNonVariantCallSetData.concat(transformedDsa).concat(transformedSnv)
         };
     }
 };
@@ -1366,7 +1367,7 @@ DataMatrix.browseFilteringTransformFuncs = {
             filteringProperties['data_type'] = [...(filteringProperties['data_type'] || []), 'DSA', 'Chain File', 'Sequence Interval'];
             delete filteringProperties[assayField];
         } else if (filteringProperties[assayField] === 'Variant Call Sets') {
-            filteringProperties['analysis_details'] = [...(filteringProperties['analysis_details'] || []), 'Filtered'];
+            filteringProperties['analysis_details'] = [...(filteringProperties['analysis_details'] || []), 'Filtered', 'Phased'];
             filteringProperties['data_type!'] = [...(filteringProperties['data_type!'] || []), 'DSA', 'Chain File', 'Sequence Interval'];
             delete filteringProperties[assayField];
         } else if (
@@ -1377,7 +1378,7 @@ DataMatrix.browseFilteringTransformFuncs = {
             // for overall summary (no assay filter) keep all data types.
             filteringProperties['data_type!'] = [...(filteringProperties['data_type!'] || []), 'DSA', 'Chain File', 'Sequence Interval'];
             if (isProductionStudy) {
-                filteringProperties['analysis_details!'] = [...(filteringProperties['analysis_details!'] || []), 'Filtered'];
+                filteringProperties['analysis_details!'] = [...(filteringProperties['analysis_details!'] || []), 'Filtered', 'Phased'];
             }
         }
         return filteringProperties;

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -2035,6 +2035,9 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                     const donorsCount = isPrimarySummaryBand
                         ? getPrimaryGroupCountFromGroupedRows(columnKey)
                         : (totalsCounts?.donors ?? totalsCounts?.donor_count ?? getPrimaryGroupCountFromGroupedRows(columnKey));
+                    const summaryCounts = isPrimarySummaryBand
+                        ? { donors: donorsCount }
+                        : { ...(totalsCounts || {}), donors: donorsCount };
                     const columnSummaryData = summaryCountFor === 'donors'
                         ? [{ counts: { donors: donorsCount } }]
                         : summaryCountFor === 'total_coverage'
@@ -2059,7 +2062,7 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                                     popoverPrimaryTitle={props.rowGroupKey}
                                     columnKey={columnKey}
                                     countFor={summaryCountFor}
-                                    summaryCounts={isPrimarySummaryBand ? { donors: donorsCount } : totalsCounts}
+                                    summaryCounts={summaryCounts}
                                     summaryRowType={summaryBlockType}
                                 />
                             </div>


### PR DESCRIPTION
TLDR; replaces [existing](https://data.smaht.org/browse/?analysis_details=No+value&analysis_details=Filtered&dataset%21=No+value&sample_summary.studies=Production&status=open&status=open-early&status=open-network&status=protected&status=protected-early&status=protected-network&type=File) query with [this](https://data.smaht.org/browse/?analysis_details=No+value&analysis_details=Filtered&analysis_details=Phased&dataset%21=No+value&sample_summary.studies=Production&status=open&status=open-early&status=open-network&status=protected&status=protected-early&status=protected-network&type=File) one to retrieve all files.

This pull request expands support for the "Phased" value in the `analysis_details` field across the data matrix and donor views. The main goal is to treat "Phased" similarly to "Filtered" when filtering, transforming, and displaying variant call set data. This ensures that data with "Phased" analysis details is included wherever "Filtered" data was previously handled.

Key changes include:

**Data matrix filtering and transformation:**

* Updated filtering logic in `DataMatrix.browseFilteringTransformFuncs` to include both "Filtered" and "Phased" as valid `analysis_details` for variant call sets, ensuring these are included in relevant queries and excluded from certain summaries as needed. [[1]](diffhunk://#diff-dbab0b6217046abae7507d5756a3a302d94ae8c6aa3e3b634bf127be61b55257L1369-R1370) [[2]](diffhunk://#diff-dbab0b6217046abae7507d5756a3a302d94ae8c6aa3e3b634bf127be61b55257L1380-R1381)
* Modified the transformation logic in `DataMatrix.resultTransformedPostProcessFuncs` to process both "Filtered" and "Phased" variant call sets together, so that downstream visualizations and data aggregations handle both types uniformly.

**Query updates in donor and matrix views:**

* Added `analysis_details=Phased` to the data matrix queries in `PublicDonorView.js`, `ProtectedDonorView.js`, and `data_matrix_comparison.jsx` to ensure "Phased" data is fetched and displayed alongside "Filtered" data. [[1]](diffhunk://#diff-f4e2784f9acb311327196bae5419e6b48fcdd4ef53411b078194ca413a9d5e79L309-R309) [[2]](diffhunk://#diff-133cf42fff9eeaf93d8497ed8691e25ad10c3f335a30377a5ebf93b4f52fd8f2L221-R221) [[3]](diffhunk://#diff-d3a364fb07ad9c358c60ca8e7f99802f679477da79d8766b17f123d8852f6834L61-R61)

**Visualization improvements:**

* Improved summary count handling in `StackedBlockGroupedRow` of `StackedBlockVisual.js` by introducing a `summaryCounts` object that consistently includes donor counts, ensuring accurate display in both primary and non-primary summary bands. [[1]](diffhunk://#diff-34390d0bfa3a495abf6e04e653372f5f62f5ae874e74dcebd193cb1c0d38bfbdR2038-R2040) [[2]](diffhunk://#diff-34390d0bfa3a495abf6e04e653372f5f62f5ae874e74dcebd193cb1c0d38bfbdL2062-R2065)