### PR TITLE
Bump SPC to 0.1.97

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@ smaht-portal
 Change Log
 ----------
 
+
+1.22.2
+======
+
+`PR 638: Bump SPC to 0.1.97 <https://github.com/smaht-dac/smaht-portal/pull/638>`_
+
+* Bump @hms-dbmi-bgm/shared-portal-components from 0.1.96 to 0.1.97 that basically fixes data fetch for 20+ selected facet terms.
+
+
 1.22.1
 ======
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@gmod/tabix": "^1.5.3",
         "@gmod/vcf": "^5.0.6",
         "@hms-dbmi-bgm/react-workflow-viz": "0.1.11",
-        "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.96",
+        "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.97",
         "@reduxjs/toolkit": "^2.2.6",
         "auth0-lock": "^12.5.1",
         "d3": "^7.8.5",
@@ -2497,8 +2497,8 @@
       }
     },
     "node_modules/@hms-dbmi-bgm/shared-portal-components": {
-      "version": "0.1.96",
-      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#ce88a14a651f7c12274bf0b611668bf8cc49a14a",
+      "version": "0.1.97",
+      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#d17e5904294ba0a4a29bb0eec31ec907fc8d3ec1",
       "license": "MIT",
       "dependencies": {
         "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@gmod/tabix": "^1.5.3",
     "@gmod/vcf": "^5.0.6",
     "@hms-dbmi-bgm/react-workflow-viz": "0.1.11",
-    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.96",
+    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.97",
     "@reduxjs/toolkit": "^2.2.6",
     "auth0-lock": "^12.5.1",
     "d3": "^7.8.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "1.22.1"
+version = "1.22.2"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
This pull request makes a minor update to the dependency version of `@hms-dbmi-bgm/shared-portal-components` in the `package.json` file, upgrading it from version `0.1.96` to `0.1.97` that  basically fixes data fetch for >20 selected facet terms.