### PR TITLE
260406 ajs add enums to libprep

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Change Log
 1.22.4
 ======
 
-`PR : fix: update enums in library_preparation <https://github.com/smaht-dac/smaht-portal/pull/>`_
+`PR 645: fix: update enums in library_preparation <https://github.com/smaht-dac/smaht-portal/pull/645>`_
 
 * Add to enum in library_preparation schema for adapter_inclusion_method and fragmentation_method to support STORM-seq libraries 
 1.22.3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ smaht-portal
 Change Log
 ----------
 
+1.22.4
+======
+
+`PR : fix: update enums in library_preparation <https://github.com/smaht-dac/smaht-portal/pull/>`_
+
+* Add to enum in library_preparation schema for adapter_inclusion_method and fragmentation_method to support STORM-seq libraries 
 1.22.3
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "1.22.3"
+version = "1.22.4"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/schemas/library_preparation.json
+++ b/src/encoded/schemas/library_preparation.json
@@ -69,6 +69,7 @@
                 "type": "string",
                 "enum": [
                     "Ligation",
+                    "PCR",
                     "Tagmentation",
                     "Not Applicable"
                 ]
@@ -100,6 +101,7 @@
             "items": {
                 "type": "string",
                 "enum": [
+                    "Heat",
                     "Mechanical",
                     "Sonication",
                     "Restriction Enzyme",


### PR DESCRIPTION
To support STORM-seq:

in library_preparation schema add to enums:

Add 'Heat' to fragmentation_method
Add 'PCR' to adapter_incusion_method