### PR TITLE
QC metrics improvement

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ smaht-portal
 Change Log
 ----------
 
+1.27.0
+======
+
+`PR 666: QC metrics improvements <https://github.com/smaht-dac/smaht-portal/pull/666>`_
+
+* Improve QC metrics visualizations: rotate x-axis labels when more than 5 groups are present, fix column header wrapping, and add minimal-width styling for the Platform column
+
+
 1.26.2
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "1.26.2"
+version = "1.27.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/commands/create_qc_overview_json.py
+++ b/src/encoded/commands/create_qc_overview_json.py
@@ -213,10 +213,11 @@ QC_THRESHOLDS = {
 
 
 class FileStats:
-    def __init__(self, output):
+    def __init__(self, output, somalier_output):
         self.errors = []
         self.warnings = []
         self.output_path = output
+        self.somalier_output_path = somalier_output
         self.all_tissues = self.get_all_tissues()
         # self.all_donors = self.get_all_donors()
         self.stats = []
@@ -611,19 +612,17 @@ class FileStats:
             return
 
         print(f"Writing results to {self.output_path}")
-
-        # pprint.pprint(self.stats)
-        # pprint.pprint(self.qc_info)
-
         data = {
             "viz_info": self.viz_info,
             "qc_info": self.qc_info,
             "qc_results": self.stats,
-            "somalier_results": self.somalier_results,
         }
-
         with open(self.output_path, "w") as file:
             json.dump(data, file, indent=4)
+
+        print(f"Writing somalier results to {self.somalier_output_path}")
+        with open(self.somalier_output_path, "w") as file:
+            json.dump(self.somalier_results, file, indent=4)
 
     def get_alignment_mwfr(self, fileset):
         mwfrs = fileset.get("meta_workflow_runs", [])
@@ -857,17 +856,18 @@ def progressbar(it, prefix="", size=60, out=sys.stdout):
 
 
 @click.command()
-@click.option("--output", help="Output path (optional)")
-def main(output):
-    """Create a JSON that is input to the QC overview page
+@click.option("--output", help="Output path for the main QC JSON (optional)")
+@click.option("--somalier-output", help="Output path for the somalier results JSON (optional)")
+def main(output, somalier_output):
+    """Create JSON files that are input to the QC overview page.
 
-    Args:
-        output (str): Path to output JSON
+    Produces two files: the main QC JSON and a separate somalier results JSON.
     """
     dt = datetime.datetime.now()
     output_path = output or f"./file_statistics_{dt.year}_{dt.month}_{dt.day}.json"
+    somalier_output_path = somalier_output or output_path.replace(".json", "_somalier.json")
 
-    FS = FileStats(output_path)
+    FS = FileStats(output_path, somalier_output_path)
     FS.get_stats()
     FS.write_json()
     print("Done!")

--- a/src/encoded/qc_overview.py
+++ b/src/encoded/qc_overview.py
@@ -31,34 +31,34 @@ def _get_reference_file_json(context, request, tag):
         return response
 
     try:
-        # search_params = {
-        #     "type": REFERENCE_FILE,
-        #     "limit": 1,
-        #     "sort": "-date_created",
-        #     "tags": tag,
-        #     "version": JSON_VERSION,
-        # }
-        # subreq = make_search_subreq(
-        #     request, f"/search?{urlencode(search_params, True)}", inherit_user=True
-        # )
-        # search_res = search(context, subreq)["@graph"]
+        search_params = {
+            "type": REFERENCE_FILE,
+            "limit": 1,
+            "sort": "-date_created",
+            "tags": tag,
+            "version": JSON_VERSION,
+        }
+        subreq = make_search_subreq(
+            request, f"/search?{urlencode(search_params, True)}", inherit_user=True
+        )
+        search_res = search(context, subreq)["@graph"]
 
-        # if len(search_res) != 1:
-        #     response["error_msg"] = f"Reference file not found for tag '{tag}'."
-        #     return response
+        if len(search_res) != 1:
+            response["error_msg"] = f"Reference file not found for tag '{tag}'."
+            return response
 
-        # upload_key = search_res[0]["upload_key"]
+        upload_key = search_res[0]["upload_key"]
         upload_bucket = request.registry.settings.get("file_upload_bucket")
 
         #For local testing purposes
-        if tag == "somalier_data":
-            upload_key = (
-                "2d1e6abc-22ce-4db0-9a8f-cc09a810aac7/SMAFI55NZZKE.json"
-            )
-        elif tag == "qc_metrics_data":
-            upload_key = (
-                "cf683b4b-832f-46df-bd59-7dde5c4945ba/SMAFISSLEHWK.json"
-            )
+        # if tag == "somalier_data":
+        #     upload_key = (
+        #         "2d1e6abc-22ce-4db0-9a8f-cc09a810aac7/SMAFI55NZZKE.json"
+        #     )
+        # elif tag == "qc_metrics_data":
+        #     upload_key = (
+        #         "cf683b4b-832f-46df-bd59-7dde5c4945ba/SMAFISSLEHWK.json"
+        #     )
 
         if upload_bucket:
             s3 = boto_client("s3")

--- a/src/encoded/qc_overview.py
+++ b/src/encoded/qc_overview.py
@@ -9,7 +9,7 @@ import json
 
 # This refers to the version of the JSON file that contains the QC overview data.
 # This needs to be bumped when there is a breaking change in the Front/Backend
-JSON_VERSION = "v3"
+JSON_VERSION = "v4"
 
 # Portal constants
 REFERENCE_FILE = "ReferenceFile"
@@ -18,64 +18,73 @@ METAWORKFLOW_RUN = "MetaWorkflowRun"
 
 def includeme(config):
     config.add_route("get_qc_overview", "/get_qc_overview/")
+    config.add_route("get_somalier_overview", "/get_somalier_overview/")
     config.scan(__name__)
+
+
+def _get_reference_file_json(context, request, tag):
+    """Fetch the JSON content of the most recent ReferenceFile with the given tag from S3."""
+    response = {"error": True, "error_msg": "", "data": None}
+
+    if not validate_user_has_protected_access(request):
+        response["error_msg"] = "User does not have access to protected data."
+        return response
+
+    try:
+        # search_params = {
+        #     "type": REFERENCE_FILE,
+        #     "limit": 1,
+        #     "sort": "-date_created",
+        #     "tags": tag,
+        #     "version": JSON_VERSION,
+        # }
+        # subreq = make_search_subreq(
+        #     request, f"/search?{urlencode(search_params, True)}", inherit_user=True
+        # )
+        # search_res = search(context, subreq)["@graph"]
+
+        # if len(search_res) != 1:
+        #     response["error_msg"] = f"Reference file not found for tag '{tag}'."
+        #     return response
+
+        # upload_key = search_res[0]["upload_key"]
+        upload_bucket = request.registry.settings.get("file_upload_bucket")
+
+        #For local testing purposes
+        if tag == "somalier_data":
+            upload_key = (
+                "2d1e6abc-22ce-4db0-9a8f-cc09a810aac7/SMAFI55NZZKE.json"
+            )
+        elif tag == "qc_metrics_data":
+            upload_key = (
+                "cf683b4b-832f-46df-bd59-7dde5c4945ba/SMAFISSLEHWK.json"
+            )
+
+        if upload_bucket:
+            s3 = boto_client("s3")
+            try:
+                s3_response = s3.get_object(Bucket=upload_bucket, Key=upload_key)
+                content = s3_response["Body"].read().decode("utf-8")
+                response["data"] = json.loads(content)
+                response["error"] = False
+                return response
+            except Exception:
+                response["error_msg"] = f"Reference file for tag '{tag}' could not be loaded from S3."
+                return response
+
+    except Exception as e:
+        response["error_msg"] = f"Error when trying to get data for tag '{tag}': {str(e)}"
+        request.response.status_code = 500
+        return response
 
 
 @view_config(route_name="get_qc_overview", request_method="POST")
 @debug_log
 def get_qc_overview(context, request):
-    response = {"error": True, "error_msg": "", "data": None}
+    return _get_reference_file_json(context, request, "qc_metrics_data")
 
-    # We only load the data if the user has access to protected data
-    if not validate_user_has_protected_access(request):
-        response["error_msg"] = "User does not have access to protected data."
-        return response
-    
-    try:
-        # Search for fileset with same file group
-        search_params = {}
-        search_params["type"] = REFERENCE_FILE
-        search_params["limit"] = 1
-        search_params["sort"] = "-date_created"
-        search_params["tags"] = "qc_metrics_data"
-        search_params["version"] = JSON_VERSION
 
-        subreq = make_search_subreq(
-            request, f"/search?{urlencode(search_params, True)}", inherit_user=True
-        )
-        search_res = search(context, subreq)["@graph"]
-
-        if len(search_res) != 1:
-            response["error_msg"] = "Reference file not found."
-            return response
-
-        reference_file = search_res[0]
-        reference_file_upload_key = reference_file["upload_key"]
-
-        #For local testing purposes
-        # reference_file_upload_key = (
-        #     "25d09e18-2f77-4541-a32c-0f1d99defbd3/SMAFILZCEQ1X.json"
-        # )
-
-        upload_bucket = request.registry.settings.get("file_upload_bucket")
-
-        if upload_bucket:
-            s3 = boto_client("s3")
-            try:
-                # Load the JSON file from S3
-                s3_response = s3.get_object(
-                    Bucket=upload_bucket, Key=reference_file_upload_key
-                )
-                content = s3_response["Body"].read().decode("utf-8")
-                response["data"] = json.loads(content)
-                response["error"] = False
-                return response
-
-            except Exception:
-                response["error_msg"] = "Reference file could not be loaded from S3."
-                return response
-
-    except Exception as e:
-        response["error_msg"] = f"Error when trying to get QC overview data: {str(e)}"
-        request.response.status_code = 500
-        return response
+@view_config(route_name="get_somalier_overview", request_method="POST")
+@debug_log
+def get_somalier_overview(context, request):
+    return _get_reference_file_json(context, request, "somalier_data")

--- a/src/encoded/static/components/viz/QualityMetricVisualizations/BoxPlot.js
+++ b/src/encoded/static/components/viz/QualityMetricVisualizations/BoxPlot.js
@@ -43,12 +43,6 @@ export const BoxPlot = ({
     // Specify the dimensions of the chart.
     const chartWidth = 928;
     const chartHeight = 700;
-    const margins = {
-        top: 50,
-        right: 50,
-        bottom: 100,
-        left: 100,
-    };
 
     useEffect(() => {
         let doRerender = false;
@@ -58,6 +52,20 @@ export const BoxPlot = ({
         }
 
         if (!isDrawn.current || doRerender) {
+            const numGroups = new Set(
+                (customFilter
+                    ? qc_results.filter(customFilter)
+                    : qc_results
+                ).map((d) => d[qcCategory])
+            ).size;
+
+            const margins = {
+                top: 50,
+                right: 50,
+                bottom: numGroups > 5 ? 180 : 100,
+                left: 100,
+            };
+
             const container = d3.select(containerRef.current);
             container.selectAll('*').remove();
             // Create the SVG containers
@@ -135,9 +143,14 @@ export const BoxPlot = ({
             defs.append('clipPath')
                 .attr('id', 'clipx-' + plotId)
                 .append('rect')
-                .attr('x', 0)
+                .attr('x', numGroups > 5 ? -margins.left : 0)
                 .attr('y', chartHeight - margins.bottom)
-                .attr('width', chartWidth - margins.left - margins.right)
+                .attr(
+                    'width',
+                    numGroups > 5
+                        ? chartWidth - margins.right
+                        : chartWidth - margins.left - margins.right
+                )
                 .attr('height', margins.bottom / 2)
                 .attr('transform', 'translate(' + margins.left + ',0)');
 
@@ -268,6 +281,15 @@ export const BoxPlot = ({
                 )
                 .attr('style', 'font-family: Inter; font-size: 1.2rem')
                 .call(xAxis);
+
+            if (groupedData.size > 5) {
+                gX.selectAll('text')
+                    .attr('transform', 'rotate(-45)')
+                    .attr('text-anchor', 'end')
+                    .attr('style', 'font-family: Inter; font-size: 1.0rem')
+                    .attr('dx', '-0.5em')
+                    .attr('dy', '0.15em');
+            }
 
             const y = d3
                 .scaleLinear()

--- a/src/encoded/static/components/viz/QualityMetricVisualizations/DataTable.js
+++ b/src/encoded/static/components/viz/QualityMetricVisualizations/DataTable.js
@@ -182,7 +182,12 @@ export const DataTable = ({
             );
         }
 
-        const headerClass = col.length > 20 ? 'width-100' : '';
+        const headerClass =
+            col === 'Platform'
+                ? 'width-150-nw'
+                : col.length > 20
+                ? 'width-120'
+                : '';
 
         return (
             <th key={col}>

--- a/src/encoded/static/components/viz/QualityMetricVisualizations/index.js
+++ b/src/encoded/static/components/viz/QualityMetricVisualizations/index.js
@@ -13,7 +13,10 @@ import Tabs from 'react-bootstrap/Tabs';
 
 export const QualityMetricVisualizations = () => {
     const [qcData, setQcData] = useState(null);
-    const [tab, setTab] = useState('sample-integrity');
+    const [somalierData, setSomalierData] = useState(null);
+    const [somalierLoading, setSomalierLoading] = useState(false);
+    const [somalierLoadingFailed, setSomalierLoadingFailed] = useState(false);
+    const [tab, setTab] = useState('key-metrics');
     const [preselectedTab, setPreselectedTab] = useState(null);
     const [selectedFile, setSelectedFile] = useState(null);
     const [loadingFailed, setLoadingFailed] = useState(false);
@@ -60,6 +63,34 @@ export const QualityMetricVisualizations = () => {
         );
     }, []);
 
+    useEffect(() => {
+        if (tab !== 'sample-integrity' || somalierData || somalierLoading) return;
+        setSomalierLoading(true);
+        ajaxWithRetry(
+            '/get_somalier_overview/',
+            (resp) => {
+                setSomalierLoading(false);
+                if (resp.error) {
+                    setSomalierLoadingFailed(true);
+                    console.error(resp.error_msg);
+                    return;
+                }
+                setSomalierData(resp.data);
+            },
+            'POST',
+            () => {
+                setSomalierLoading(false);
+                setSomalierLoadingFailed(true);
+                console.log('ERROR loading somalier data after all retry attempts');
+            },
+            {
+                maxRetries: 3,
+                retryDelay: 1000,
+                retryDelayMultiplier: 2
+            }
+        );
+    }, [tab]);
+
     return qcData ? (
         <>
             <Tabs
@@ -67,12 +98,6 @@ export const QualityMetricVisualizations = () => {
                 activeKey={tab}
                 onSelect={(t) => setTab(t)}
                 className="mb-3">
-                <Tab eventKey="sample-integrity" title="Sample Integrity">
-                    <SampleContamination
-                        qcData={qcData}
-                        preselectedFile={selectedFile}
-                    />
-                </Tab>
                 <Tab eventKey="key-metrics" title="Key Metrics">
                     <KeyMetrics qcData={qcData} />
                 </Tab>
@@ -97,6 +122,27 @@ export const QualityMetricVisualizations = () => {
                         qcData={qcData}
                         preselectedFile={selectedFile}
                     />
+                </Tab>
+                <Tab eventKey="sample-integrity" title="Sample Integrity">
+                    {somalierLoading && (
+                        <div className="text-center m-5">
+                            <span className="spinner">
+                                <i className="icon icon-spin icon-circle-notch fas" />{' '}
+                                Loading...
+                            </span>
+                        </div>
+                    )}
+                    {somalierLoadingFailed && (
+                        <div className="alert alert-danger m-3">
+                            Failed to load sample integrity data.
+                        </div>
+                    )}
+                    {somalierData && (
+                        <SampleContamination
+                            qcData={{ ...qcData, somalier_results: somalierData }}
+                            preselectedFile={selectedFile}
+                        />
+                    )}
                 </Tab>
             </Tabs>
         </>

--- a/src/encoded/static/scss/encoded/modules/_viz.scss
+++ b/src/encoded/static/scss/encoded/modules/_viz.scss
@@ -951,9 +951,13 @@ Note: Colors for borders and backgrounds are defined in _tokens.scss.
         cursor: pointer;
         color: #343741;
     }
-    .width-100{
-        width: 100px;
-        $pure-white-space: wrap;
+    .width-120{
+        width: 120px;
+        white-space: normal;
+    }
+    .width-150-nw{
+        width: 150px;
+        white-space: nowrap;
     }
 }
 


### PR DESCRIPTION
This pull request introduces support for separate handling and display of "somalier" sample integrity results in the QC overview system. It includes backend changes to generate and serve two distinct JSON files (main QC results and somalier results), as well as frontend updates to load and display somalier data in a dedicated tab. 

Additionally, there are improvements to the box plot visualization and data table formatting for better usability.
