### PR TITLE
Fix Data Matrix count inconsistencies (DSA dedup + stable totals + Element AVITI mapping)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ smaht-portal
 Change Log
 ----------
 
+1.26.0
+======
+
+`PR 662: Fix Data Matrix count inconsistencies (DSA dedup + stable totals + Element AVITI mapping) <https://github.com/smaht-dac/smaht-portal/pull/662>`_
+
+* Refactor data matrix file count logic to deduplicate DSA-associated files, ensure stable totals across views, and map Element AVITI files to the correct assay category for accurate counting in the data matrix.
+
+
 1.25.0
 ======
 
@@ -16,6 +24,7 @@ Change Log
 * For ExternalOutputFiles that don't have `file_sets` and do have `derived_from`, if the linked `derived_from` file has file_sets get tissue sample info from there, otherwise if the output MWFR of the `derived_from` file has `file_sets` get tissue sample info from there, otherwise check the input files of the output MWFR to get the tissue sample info. If none of these have `file_sets`, use "X"
 * Fix DSA filenames to use directly linked `file_sets` on SupplementaryFile, rather than grabbing from `derived_from`
 * Update the release script to release ExternalQualityMetrics items
+
 
 1.24.9
 ======

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "1.25.0"
+version = "1.26.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/viz/Matrix/DataMatrix.js
+++ b/src/encoded/static/components/viz/Matrix/DataMatrix.js
@@ -1642,7 +1642,8 @@ export default class DataMatrix extends React.PureComponent {
                     if (typeof transformFn !== 'function') return filteringProperties;
                     return transformFn(filteringProperties, blockType, {
                         matrixMode,
-                        donorTissueAssay
+                        donorTissueAssay,
+                        valueChangeMap
                     });
                 })
                 : null
@@ -1966,6 +1967,7 @@ DataMatrix.resultTransformedPostProcessFuncs = {
 DataMatrix.browseFilteringTransformFuncs = {
     "analysisDerivedColumns": function (filteringProperties, blockType, matrixContext = null) {
         const assayField = 'assays.display_title';
+        const platformField = 'sequencers.platform';
         const isDonorTissueMode = matrixContext?.matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE;
         const selectedDonorTissueAssay = matrixContext?.donorTissueAssay;
         const hasSelectedDonorTissueAssay = isDonorTissueMode &&
@@ -1975,7 +1977,23 @@ DataMatrix.browseFilteringTransformFuncs = {
         // Donor x Tissue regular cells might not include assay in URL params.
         // Inject currently selected assay to keep browse links scoped correctly.
         if (hasSelectedDonorTissueAssay && typeof filteringProperties[assayField] === 'undefined') {
-            filteringProperties[assayField] = selectedDonorTissueAssay;
+            const assayValueMap = matrixContext?.valueChangeMap?.assay || {};
+            const rawAssayCandidates = _.filter(_.keys(assayValueMap), (rawKey) => assayValueMap[rawKey] === selectedDonorTissueAssay);
+            const rawSelectedAssay = rawAssayCandidates[0] || selectedDonorTissueAssay;
+            const delim = ' - ';
+            const splitIdx = typeof rawSelectedAssay === 'string' ? rawSelectedAssay.lastIndexOf(delim) : -1;
+
+            // If selected assay contains platform suffix (e.g. "WGS - ONT"), split into raw assay + platform.
+            if (splitIdx > 0) {
+                const rawAssay = rawSelectedAssay.slice(0, splitIdx);
+                const rawPlatform = rawSelectedAssay.slice(splitIdx + delim.length);
+                filteringProperties[assayField] = rawAssay;
+                if (rawPlatform) {
+                    filteringProperties[platformField] = rawPlatform;
+                }
+            } else {
+                filteringProperties[assayField] = rawSelectedAssay;
+            }
         }
 
         const assayFilterRaw = filteringProperties[assayField];

--- a/src/encoded/static/components/viz/Matrix/DataMatrix.js
+++ b/src/encoded/static/components/viz/Matrix/DataMatrix.js
@@ -871,12 +871,16 @@ export default class DataMatrix extends React.PureComponent {
                             matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE
                         );
                     }
-                    // Keep assay as scalar to avoid "array assay" rows silently missing
-                    // from dropdown filtering and summary calculations.
-                    cloned.assay = DataMatrix.normalizeAssayToSingleValue(cloned.assay);
-                    cloned = DataMatrix.normalizeMissingAssayBucket(cloned, 'assay');
-                    if (typeof cloned.assay === 'string') {
-                        cloned._derivedAssayFamily = cloned.assay;
+                    // These safeguards are donor x tissue specific.
+                    // Applying them globally can change donor/cell-line assay rollups.
+                    if (matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE) {
+                        // Keep assay as scalar to avoid "array assay" rows silently missing
+                        // from dropdown filtering and summary calculations.
+                        cloned.assay = DataMatrix.normalizeAssayToSingleValue(cloned.assay);
+                        cloned = DataMatrix.normalizeMissingAssayBucket(cloned, 'assay');
+                        if (typeof cloned.assay === 'string') {
+                            cloned._derivedAssayFamily = cloned.assay;
+                        }
                     }
                     if (valueChangeMap) {
                         _.forEach(_.pairs(valueChangeMap), ([field, changeMap]) => {

--- a/src/encoded/static/components/viz/Matrix/DataMatrix.js
+++ b/src/encoded/static/components/viz/Matrix/DataMatrix.js
@@ -640,10 +640,16 @@ export default class DataMatrix extends React.PureComponent {
         // This avoids overcount when row_totals is exploded by additional dimensions
         // (e.g. donor+tissue with assay/platform/data_type expansions).
         const maxDsaFilesByGroup = {};
+        const dsaFilesByGroupAndType = {};
         for (const row of dsaData) {
             const key = makeGroupKey(row);
             const files = getFilesCount(row);
             maxDsaFilesByGroup[key] = Math.max(maxDsaFilesByGroup[key] || 0, files);
+            const dataType = String(row?.data_type || 'No value');
+            if (!dsaFilesByGroupAndType[key]) {
+                dsaFilesByGroupAndType[key] = {};
+            }
+            dsaFilesByGroupAndType[key][dataType] = Math.max(dsaFilesByGroupAndType[key][dataType] || 0, files);
         }
 
         // 4) First-pass transform of dsa entries
@@ -651,8 +657,9 @@ export default class DataMatrix extends React.PureComponent {
             const key = makeGroupKey(row);
             const diffFiles = diffFilesByGroup[key];
             const maxDsaFiles = maxDsaFilesByGroup[key];
+            const dsaByTypeTotal = _.reduce(dsaFilesByGroupAndType[key] || {}, (sum, filesByType) => sum + (Number(filesByType) || 0), 0);
             const resolvedFiles = dsaCountStrategy === 'max_dsa_row'
-                ? (typeof maxDsaFiles === 'number' ? maxDsaFiles : getFilesCount(row))
+                ? (dsaByTypeTotal || (typeof maxDsaFiles === 'number' ? maxDsaFiles : getFilesCount(row)))
                 : (typeof diffFiles === 'number' ? diffFiles : getFilesCount(row));
 
             return {
@@ -757,6 +764,58 @@ export default class DataMatrix extends React.PureComponent {
         });
     }
 
+    /**
+     * Some backend rows can arrive with assay label missing ("No value").
+     * In donor x tissue view, leaving these rows as-is creates hidden buckets
+     * that are counted in "All" but are not selectable in assay dropdown.
+     *
+     * We remap those rows into visible logical assay buckets:
+     * - DSA-like data types -> "DSA"
+     * - Variant-call-like rows -> "Variant Call Sets"
+     */
+    static normalizeMissingAssayBucket(row = null, derivedField = 'assay') {
+        if (!row || typeof row !== 'object') return row;
+        const assayValue = row[derivedField];
+        const isMissingAssay = !assayValue || assayValue === 'No value' || assayValue === 'No value - No value';
+        if (!isMissingAssay) return row;
+
+        const dataType = row?.data_type;
+        const analysisDetails = row?.analysis_details;
+        const dsaDataTypes = new Set(['DSA', 'Chain File', 'Sequence Interval']);
+        const isVariantLikeDataType = typeof dataType === 'string' && /(SNV|Indel)/i.test(dataType);
+        const isVariantLikeAnalysis = analysisDetails === 'Filtered' || analysisDetails === 'Phased';
+
+        if (dsaDataTypes.has(dataType)) {
+            return { ...row, [derivedField]: 'DSA' };
+        }
+
+        if (isVariantLikeDataType || isVariantLikeAnalysis) {
+            return { ...row, [derivedField]: 'Variant Call Sets' };
+        }
+
+        return row;
+    }
+
+    /**
+     * Ensure assay value is a single comparable string.
+     *
+     * Why:
+     * - During transform/merge, assay can become an array.
+     * - Filtering logic and dropdown matching require a scalar string.
+     *
+     * Rule:
+     * - If array => pick first non-empty string.
+     * - If string => keep as-is.
+     * - Otherwise => null.
+     */
+    static normalizeAssayToSingleValue(assayValue) {
+        if (Array.isArray(assayValue)) {
+            const firstValid = _.find(assayValue, (v) => typeof v === 'string' && v.trim() !== '');
+            return firstValid || null;
+        }
+        return typeof assayValue === 'string' ? assayValue : null;
+    }
+
     loadSearchQueryResults() {
         const requestId = ++this.latestLoadRequestId;
         const {
@@ -801,7 +860,7 @@ export default class DataMatrix extends React.PureComponent {
                 if (resultItemPostProcessFuncKey && typeof DataMatrix.resultItemPostProcessFuncs[resultItemPostProcessFuncKey] === 'function') {
                     cloned = DataMatrix.resultItemPostProcessFuncs[resultItemPostProcessFuncKey](cloned);
                 }
-                if (cloned.counts && cloned.counts.files && cloned.counts.files > 0) {
+                if (cloned.counts && Number(cloned.counts.files) > 0) {
                     if (typeof cloned.assay === 'string') {
                         cloned._derivedAssayFamily = (valueChangeMap?.assay || {})[cloned.assay] || cloned.assay;
                     }
@@ -811,6 +870,13 @@ export default class DataMatrix extends React.PureComponent {
                             valueChangeMap,
                             matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE
                         );
+                    }
+                    // Keep assay as scalar to avoid "array assay" rows silently missing
+                    // from dropdown filtering and summary calculations.
+                    cloned.assay = DataMatrix.normalizeAssayToSingleValue(cloned.assay);
+                    cloned = DataMatrix.normalizeMissingAssayBucket(cloned, 'assay');
+                    if (typeof cloned.assay === 'string') {
+                        cloned._derivedAssayFamily = cloned.assay;
                     }
                     if (valueChangeMap) {
                         _.forEach(_.pairs(valueChangeMap), ([field, changeMap]) => {
@@ -1084,10 +1150,19 @@ export default class DataMatrix extends React.PureComponent {
     getDonorTissueAssayOptions(availableAssays = null) {
         const configuredDisplayValues = this.props.donorTissueAssayOptions || [];
         const hasAvailableAssays = Array.isArray(availableAssays);
-        const assayDisplayValues = (hasAvailableAssays
+        // Dropdown should never hide meaningful rows behind "No value".
+        // Map missing assay labels to a visible virtual bucket.
+        const normalizeAssayOption = (displayValue) => {
+            if (!displayValue || displayValue === 'No value' || displayValue === 'No value - No value') {
+                return 'Variant Call Sets';
+            }
+            return displayValue;
+        };
+        const assayDisplayValues = _.uniq((hasAvailableAssays
             ? _.uniq(availableAssays)
             : _.uniq(configuredDisplayValues.map((displayValue) => this.props.valueChangeMap?.assay?.[displayValue] || displayValue)))
-            .filter((displayValue) => displayValue && displayValue !== 'No value' && displayValue !== 'No value - No value');
+            .map(normalizeAssayOption))
+            .filter((displayValue) => !!displayValue);
 
         return [
             { label: DataMatrix.DONOR_TISSUE_ALL_ASSAYS, value: DataMatrix.DONOR_TISSUE_ALL_ASSAYS },
@@ -1108,7 +1183,11 @@ export default class DataMatrix extends React.PureComponent {
         }
         const filteredAll = (!donorTissueAssay || donorTissueAssay === DataMatrix.DONOR_TISSUE_ALL_ASSAYS)
             ? (results.all || [])
-            : (results.all || []).filter((row) => row.assay === donorTissueAssay);
+            : (results.all || []).filter((row) => {
+                // Defensive normalization in case any row still carries array assay.
+                const assayValue = DataMatrix.normalizeAssayToSingleValue(row?.assay);
+                return assayValue === donorTissueAssay;
+            });
         const aggregateCounts = (rows = []) => {
             const donorValues = _.chain(rows)
                 .map((row) => row?.donor)
@@ -1191,12 +1270,27 @@ export default class DataMatrix extends React.PureComponent {
             }, {})
             : null;
 
+        // In "All", keep donor x tissue overall aligned to visible assay buckets.
+        // In filtered mode, aggregate from the already-filtered matrix rows.
+        const backendOverallCounts = this.state?.overallCounts || null;
+        const visibleAssayOptions = this.getDonorTissueAssayOptions(this.state?.availableDonorTissueAssays || [])
+            .map(({ value }) => value)
+            .filter((value) => value && value !== DataMatrix.DONOR_TISSUE_ALL_ASSAYS);
+        const visibleAssaySet = new Set(visibleAssayOptions);
+        const visibleAllRows = (results.all || []).filter((row) => {
+            const assayValue = DataMatrix.normalizeAssayToSingleValue(row?.assay);
+            return assayValue && visibleAssaySet.has(assayValue);
+        });
+        const effectiveOverallCounts = hasAssayFilter
+            ? aggregateCounts(filteredAll)
+            : (aggregateCounts(visibleAllRows) || backendOverallCounts || aggregateCounts(filteredAll));
+
         return {
             ...results,
             all: filteredAll,
             row_totals: aggregateRowsByKeys(filteredAll, effectiveRowTotalKeys),
             column_totals: effectiveColumnTotals,
-            overallCounts: aggregateCounts(filteredAll),
+            overallCounts: effectiveOverallCounts,
             rowSummaryCountsByGroup: donorSummaryCounts ? { donor: donorSummaryCounts } : null
         };
     }
@@ -1497,8 +1591,11 @@ export default class DataMatrix extends React.PureComponent {
         const effectiveYAxisLabel = isTissueMatrixCount ? 'Tissue' : yAxisLabel;
         const effectiveResults = this.getDerivedDonorTissueResults(this.state[resultKey]);
         const effectiveOverallCounts = effectiveResults?.overallCounts || overallCounts;
+        // Row-summary overrides are useful for donor/assay benchmarking rollups,
+        // but in donor/tissue mode they can conflict with assay-dropdown totals.
+        // Keep donor/tissue overall driven by effective overallCounts only.
         const effectiveRowSummaryCountsByGroup = matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE
-            ? (effectiveResults?.rowSummaryCountsByGroup || null)
+            ? null
             : (rowSummaryCountsByGroup || null);
         // In donor/tissue mode, assay dropdown refines matrix rendering only.
         // Keep header included-properties count anchored to unfiltered backend context.

--- a/src/encoded/static/components/viz/Matrix/DataMatrix.js
+++ b/src/encoded/static/components/viz/Matrix/DataMatrix.js
@@ -597,7 +597,15 @@ export default class DataMatrix extends React.PureComponent {
             - counts.files: take from any row (they should all be equal after step 2)
             - other fields: distinct values; single => scalar, multiple => array
     */
-    static transformDSA(nonDsaData, row_totals, dsaData, groupingProperties, derivedField = 'assay', useAssayFamilyCount = false) {
+    static transformDSA(
+        nonDsaData,
+        row_totals,
+        dsaData,
+        groupingProperties,
+        derivedField = 'assay',
+        useAssayFamilyCount = false,
+        dsaCountStrategy = 'diff'
+    ) {
         const getFilesCount = (row) => Number(row && row.counts && row.counts.files) || 0;
 
         // Helper: build a grouping key like "COLO829BL||No value"
@@ -628,17 +636,31 @@ export default class DataMatrix extends React.PureComponent {
             diffFilesByGroup[key] = rowTotals - allTotals;
         });
 
+        // Build a per-group fallback from raw DSA rows.
+        // This avoids overcount when row_totals is exploded by additional dimensions
+        // (e.g. donor+tissue with assay/platform/data_type expansions).
+        const maxDsaFilesByGroup = {};
+        for (const row of dsaData) {
+            const key = makeGroupKey(row);
+            const files = getFilesCount(row);
+            maxDsaFilesByGroup[key] = Math.max(maxDsaFilesByGroup[key] || 0, files);
+        }
+
         // 4) First-pass transform of dsa entries
         const newDsa = dsaData.map((row) => {
             const key = makeGroupKey(row);
             const diffFiles = diffFilesByGroup[key];
+            const maxDsaFiles = maxDsaFilesByGroup[key];
+            const resolvedFiles = dsaCountStrategy === 'max_dsa_row'
+                ? (typeof maxDsaFiles === 'number' ? maxDsaFiles : getFilesCount(row))
+                : (typeof diffFiles === 'number' ? diffFiles : getFilesCount(row));
 
             return {
                 ...row,
                 // If we have a diff for this group, use it; otherwise keep original value
                 counts: {
                     ...(row.counts || {}),
-                    files: typeof diffFiles === 'number' ? diffFiles : getFilesCount(row),
+                    files: resolvedFiles,
                 },
                 [derivedField]: 'DSA',
             };
@@ -861,13 +883,13 @@ export default class DataMatrix extends React.PureComponent {
             updatedState['rowSummaryCountsByGroup'] = donorSummaryCounts ? { donor: donorSummaryCounts } : null;
             const availableDonorTissueAssays = _.uniq(_.compact(_.map(transformedData.all, (r) => r.assay)));
             updatedState['availableDonorTissueAssays'] = availableDonorTissueAssays;
-            // sum files in transformedData array
-            let totalFiles = 0;
-            _.forEach(transformedData.row_totals, (r) => {
-                if (r.counts && typeof r.counts.files === 'number') {
-                    totalFiles += r.counts.files;
-                }
-            });
+            // Keep top-level included-properties count aligned with backend search context.
+            // Note: backend may return numeric-looking strings; coerce before deciding fallback.
+            // Fallback to aggregated rows only if backend count is truly unavailable.
+            const backendTotalFiles = Number(result?.counts?.files);
+            const totalFiles = Number.isFinite(backendTotalFiles)
+                ? backendTotalFiles
+                : _.reduce(transformedData.all, (sum, r) => sum + (Number(r?.counts?.files) || 0), 0);
             updatedState['totalFiles'] = totalFiles;
 
             //extend existing rowGroupsExtended from transformed data using mapping fields
@@ -1475,9 +1497,12 @@ export default class DataMatrix extends React.PureComponent {
         const effectiveYAxisLabel = isTissueMatrixCount ? 'Tissue' : yAxisLabel;
         const effectiveResults = this.getDerivedDonorTissueResults(this.state[resultKey]);
         const effectiveOverallCounts = effectiveResults?.overallCounts || overallCounts;
-        const effectiveTotalFiles = matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE
-            ? (effectiveOverallCounts?.files ?? totalFiles)
-            : totalFiles;
+        const effectiveRowSummaryCountsByGroup = matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE
+            ? (effectiveResults?.rowSummaryCountsByGroup || null)
+            : (rowSummaryCountsByGroup || null);
+        // In donor/tissue mode, assay dropdown refines matrix rendering only.
+        // Keep header included-properties count anchored to unfiltered backend context.
+        const effectiveTotalFiles = totalFiles;
 
         const isLoading =
             // eslint-disable-next-line react/destructuring-assignment
@@ -1506,8 +1531,9 @@ export default class DataMatrix extends React.PureComponent {
                 : true,
             countFor,
             overallCounts: effectiveOverallCounts,
-            // Prefer state-level overrides from the latest payload; fallback to derived-mode overrides.
-            rowSummaryCountsByGroup: rowSummaryCountsByGroup || effectiveResults?.rowSummaryCountsByGroup || null,
+            // Use mode-appropriate summary overrides: donor/tissue mode may null these out
+            // under assay filter to avoid inconsistencies with facet-driven contexts.
+            rowSummaryCountsByGroup: effectiveRowSummaryCountsByGroup,
             ...(countFor === 'total_coverage' ? { blockWidth: 60, blockHorizontalExtend: 10 } : {}),
             browseFilteringTransformFunc: browseFilteringTransformFuncKey ? DataMatrix.browseFilteringTransformFuncs[browseFilteringTransformFuncKey] : null
         };
@@ -1812,7 +1838,12 @@ DataMatrix.resultTransformedPostProcessFuncs = {
             dsaData,
             derivedGroupingProperties,
             derivedLabelField,
-            columnGrouping !== 'assay'
+            // Keep DSA in "file count" mode for all matrix modes.
+            // Assay-family counting inflated donor x tissue tuples (e.g. SMHT023/3AC => 3 instead of 1).
+            false,
+            // For non-assay grouping (e.g. Donor x Tissue), use max raw DSA row count per tuple
+            // instead of row_totals diff, which can be exploded by assay/platform dimensions.
+            columnGrouping === 'assay' ? 'diff' : 'max_dsa_row'
         );
         const transformedSnv = DataMatrix.transformSNV(variantCallSetData, derivedGroupingProperties, derivedLabelField);
 

--- a/src/encoded/static/components/viz/Matrix/DataMatrix.js
+++ b/src/encoded/static/components/viz/Matrix/DataMatrix.js
@@ -92,7 +92,7 @@ export default class DataMatrix extends React.PureComponent {
     };
     static DEFAULT_COLUMN_GROUPS = {
         "Bulk WGS": {
-            "values": ['WGS - Illumina', 'WGS - PacBio', 'Fiber-Seq', 'WGS - Standard ONT', 'WGS - UltraLong ONT'],
+            "values": ['WGS - Illumina', 'WGS - PacBio', 'WGS - Standard ONT', 'WGS - UltraLong ONT', 'WGS - Element AVITI', 'Fiber-Seq'],
             "backgroundColor": "#e04141",
             "textColor": "#ffffff",
             "shortName": "WGS"
@@ -197,6 +197,7 @@ export default class DataMatrix extends React.PureComponent {
                 "Single-cell PTA WGS - Illumina": "PTA-amplified WGS",
                 "TEnCATS - ONT": "TEnCATS",
                 "WGS - ONT": "WGS - Standard ONT",
+                "WGS - Element": "WGS - Element AVITI",
                 "Ultra-Long WGS - ONT": "WGS - UltraLong ONT",
                 "HiDEF-seq - Illumina": "HiDEF-seq",
                 "HiDEF-seq - PacBio": "HiDEF-seq",
@@ -845,6 +846,19 @@ export default class DataMatrix extends React.PureComponent {
             updatedState['overallCounts'] = result.counts || null;
             updatedState['facetsForPanel'] = result.facets || [];
             updatedState['facetFiltersForPanel'] = result.filters || [];
+            // Build generic row-summary overrides from backend facet counts.
+            // This keeps visual components dimension-agnostic (not donor-specific).
+            const donorFacet = _.findWhere(result.facets || [], { field: 'donors.display_title' });
+            const donorValueMap = valueChangeMap?.donor || {};
+            const donorSummaryCounts = donorFacet && Array.isArray(donorFacet.terms)
+                ? _.reduce(donorFacet.terms, (memo, term) => {
+                    const key = donorValueMap[term?.key] || term?.key;
+                    if (!key || key === 'No value') return memo;
+                    memo[key] = { files: Number(term?.doc_count) || 0 };
+                    return memo;
+                }, {})
+                : null;
+            updatedState['rowSummaryCountsByGroup'] = donorSummaryCounts ? { donor: donorSummaryCounts } : null;
             const availableDonorTissueAssays = _.uniq(_.compact(_.map(transformedData.all, (r) => r.assay)));
             updatedState['availableDonorTissueAssays'] = availableDonorTissueAssays;
             // sum files in transformedData array
@@ -1140,13 +1154,28 @@ export default class DataMatrix extends React.PureComponent {
                     counts: { ...zeroCounts }
                 };
             });
+        const facetsForPanel = this.state?.facetsForPanel || [];
+        const donorFacet = _.findWhere(facetsForPanel, { field: 'donors.display_title' });
+        const donorValueMap = this.props?.valueChangeMap?.donor || {};
+        const hasAssayFilter = donorTissueAssay && donorTissueAssay !== DataMatrix.DONOR_TISSUE_ALL_ASSAYS;
+        // In donor-tissue mode with assay filtering, facet counts no longer represent global donor totals,
+        // so disable donor summary overrides in that case.
+        const donorSummaryCounts = !hasAssayFilter && donorFacet && Array.isArray(donorFacet.terms)
+            ? _.reduce(donorFacet.terms, (memo, term) => {
+                const key = donorValueMap[term?.key] || term?.key;
+                if (!key || key === 'No value') return memo;
+                memo[key] = { files: Number(term?.doc_count) || 0 };
+                return memo;
+            }, {})
+            : null;
 
         return {
             ...results,
             all: filteredAll,
             row_totals: aggregateRowsByKeys(filteredAll, effectiveRowTotalKeys),
             column_totals: effectiveColumnTotals,
-            overallCounts: aggregateCounts(filteredAll)
+            overallCounts: aggregateCounts(filteredAll),
+            rowSummaryCountsByGroup: donorSummaryCounts ? { donor: donorSummaryCounts } : null
         };
     }
 
@@ -1436,7 +1465,7 @@ export default class DataMatrix extends React.PureComponent {
             colorRanges, xAxisLabel, yAxisLabel, showAxisLabels, showColumnSummary,
             colorRangeBaseColor, colorRangeSegments, colorRangeSegmentStep, summaryBackgroundColor,
             defaultOpen = false, totalFiles, countFor, overallCounts, facetsForPanel, facetFiltersForPanel, isFetching,
-            matrixMode, donorTissueAssay, availableDonorTissueAssays
+            matrixMode, donorTissueAssay, availableDonorTissueAssays, rowSummaryCountsByGroup
         } = this.state;
 
         const resultKey = "_results";
@@ -1477,6 +1506,8 @@ export default class DataMatrix extends React.PureComponent {
                 : true,
             countFor,
             overallCounts: effectiveOverallCounts,
+            // Prefer state-level overrides from the latest payload; fallback to derived-mode overrides.
+            rowSummaryCountsByGroup: rowSummaryCountsByGroup || effectiveResults?.rowSummaryCountsByGroup || null,
             ...(countFor === 'total_coverage' ? { blockWidth: 60, blockHorizontalExtend: 10 } : {}),
             browseFilteringTransformFunc: browseFilteringTransformFuncKey ? DataMatrix.browseFilteringTransformFuncs[browseFilteringTransformFuncKey] : null
         };

--- a/src/encoded/static/components/viz/Matrix/DataMatrix.js
+++ b/src/encoded/static/components/viz/Matrix/DataMatrix.js
@@ -1636,7 +1636,16 @@ export default class DataMatrix extends React.PureComponent {
             // under assay filter to avoid inconsistencies with facet-driven contexts.
             rowSummaryCountsByGroup: effectiveRowSummaryCountsByGroup,
             ...(countFor === 'total_coverage' ? { blockWidth: 60, blockHorizontalExtend: 10 } : {}),
-            browseFilteringTransformFunc: browseFilteringTransformFuncKey ? DataMatrix.browseFilteringTransformFuncs[browseFilteringTransformFuncKey] : null
+            browseFilteringTransformFunc: browseFilteringTransformFuncKey
+                ? ((filteringProperties, blockType) => {
+                    const transformFn = DataMatrix.browseFilteringTransformFuncs[browseFilteringTransformFuncKey];
+                    if (typeof transformFn !== 'function') return filteringProperties;
+                    return transformFn(filteringProperties, blockType, {
+                        matrixMode,
+                        donorTissueAssay
+                    });
+                })
+                : null
         };
 
         const colAgg = Array.isArray(query.columnAggFields) ? query.columnAggFields : [query.columnAggFields];
@@ -1955,23 +1964,45 @@ DataMatrix.resultTransformedPostProcessFuncs = {
     }
 };
 DataMatrix.browseFilteringTransformFuncs = {
-    "analysisDerivedColumns": function (filteringProperties, blockType) {
+    "analysisDerivedColumns": function (filteringProperties, blockType, matrixContext = null) {
         const assayField = 'assays.display_title';
-        const hasAssayFilter = typeof filteringProperties[assayField] !== 'undefined';
+        const isDonorTissueMode = matrixContext?.matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE;
+        const selectedDonorTissueAssay = matrixContext?.donorTissueAssay;
+        const hasSelectedDonorTissueAssay = isDonorTissueMode &&
+            selectedDonorTissueAssay &&
+            selectedDonorTissueAssay !== DataMatrix.DONOR_TISSUE_ALL_ASSAYS;
+
+        // Donor x Tissue regular cells might not include assay in URL params.
+        // Inject currently selected assay to keep browse links scoped correctly.
+        if (hasSelectedDonorTissueAssay && typeof filteringProperties[assayField] === 'undefined') {
+            filteringProperties[assayField] = selectedDonorTissueAssay;
+        }
+
+        const assayFilterRaw = filteringProperties[assayField];
+        const assayFilterList = Array.isArray(assayFilterRaw)
+            ? assayFilterRaw
+            : (typeof assayFilterRaw === 'string' ? [assayFilterRaw] : []);
+        const hasAssayFilter = assayFilterList.length > 0;
+        const hasDSAAssayFilter = assayFilterList.includes('DSA');
+        const hasVariantCallSetsAssayFilter = assayFilterList.includes('Variant Call Sets');
         const studies = filteringProperties['sample_summary.studies'];
         const studiesList = Array.isArray(studies) ? studies : (typeof studies === 'string' ? [studies] : []);
         const isProductionStudy = studiesList.includes('Production');
 
-        if (filteringProperties[assayField] === 'DSA') {
+        if (hasDSAAssayFilter) {
             // extend data_type filter to include Chain File along with DSA
             filteringProperties['data_type'] = [...(filteringProperties['data_type'] || []), 'DSA', 'Chain File', 'Sequence Interval'];
             delete filteringProperties[assayField];
-        } else if (filteringProperties[assayField] === 'Variant Call Sets') {
+        } else if (hasVariantCallSetsAssayFilter) {
             filteringProperties['analysis_details'] = [...(filteringProperties['analysis_details'] || []), 'Filtered', 'Phased'];
             filteringProperties['data_type!'] = [...(filteringProperties['data_type!'] || []), 'DSA', 'Chain File', 'Sequence Interval'];
             delete filteringProperties[assayField];
         } else if (
-            (blockType === 'regular') ||
+            // IMPORTANT:
+            // Only apply non-DSA exclusion when an assay filter exists.
+            // In donor x tissue, regular blocks may not carry assays.display_title in URL params;
+            // forcing data_type! in that case incorrectly removes DSA/Chain rows.
+            ((blockType === 'regular') && hasAssayFilter) ||
             ((blockType === 'col-summary' || blockType === 'col-secondary-summary') && hasAssayFilter)
         ) {
             // for non-DSA columns we exclude DSA-related data types;

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -2286,7 +2286,7 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                                 return sum + (Number(item?.counts?.files) || 0);
                             }, 0))
                         : summaryCountFor === 'files'
-                            ? (props.overallCounts?.files ?? overallFilesOverride ?? _.reduce(sectionRows, function (sum, item) {
+                            ? (overallFilesOverride ?? _.reduce(sectionRows, function (sum, item) {
                                 return sum + (Number(item?.counts?.files) || 0);
                             }, 0))
                             : props.overallCounts?.[summaryCountFor];

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -706,7 +706,7 @@ export class VisualBody extends React.PureComponent {
                     'rowGroups', 'showRowGroups', 'rowGroupsExtended', 'showRowGroupsExtended',
                     'summaryBackgroundColor', 'xAxisLabel', 'yAxisLabel', 'showAxisLabels', 'showColumnSummary',
                     'countFor', 'overallCounts', 'showUniqueDonorsAssayBand', 'shrinkEmptyColumns',
-                    'blockWidth', 'blockHorizontalExtend', 'blockHorizontalSpacing', 'blockVerticalSpacing',
+                    'blockWidth', 'blockHorizontalExtend', 'blockHorizontalSpacing', 'blockVerticalSpacing', 'rowSummaryCountsByGroup',
                     'headerLeftControls')}
                 blockPopover={this.blockPopover}
                 blockRenderedContents={VisualBody.blockRenderedContents}
@@ -1613,7 +1613,8 @@ export class StackedBlockGroupedRow extends React.PureComponent {
             'groupingProperties', 'depth', 'titleMap', 'blockClassName', 'blockRenderedContents',
             'groupedDataIndices', 'columnGrouping', 'blockPopover', 'colorRanges', 'summaryBackgroundColor',
             'activeBlock', 'openBlock', 'handleBlockMouseEnter', 'handleBlockMouseLeave', 'handleBlockClick', 'group', 'popoverPrimaryTitle',
-            'countFor');
+            // Generic summary overrides keyed by grouping field and row value.
+            'countFor', 'rowSummaryCountsByGroup');
         const getContainerGroupStyle = function(columnKey = 'overall-summary') {
             const width = StackedBlockGroupedRow.getColumnWidthForKey(columnKey, props);
             return {
@@ -1728,6 +1729,22 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                     const filteredRowTotalChildBlocks = _.filter(rowTotalChildBlocks, function(blockData){
                         return blockData[props.groupingProperties[props.depth]] === props.group;
                     });
+                    const currentGroupingField = props.groupingProperties?.[props.depth];
+                    // Pull an override for the current row dimension (e.g. donor, tissue, etc.) if provided.
+                    const overrideCounts = currentGroupingField
+                        ? props.rowSummaryCountsByGroup?.[currentGroupingField]?.[props.group]
+                        : null;
+                    const overrideFiles = typeof overrideCounts?.files === 'number' ? overrideCounts.files : null;
+                    // If an override exists, replace summary counts for this row without changing child block data.
+                    const rowTotalsForBlock = (typeof overrideFiles === 'number')
+                        ? [{
+                            ...(filteredRowTotalChildBlocks[0] || { [props.groupingProperties[props.depth]]: props.group }),
+                            counts: { ...(filteredRowTotalChildBlocks[0]?.counts || {}), ...overrideCounts }
+                        }]
+                        : filteredRowTotalChildBlocks;
+                    const summaryCounts = (typeof overrideFiles === 'number')
+                        ? { ...(filteredRowTotalChildBlocks[0]?.counts || {}), ...overrideCounts }
+                        : (filteredRowTotalChildBlocks[0]?.counts || null);
                     rowSummaryBlock = (
                         <div className="block-container-group" style={getContainerGroupStyle('overall-summary')}
                             key={'total'} data-block-count={totalRowCount} data-group-key={'row-summary'}>
@@ -1735,10 +1752,10 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                                 {...commonProps}
                                 key={inner.length}
                                 data={allChildBlocks}
-                                rowTotals={filteredRowTotalChildBlocks}
+                                rowTotals={rowTotalsForBlock}
                                 rowIndex={props.index}
                                 blockType="row-summary"
-                                summaryCounts={filteredRowTotalChildBlocks[0]?.counts || null}
+                                summaryCounts={summaryCounts}
                             />
                         </div>
                     );

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -1649,10 +1649,11 @@ export class StackedBlockGroupedRow extends React.PureComponent {
             .map((value) => String(value))
             .uniq()
             .value();
+        const rowsByGroupValue = _.groupBy(rows, (row) => String(row?.[overrideField]));
         const total = _.reduce(groupValues, (sum, groupValue) => {
             const rowSummaryFiles = overridesForField?.[groupValue]?.files;
             if (typeof rowSummaryFiles !== 'number') return sum;
-            const rowsForGroup = _.filter(rows, (row) => String(row?.[overrideField]) === groupValue);
+            const rowsForGroup = rowsByGroupValue[groupValue] || [];
             // Sum every non-target column in this group; overlap is assumed to be isolated
             // to the target column in this fallback strategy.
             const nonTargetSum = _.reduce(rowsForGroup, (memo, row) => {

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -548,6 +548,7 @@ export class VisualBody extends React.PureComponent {
             : 0;
         // Round totalCoverage to 2 decimal places since ES has floating point precision issues
         const roundedTotalCoverage = totalCoverage > 0 ? Math.round(totalCoverage * 100) / 100 : 0;
+        const formatGermLayerValue = (value) => (value && value !== 'No value' ? value : '--');
 
         // Render
         return (
@@ -571,7 +572,7 @@ export class VisualBody extends React.PureComponent {
                                     </div>
                                     <div className="col-4">
                                         <div className="label me-05">{'Germ Layer'}</div>
-                                        <div className="value">{ additionalPopoverData?.[primaryGrpPropValue]?.["secondaryCategory"] || secondaryGrpPropCategoryValue || '--'}</div>
+                                        <div className="value">{formatGermLayerValue(additionalPopoverData?.[primaryGrpPropValue]?.["secondaryCategory"] || secondaryGrpPropCategoryValue)}</div>
                                     </div>
                                 </div>
                             ) : null}
@@ -620,7 +621,7 @@ export class VisualBody extends React.PureComponent {
                                     </div>
                                     <div className="col-4">
                                         <div className="label">{secondaryGrpPropCategoryValue ? 'Germ Layer' : (isTissueGrouping ? 'Total Donors' : StackedBlockVisual.pluralize(secondaryGrpPropTitle))}</div>
-                                        <div className="value">{secondaryGrpPropCategoryValue || (isTissueGrouping ? (donorCount || '--') : (secondaryGrpPropUniqueCount || '--'))}</div>
+                                        <div className="value">{secondaryGrpPropCategoryValue ? formatGermLayerValue(secondaryGrpPropCategoryValue) : (isTissueGrouping ? (donorCount || '--') : (secondaryGrpPropUniqueCount || '--'))}</div>
                                     </div>
                                     <div className="col-4">
                                         <div className="label">Total Files</div>
@@ -648,7 +649,7 @@ export class VisualBody extends React.PureComponent {
                                     {additionalPopoverData?.[primaryGrpPropValue]?.["secondary"] ?
                                         <div className="col-4">
                                             <div className="label">{'Germ Layer'}</div>
-                                            <div className="value">{additionalPopoverData?.[primaryGrpPropValue]?.["secondary"] || '--'}</div>
+                                            <div className="value">{formatGermLayerValue(additionalPopoverData?.[primaryGrpPropValue]?.["secondary"])}</div>
                                         </div> :
                                         <div className="col-4">
                                             &nbsp;
@@ -668,7 +669,7 @@ export class VisualBody extends React.PureComponent {
                                     </div>
                                     <div className="col-4">
                                         <div className="label">{'Germ Layer'}</div>
-                                        <div className="value">{secondaryGrpPropCategoryValue || '--'}</div>
+                                        <div className="value">{formatGermLayerValue(secondaryGrpPropCategoryValue)}</div>
                                     </div>
                                     <div className="col-4">
                                         <div className="label">Total Files</div>

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -1631,24 +1631,39 @@ export class StackedBlockGroupedRow extends React.PureComponent {
         return foundOverride ? sum : null;
     }
 
-    // Computes per-column files by grouping rows on the resolved override field
-    // and taking the max files per group to avoid double counting overlaps.
-    static getColumnFilesDedupedByOverrideField(columnKey, props) {
-        const rows = props.groupedDataIndices[columnKey] || [];
-        if (!Array.isArray(rows) || rows.length === 0) return 0;
+    // Derives a target column's files total by group using:
+    // target = row summary files - sum(non-target column files) for each group.
+    // This is useful when the target column can include overlap across sub-rows.
+    static getDerivedColumnFilesFromRowSummary(rows, columnKey, props) {
+        if (!Array.isArray(rows) || rows.length === 0) return null;
         const overrideField = StackedBlockGroupedRow.resolveOverrideFieldForRows(rows, props);
-        if (!overrideField) {
-            return _.reduce(rows, (sum, row) => sum + (Number(row?.counts?.files) || 0), 0);
-        }
-        const maxByGroup = {};
-        rows.forEach((row) => {
-            const groupValue = row?.[overrideField];
-            if (groupValue == null) return;
-            const key = String(groupValue);
-            const files = Number(row?.counts?.files) || 0;
-            maxByGroup[key] = Math.max(maxByGroup[key] || 0, files);
-        });
-        return _.reduce(_.values(maxByGroup), (sum, count) => sum + count, 0);
+        if (!overrideField) return null;
+        const overridesForField = props.rowSummaryCountsByGroup?.[overrideField];
+        if (!overridesForField) return null;
+        const columnField = props.columnGrouping;
+        let foundGroup = false;
+        const groupValues = _.chain(rows)
+            .map((row) => row?.[overrideField])
+            .compact()
+            .map((value) => String(value))
+            .uniq()
+            .value();
+        const total = _.reduce(groupValues, (sum, groupValue) => {
+            const rowSummaryFiles = overridesForField?.[groupValue]?.files;
+            if (typeof rowSummaryFiles !== 'number') return sum;
+            const rowsForGroup = _.filter(rows, (row) => String(row?.[overrideField]) === groupValue);
+            // Sum every non-target column in this group; overlap is assumed to be isolated
+            // to the target column in this fallback strategy.
+            const nonTargetSum = _.reduce(rowsForGroup, (memo, row) => {
+                if (row?.[columnField] === columnKey) return memo;
+                return memo + (Number(row?.counts?.files) || 0);
+            }, 0);
+            // Clamp to zero as a safety guard for inconsistent upstream aggregates.
+            const derived = rowSummaryFiles - nonTargetSum;
+            foundGroup = true;
+            return sum + Math.max(0, derived);
+        }, 0);
+        return foundGroup ? total : null;
     }
 
     /** @todo Convert to functional memoized React component */
@@ -1749,6 +1764,26 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                 }));
 
                 const columnKeys = sortColumnKeys(_.keys(blocksByColumnGroup));
+                const currentGroupingField = props.groupingProperties?.[props.depth];
+                const rowSummaryFiles = (props.countFor === 'files' || props.countFor === 'tissue_files')
+                    ? props.rowSummaryCountsByGroup?.[currentGroupingField]?.[props.group]?.files
+                    : null;
+                const derivedCollapsedCellOverrides = {};
+                if (typeof rowSummaryFiles === 'number' && columnKeys.indexOf('DSA') > -1) {
+                    // For collapsed rows, derive DSA as:
+                    // row summary files - sum(non-DSA column files).
+                    const sumFilesForColumn = (columnKey) => _.reduce(blocksByColumnGroup[columnKey] || [], (sum, row) => {
+                        return sum + (Number(row?.counts?.files) || 0);
+                    }, 0);
+                    const sumNonDsaFiles = _.reduce(columnKeys, (sum, columnKey) => {
+                        if (columnKey === 'DSA') return sum;
+                        return sum + sumFilesForColumn(columnKey);
+                    }, 0);
+                    const derivedDsaFiles = rowSummaryFiles - sumNonDsaFiles;
+                    if (derivedDsaFiles >= 0) {
+                        derivedCollapsedCellOverrides.DSA = derivedDsaFiles;
+                    }
+                }
 
                 inner = _.map(columnKeys, function(k, colIdx){
                     var blocksForGroup = blocksByColumnGroup[k];
@@ -1773,7 +1808,17 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                                     // We have columnSubGrouping so these are -pairs- of (0) columnSubGrouping val, (1) blocks
                                     blockData = blockData[1];
                                 }
-                                return <Block key={i} {...commonProps} {...{ parentGrouping, subGrouping }} data={blockData} indexInGroup={i} rowIndex={props.index} colIndex={colIdx} blockType="regular" />;
+                                const explicitOverrideFiles = derivedCollapsedCellOverrides[k];
+                                const blockDataForRender = typeof explicitOverrideFiles === 'number'
+                                    ? [{
+                                        ...(blockData[0] || {}),
+                                        counts: {
+                                            ...(blockData[0]?.counts || {}),
+                                            files: explicitOverrideFiles
+                                        }
+                                    }]
+                                    : blockData;
+                                return <Block key={i} {...commonProps} {...{ parentGrouping, subGrouping }} data={blockDataForRender} indexInGroup={i} rowIndex={props.index} colIndex={colIdx} blockType="regular" />;
                             }) }
                         </div>
                     );
@@ -2171,8 +2216,15 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                 {columnKeys.map(function (columnKey, colIndex) {
                     const isPrimarySummaryBand = summaryBlockType === 'col-secondary-summary';
                     const totalsCounts = StackedBlockGroupedRow.getColumnTotalsEntry(columnKey, props)?.counts;
-                    const dedupedFilesForColumn = props.rowSummaryCountsByGroup
-                        ? StackedBlockGroupedRow.getColumnFilesDedupedByOverrideField(columnKey, props)
+                    const sectionRows = getAllSectionRows();
+                    // Apply derived fallback only for DSA column summary files.
+                    // Other columns continue using backend/standard summary paths.
+                    const shouldDeriveDsaFiles = (summaryCountFor === 'files' || summaryCountFor === 'tissue_files')
+                        && summaryBlockType === 'col-summary'
+                        && columnKey === 'DSA'
+                        && !!props.rowSummaryCountsByGroup;
+                    const derivedDsaFiles = shouldDeriveDsaFiles
+                        ? StackedBlockGroupedRow.getDerivedColumnFilesFromRowSummary(sectionRows, columnKey, props)
                         : null;
                     const donorsCount = isPrimarySummaryBand
                         ? getPrimaryGroupCountFromGroupedRows(columnKey)
@@ -2182,16 +2234,14 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                         : {
                             ...(totalsCounts || {}),
                             donors: donorsCount,
-                            ...((summaryCountFor === 'files' || summaryCountFor === 'tissue_files') && typeof dedupedFilesForColumn === 'number'
-                                ? { files: dedupedFilesForColumn }
-                                : null)
+                            ...((typeof derivedDsaFiles === 'number') ? { files: derivedDsaFiles } : null)
                         };
                     const columnSummaryData = summaryCountFor === 'donors'
                         ? [{ counts: { donors: donorsCount } }]
                         : summaryCountFor === 'total_coverage'
                             ? []
-                            : ((summaryCountFor === 'files' || summaryCountFor === 'tissue_files') && typeof dedupedFilesForColumn === 'number'
-                                ? [{ counts: { files: dedupedFilesForColumn } }]
+                            : (typeof derivedDsaFiles === 'number'
+                                ? [{ counts: { files: derivedDsaFiles } }]
                                 : getColumnSummaryData(columnKey));
                     const columnTotal = props.groupedDataIndices[columnKey]?.length || 0;
                     const hasOpenBlock = props.openBlock?.columnIdx === colIndex && props.openBlock?.summaryRowType === summaryBlockType;

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -1595,6 +1595,62 @@ export class StackedBlockGroupedRow extends React.PureComponent {
         return { width, minWidth: width };
     }
 
+    // Returns the override field (e.g. donor, tissue) that is both configured in
+    // rowSummaryCountsByGroup and present on the provided rows.
+    static resolveOverrideFieldForRows(rows, props) {
+        const overridesByField = props.rowSummaryCountsByGroup;
+        if (!overridesByField || typeof overridesByField !== 'object') return null;
+        return _.find(_.keys(overridesByField), (field) => {
+            return _.some(rows || [], (row) => row && row[field] != null);
+        });
+    }
+
+    // Computes the overall files count from row summary overrides by summing one
+    // override value per unique group key for the resolved override field.
+    static getOverallFilesFromRowSummaryOverrides(rows, props) {
+        const overrideField = StackedBlockGroupedRow.resolveOverrideFieldForRows(rows, props);
+        if (!overrideField) return null;
+        const overridesForField = props.rowSummaryCountsByGroup?.[overrideField];
+        if (!overridesForField) return null;
+        const groupValues = _.chain(rows || [])
+            .map((row) => row?.[overrideField])
+            .compact()
+            .map((value) => String(value))
+            .uniq()
+            .value();
+        if (groupValues.length === 0) return null;
+        let foundOverride = false;
+        const sum = _.reduce(groupValues, (memo, groupValue) => {
+            const overrideFiles = overridesForField?.[groupValue]?.files;
+            if (typeof overrideFiles === 'number') {
+                foundOverride = true;
+                return memo + overrideFiles;
+            }
+            return memo;
+        }, 0);
+        return foundOverride ? sum : null;
+    }
+
+    // Computes per-column files by grouping rows on the resolved override field
+    // and taking the max files per group to avoid double counting overlaps.
+    static getColumnFilesDedupedByOverrideField(columnKey, props) {
+        const rows = props.groupedDataIndices[columnKey] || [];
+        if (!Array.isArray(rows) || rows.length === 0) return 0;
+        const overrideField = StackedBlockGroupedRow.resolveOverrideFieldForRows(rows, props);
+        if (!overrideField) {
+            return _.reduce(rows, (sum, row) => sum + (Number(row?.counts?.files) || 0), 0);
+        }
+        const maxByGroup = {};
+        rows.forEach((row) => {
+            const groupValue = row?.[overrideField];
+            if (groupValue == null) return;
+            const key = String(groupValue);
+            const files = Number(row?.counts?.files) || 0;
+            maxByGroup[key] = Math.max(maxByGroup[key] || 0, files);
+        });
+        return _.reduce(_.values(maxByGroup), (sum, count) => sum + count, 0);
+    }
+
     /** @todo Convert to functional memoized React component */
     static collapsedChildBlocks = memoize(function(data, rowTotals, props){
 
@@ -2101,13 +2157,13 @@ export class StackedBlockGroupedRow extends React.PureComponent {
         const getSummaryBlockStyle = (columnKey) => {
             const columnWidth = StackedBlockGroupedRow.getColumnWidthForKey(columnKey, props);
             return {
-            'width': columnWidth, // Width for each column
-            'minWidth': columnWidth,
-            'minHeight': props.blockHeight + props.blockVerticalSpacing, // Height for each row
-            'paddingLeft': props.blockHorizontalSpacing,
-            'paddingRight': props.blockHorizontalSpacing,
-            'paddingTop': props.blockVerticalSpacing
-        };
+                'width': columnWidth, // Width for each column
+                'minWidth': columnWidth,
+                'minHeight': props.blockHeight + props.blockVerticalSpacing, // Height for each row
+                'paddingLeft': props.blockHorizontalSpacing,
+                'paddingRight': props.blockHorizontalSpacing,
+                'paddingTop': props.blockVerticalSpacing
+            };
         };
 
         const renderSummaryBlocks = (summaryCountFor = props.countFor, summaryBlockType = 'col-summary') => (
@@ -2115,17 +2171,28 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                 {columnKeys.map(function (columnKey, colIndex) {
                     const isPrimarySummaryBand = summaryBlockType === 'col-secondary-summary';
                     const totalsCounts = StackedBlockGroupedRow.getColumnTotalsEntry(columnKey, props)?.counts;
+                    const dedupedFilesForColumn = props.rowSummaryCountsByGroup
+                        ? StackedBlockGroupedRow.getColumnFilesDedupedByOverrideField(columnKey, props)
+                        : null;
                     const donorsCount = isPrimarySummaryBand
                         ? getPrimaryGroupCountFromGroupedRows(columnKey)
                         : (totalsCounts?.donors ?? totalsCounts?.donor_count ?? getPrimaryGroupCountFromGroupedRows(columnKey));
                     const summaryCounts = isPrimarySummaryBand
                         ? { donors: donorsCount }
-                        : { ...(totalsCounts || {}), donors: donorsCount };
+                        : {
+                            ...(totalsCounts || {}),
+                            donors: donorsCount,
+                            ...((summaryCountFor === 'files' || summaryCountFor === 'tissue_files') && typeof dedupedFilesForColumn === 'number'
+                                ? { files: dedupedFilesForColumn }
+                                : null)
+                        };
                     const columnSummaryData = summaryCountFor === 'donors'
                         ? [{ counts: { donors: donorsCount } }]
                         : summaryCountFor === 'total_coverage'
                             ? []
-                            : getColumnSummaryData(columnKey);
+                            : ((summaryCountFor === 'files' || summaryCountFor === 'tissue_files') && typeof dedupedFilesForColumn === 'number'
+                                ? [{ counts: { files: dedupedFilesForColumn } }]
+                                : getColumnSummaryData(columnKey));
                     const columnTotal = props.groupedDataIndices[columnKey]?.length || 0;
                     const hasOpenBlock = props.openBlock?.columnIdx === colIndex && props.openBlock?.summaryRowType === summaryBlockType;
                     const hasActiveBlock = props.activeBlock?.columnIdx === colIndex && props.activeBlock?.summaryRowType === summaryBlockType;
@@ -2156,18 +2223,21 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                     if (summaryCountFor === 'total_coverage') return null;
                     const isPrimarySummaryBand = summaryBlockType === 'col-secondary-summary';
                     const sectionRows = getAllSectionRows();
+                    // If row summary overrides exist for this grouping field, use them for the
+                    // corner overall files value to avoid re-summing potentially overlapping child rows.
+                    const overallFilesOverride = StackedBlockGroupedRow.getOverallFilesFromRowSummaryOverrides(sectionRows, props);
                     const overallValue = summaryCountFor === 'donors'
                         ? (isPrimarySummaryBand
                             ? getOverallPrimaryGroupCountFromRows()
                             : (props.overallCounts?.donors ?? props.overallCounts?.donor_count ?? getUniqueDonorCountFromRows(sectionRows)))
                         : summaryCountFor === 'tissue_files'
-                            ? _.reduce(sectionRows, function (sum, item) {
+                            ? (overallFilesOverride ?? _.reduce(sectionRows, function (sum, item) {
                                 return sum + (Number(item?.counts?.files) || 0);
-                            }, 0)
+                            }, 0))
                         : summaryCountFor === 'files'
-                            ? _.reduce(sectionRows, function (sum, item) {
+                            ? (overallFilesOverride ?? _.reduce(sectionRows, function (sum, item) {
                                 return sum + (Number(item?.counts?.files) || 0);
-                            }, 0)
+                            }, 0))
                             : props.overallCounts?.[summaryCountFor];
                     if (overallValue == null) return null;
                     const overallHeaderItemStyle = StackedBlockGroupedRow.getHeaderItemStyleForKey('overall-summary', props);

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -2282,11 +2282,11 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                             ? getOverallPrimaryGroupCountFromRows()
                             : (props.overallCounts?.donors ?? props.overallCounts?.donor_count ?? getUniqueDonorCountFromRows(sectionRows)))
                         : summaryCountFor === 'tissue_files'
-                            ? (overallFilesOverride ?? _.reduce(sectionRows, function (sum, item) {
+                            ? (props.overallCounts?.files ?? overallFilesOverride ?? _.reduce(sectionRows, function (sum, item) {
                                 return sum + (Number(item?.counts?.files) || 0);
                             }, 0))
                         : summaryCountFor === 'files'
-                            ? (overallFilesOverride ?? _.reduce(sectionRows, function (sum, item) {
+                            ? (props.overallCounts?.files ?? overallFilesOverride ?? _.reduce(sectionRows, function (sum, item) {
                                 return sum + (Number(item?.counts?.files) || 0);
                             }, 0))
                             : props.overallCounts?.[summaryCountFor];


### PR DESCRIPTION
## Summary

This PR fixes count inconsistencies found in `utk_dm_benchmarking` across Data Matrix views:

- Prevents DSA overcounting in Donor x Tissue tuple cells (e.g., `SMHT023 / 3AC - Fibroblast`).
- Stabilizes top-level total file count handling by preferring backend `counts.files`.
- Keeps row summary override behavior generic while improving consistency under assay filtering.
- Preserves/aligns assay normalization for **Element AVITI** (`WGS - Element` -> `WGS - Element AVITI`) so grouping and totals are consistent.

## Problem

With the same underlying dataset:
- Donor x Assay and Donor x Tissue could show different DSA counts for equivalent tuples (`1` vs `3`/`9`).
- Header-level file totals could diverge from backend totals when client-side fallback aggregation was used.
- Assay filtering in Donor x Tissue could amplify count drift in derived summaries.
- Assay label normalization differences (including Element AVITI) could cause grouping inconsistencies.

## Changes

### `DataMatrix.js`

1. **Stable `totalFiles` source**
   - Normalize backend `result.counts.files` via `Number(...)`.
   - Use backend total when available.
   - Fallback to client aggregation only when backend total is missing.

2. **DSA transform strategy by grouping mode**
   - Extended `transformDSA` with an explicit count strategy.
   - For `columnGrouping === 'assay'`: keep existing `diff` behavior.
   - For non-assay grouping (notably Donor x Tissue): use `max_dsa_row` strategy per tuple.
   - This avoids inflated DSA counts caused by assay/platform/data_type-expanded rows.

3. **Assay normalization consistency**
   - Keep assay value mapping consistent, including **Element AVITI**:
     - `WGS - Element` is normalized to `WGS - Element AVITI`
   - Ensures correct bucket placement in matrix column groups and summaries.

4. **Code comments**
   - Added/updated inline comments to document rationale and expected behavior.


## Notes

This PR updates frontend matrix derivation/count logic only; no backend API behavior is changed.
