### PR TITLE
fix: move alert in registration modal to bottom of form

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ smaht-portal
 Change Log
 ----------
 
+1.23.1
+======
+
+`PR 652: fix: move alert in registration modal to bottom of form <https://github.com/smaht-dac/smaht-portal/pull/652>`_
+
+* Move the blocked email error registration alert to the bottom of the form
+
+
 1.23.0
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "1.23.0"
+version = "1.23.1"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/forms/UserRegistrationForm.js
+++ b/src/encoded/static/components/forms/UserRegistrationForm.js
@@ -360,8 +360,6 @@ export default class UserRegistrationForm extends React.PureComponent {
 
         return (
             <div className="user-registration-form-container position-relative">
-                {errorIndicator}
-
                 {heading}
 
                 <div className={isConsortiumMember === true ? null : "mb-3"}>
@@ -513,6 +511,13 @@ export default class UserRegistrationForm extends React.PureComponent {
                                 </div>
                             </div>
                         </div>
+
+                        <div className="row">
+                            <div className="col-12">
+                                {errorIndicator}
+                            </div>
+                        </div>
+
 
                         <div className="row mt-15 recaptcha-privacy-row">
                             <div className="col-12 col-lg-5">

--- a/src/encoded/static/components/forms/UserRegistrationForm.js
+++ b/src/encoded/static/components/forms/UserRegistrationForm.js
@@ -340,7 +340,7 @@ export default class UserRegistrationForm extends React.PureComponent {
             );
         } else if (registrationStatus === 'restricted-email') {
             errorIndicator = (
-                <div className="alert alert-warning d-flex align-items-center self-registration-alert restricted-email" role="alert">
+                <div className="alert alert-warning d-flex align-items-center self-registration-alert restricted-email mb-1" role="alert">
                     <i className="fas icon icon-ban me-2 self-registration-alert-icon"></i>
                     <div>
                         <span>
@@ -512,13 +512,6 @@ export default class UserRegistrationForm extends React.PureComponent {
                             </div>
                         </div>
 
-                        <div className="row">
-                            <div className="col-12">
-                                {errorIndicator}
-                            </div>
-                        </div>
-
-
                         <div className="row mt-15 recaptcha-privacy-row">
                             <div className="col-12 col-lg-5">
                                 <div
@@ -551,6 +544,12 @@ export default class UserRegistrationForm extends React.PureComponent {
                                     improve the quality of user experience and/or
                                     security assurance purposes.
                                 </p>
+                            </div>
+                        </div>
+
+                        <div className="row">
+                            <div className="col-12">
+                                {errorIndicator}
                             </div>
                         </div>
 


### PR DESCRIPTION
[Trello Ticket 859](https://trello.com/c/Qw5i6xDk/859-move-registration-modal-restricted-email-alert-to-bottom)
* Move the blocked email error registration alert to the bottom of the form