### PR TITLE
fix: remove unecessary fields from selection query

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,14 @@ Change Log
 ----------
 
 
+1.27.5
+======
+
+`PR 674: fix: remove unecessary fields from selection query <https://github.com/smaht-dac/smaht-portal/pull/674>`_
+
+* Remove unused fields from selectAll query
+
+
 1.27.4
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "1.27.4"
+version = "1.27.5"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/browse/BrowseView.js
+++ b/src/encoded/static/components/browse/BrowseView.js
@@ -49,7 +49,7 @@ export const BROWSE_STATUS_FILTERS =
 
 export const BROWSE_LINKS = {
     file:
-        '/browse/?type=File&sample_summary.studies=Production&dataset!=No+value&' +
+        '/browse/?type=File&sort=-file_status_tracking.release_dates.initial_release_date&sample_summary.studies=Production&dataset!=No+value&' +
         BROWSE_STATUS_FILTERS,
     donor:
         '/browse/?type=Donor&study=Production&tags=has_released_files&' +

--- a/src/encoded/static/components/browse/BrowseView.js
+++ b/src/encoded/static/components/browse/BrowseView.js
@@ -49,7 +49,7 @@ export const BROWSE_STATUS_FILTERS =
 
 export const BROWSE_LINKS = {
     file:
-        '/browse/?type=File&sort=-file_status_tracking.release_dates.initial_release_date&sample_summary.studies=Production&dataset!=No+value&' +
+        '/browse/?type=File&sample_summary.studies=Production&dataset!=No+value&' +
         BROWSE_STATUS_FILTERS,
     donor:
         '/browse/?type=Donor&study=Production&tags=has_released_files&' +

--- a/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
+++ b/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
@@ -120,7 +120,7 @@ const manifest_enum_map = [
 
 export class SelectAllFilesButton extends React.PureComponent {
     /** These are fields included when "Select All" button is clicked to AJAX all files in */
-    static fieldsToRequest = ['accession', '@id', 'file_sets.@id'];
+    static fieldsToRequest = ['accession', 'display_title', '@id', '@type', 'file_sets.@id'];
 
     constructor(props) {
         super(props);

--- a/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
+++ b/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
@@ -120,7 +120,13 @@ const manifest_enum_map = [
 
 export class SelectAllFilesButton extends React.PureComponent {
     /** These are fields included when "Select All" button is clicked to AJAX all files in */
-    static fieldsToRequest = ['accession', 'display_title', '@id', '@type', 'file_sets.@id'];
+    static fieldsToRequest = [
+        'accession',
+        'display_title',
+        '@id',
+        '@type',
+        'file_sets.@id',
+    ];
 
     constructor(props) {
         super(props);
@@ -174,6 +180,10 @@ export class SelectAllFilesButton extends React.PureComponent {
                 const currentHrefQuery = _.extend({}, currentHrefParts.query);
                 currentHrefQuery.field = SelectAllFilesButton.fieldsToRequest;
                 currentHrefQuery.limit = 'all';
+
+                // Strip sort to avoid ES returning duplicate entries
+                delete currentHrefQuery.sort;
+
                 const reqHref =
                     currentHrefParts.pathname +
                     '?' +

--- a/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
+++ b/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
@@ -120,18 +120,7 @@ const manifest_enum_map = [
 
 export class SelectAllFilesButton extends React.PureComponent {
     /** These are fields included when "Select All" button is clicked to AJAX all files in */
-    static fieldsToRequest = [
-        'accession',
-        'display_title',
-        '@id',
-        '@type',
-        'status',
-        'data_type',
-        'file_format.*',
-        'submission_centers.display_title',
-        'consortia.display_title',
-        'file_sets',
-    ];
+    static fieldsToRequest = ['accession', '@id', 'file_sets.@id'];
 
     constructor(props) {
         super(props);


### PR DESCRIPTION
[Trello Ticket 887](https://trello.com/c/GYR55pKm/887-bug-select-all-query-parameters)
* Remove unused fields from selectAll query
* Strip sort parameter from search query