### PR TITLE
Improve Select All scalability with paginated fetch + progress UI; remove Bluebird Babel coupling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,7 @@
         "no-invalid-this" : "error",
         "no-tabs" : "error",
         "no-trailing-spaces" : "error",
-        "no-undef": 0,
+        "no-undef": "error",
         "no-unused-vars": ["warn", { "args" : "none" }],
         "no-useless-concat": "error",
         "no-useless-constructor": "error",

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,15 @@ Change Log
 ----------
 
 
+1.28.0
+=======
+
+`PR 677: Improve Select All scalability with paginated fetch + progress UI; remove Bluebird Babel coupling <https://github.com/smaht-dac/smaht-portal/pull/677>`_
+
+* Improves the Select All workflow for large file result sets by replacing limit=all with paginated requests and adding user-visible progress feedback
+* Removes a fragile Babel Bluebird coupling that caused CI/CodeBuild failures
+
+
 1.27.10
 =======
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -16,13 +16,7 @@ module.exports = function (api) {
             '@babel/plugin-proposal-class-properties',
             'babel-plugin-minify-dead-code-elimination',
             ['@babel/plugin-proposal-decorators', { legacy: true }],
-            [
-                '@babel/transform-async-to-generator',
-                {
-                    module: 'bluebird',
-                    method: 'coroutine',
-                },
-            ],
+            ['@babel/transform-async-to-generator'],
             [
                 '@babel/plugin-proposal-pipeline-operator',
                 { proposal: 'minimal' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@gmod/tabix": "^1.5.3",
         "@gmod/vcf": "^5.0.6",
         "@hms-dbmi-bgm/react-workflow-viz": "0.1.11",
-        "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.99",
+        "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.100b1",
         "@reduxjs/toolkit": "^2.2.6",
         "auth0-lock": "^12.5.1",
         "d3": "^7.8.5",
@@ -2497,8 +2497,8 @@
       }
     },
     "node_modules/@hms-dbmi-bgm/shared-portal-components": {
-      "version": "0.1.99",
-      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#66fe56f9998352035a0d351e4f6441699581eb97",
+      "version": "0.1.100",
+      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#1cdcf8cba0909008a4043ac86a1f5813c15f69f4",
       "license": "MIT",
       "dependencies": {
         "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",
@@ -4081,9 +4081,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -6341,9 +6341,9 @@
       }
     },
     "node_modules/cypress/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -7646,14 +7646,14 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
-      "version": "2.0.0-next.6",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
-      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
+        "is-core-module": "^2.16.2",
         "node-exports-info": "^1.6.0",
         "object-keys": "^1.1.1",
         "path-parse": "^1.0.7",
@@ -9057,9 +9057,10 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -9512,12 +9513,12 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10289,9 +10290,9 @@
       }
     },
     "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -13641,9 +13642,9 @@
       }
     },
     "node_modules/superagent/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -14658,9 +14659,9 @@
       }
     },
     "node_modules/vue-eslint-parser/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -15236,9 +15237,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@gmod/tabix": "^1.5.3",
         "@gmod/vcf": "^5.0.6",
         "@hms-dbmi-bgm/react-workflow-viz": "0.1.11",
-        "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.100b1",
+        "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.99",
         "@reduxjs/toolkit": "^2.2.6",
         "auth0-lock": "^12.5.1",
         "d3": "^7.8.5",
@@ -2497,8 +2497,8 @@
       }
     },
     "node_modules/@hms-dbmi-bgm/shared-portal-components": {
-      "version": "0.1.100",
-      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#1cdcf8cba0909008a4043ac86a1f5813c15f69f4",
+      "version": "0.1.99",
+      "resolved": "git+ssh://git@github.com/4dn-dcic/shared-portal-components.git#66fe56f9998352035a0d351e4f6441699581eb97",
       "license": "MIT",
       "dependencies": {
         "@4dn-dcic/react-infinite": "github:4dn-dcic/react-infinite#1.1.9",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@gmod/tabix": "^1.5.3",
     "@gmod/vcf": "^5.0.6",
     "@hms-dbmi-bgm/react-workflow-viz": "0.1.11",
-    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.99",
+    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.100b1",
     "@reduxjs/toolkit": "^2.2.6",
     "auth0-lock": "^12.5.1",
     "d3": "^7.8.5",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@gmod/tabix": "^1.5.3",
     "@gmod/vcf": "^5.0.6",
     "@hms-dbmi-bgm/react-workflow-viz": "0.1.11",
-    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.100b1",
+    "@hms-dbmi-bgm/shared-portal-components": "github:4dn-dcic/shared-portal-components#0.1.99",
     "@reduxjs/toolkit": "^2.2.6",
     "auth0-lock": "^12.5.1",
     "d3": "^7.8.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "1.27.10"
+version = "1.28.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
+++ b/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
@@ -136,6 +136,7 @@ export class SelectAllFilesButton extends React.PureComponent {
             ? 25
             : 500;
     static defaultConcurrentRequests = 4;
+    static localhostBatchDelayMs = 1500;
     static propTypes = {
         context: PropTypes.object,
         selectedItems: PropTypes.object,
@@ -153,7 +154,7 @@ export class SelectAllFilesButton extends React.PureComponent {
         this.fetchAllPagesForSelection = this.fetchAllPagesForSelection.bind(
             this
         );
-        this.state = { selecting: false };
+        this.state = { selecting: false, selectingProgress: 0 };
     }
 
     getSelectAllConfig() {
@@ -196,6 +197,10 @@ export class SelectAllFilesButton extends React.PureComponent {
         }
 
         const fetchedResults = [];
+        const isLocalhost =
+            typeof window !== 'undefined' &&
+            (window.location.hostname === 'localhost' ||
+                window.location.hostname === '127.0.0.1');
 
         // Fetch in bounded concurrent batches to avoid overwhelming the API.
         for (
@@ -217,6 +222,14 @@ export class SelectAllFilesButton extends React.PureComponent {
                     return ajax.promise(reqHref);
                 })
             );
+            const completedPages = Math.min(
+                pageStarts.length,
+                batchStart + batchStarts.length
+            );
+            const selectingProgress = Math.round(
+                (completedPages / pageStarts.length) * 100
+            );
+            this.setState({ selectingProgress });
 
             batchResponses.forEach((resp) => {
                 const pageItems = (resp && resp['@graph']) || [];
@@ -224,6 +237,16 @@ export class SelectAllFilesButton extends React.PureComponent {
                     fetchedResults.push(...pageItems);
                 }
             });
+
+            // Dev-only pacing so progress UI can be observed with small local datasets.
+            if (isLocalhost && batchStart + batchStarts.length < pageStarts.length) {
+                await new Promise((resolve) => {
+                    window.setTimeout(
+                        resolve,
+                        SelectAllFilesButton.localhostBatchDelayMs
+                    );
+                });
+            }
         }
 
         return fetchedResults;
@@ -268,12 +291,15 @@ export class SelectAllFilesButton extends React.PureComponent {
             );
         }
 
-        this.setState({ selecting: true }, () => {
+        this.setState({ selecting: true, selectingProgress: 0 }, () => {
             if (!this.isAllSelected()) {
                 this.fetchAllPagesForSelection(searchHref)
                     .then((filesToSelect) => {
                         onSelectItem(filesToSelect, true);
-                        this.setState({ selecting: false });
+                        this.setState({
+                            selecting: false,
+                            selectingProgress: 0,
+                        });
 
                         //analytics
                         const extData = {
@@ -319,17 +345,20 @@ export class SelectAllFilesButton extends React.PureComponent {
                             message:
                                 'Unable to fetch all pages of files for selection. Please try again.',
                         });
-                        this.setState({ selecting: false });
+                        this.setState({
+                            selecting: false,
+                            selectingProgress: 0,
+                        });
                     });
             } else {
                 onResetSelectedItems();
-                this.setState({ selecting: false });
+                this.setState({ selecting: false, selectingProgress: 0 });
             }
         });
     }
 
     render() {
-        const { selecting } = this.state;
+        const { selecting, selectingProgress } = this.state;
         const { type } = this.props;
 
         const isAllSelected = this.isAllSelected();
@@ -361,19 +390,39 @@ export class SelectAllFilesButton extends React.PureComponent {
         }
 
         return (
-            <button
-                type="button"
-                id="select-all-files-button"
-                disabled={selecting || (!isAllSelected && !isEnabled)}
-                className={cls}
-                onClick={this.handleSelectAll}
-                data-tip={tooltip}>
-                <i className={iconClassName} />
-                <span className="d-none d-md-inline text-400">
-                    {isAllSelected ? 'Deselect' : 'Select'}{' '}
-                </span>
-                <span className="text-600">All</span>
-            </button>
+            <div className="d-inline-flex flex-column">
+                <button
+                    type="button"
+                    id="select-all-files-button"
+                    disabled={selecting || (!isAllSelected && !isEnabled)}
+                    className={cls}
+                    onClick={this.handleSelectAll}
+                    data-tip={tooltip}>
+                    <i className={iconClassName} />
+                    <span className="d-none d-md-inline text-400">
+                        {selecting
+                            ? `Selecting ${selectingProgress}%`
+                            : isAllSelected
+                            ? 'Deselect'
+                            : 'Select'}{' '}
+                    </span>
+                    <span className="text-600">All</span>
+                </button>
+                {selecting ? (
+                    <div
+                        className="progress mt-03"
+                        style={{ height: '3px', minWidth: '120px' }}>
+                        <div
+                            className="progress-bar"
+                            role="progressbar"
+                            style={{ width: `${selectingProgress}%` }}
+                            aria-valuenow={selectingProgress}
+                            aria-valuemin="0"
+                            aria-valuemax="100"
+                        />
+                    </div>
+                ) : null}
+            </div>
         );
     }
 }

--- a/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
+++ b/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
@@ -24,27 +24,14 @@ import { useUserDownloadAccess } from '../../util/hooks';
 
 export const SelectAllAboveTableComponent = (props) => {
     const {
-        href,
-        searchHref,
         context,
-        onFilter,
-        schemas,
-        isContextLoading = false, // Present only on embedded search views,
-        navigate,
-        sortBy,
-        sortColumns,
-        hiddenColumns,
-        addHiddenColumn,
-        removeHiddenColumn,
-        columnDefinitions,
         session,
         selectedItems, // From SelectedItemsController
         onSelectItem, // From SelectedItemsController
         onResetSelectedItems, // From SelectedItemsController
         deniedAccessPopoverType = 'login', // default to login popover
     } = props;
-    const { filters: ctxFilters = null, total: totalResultCount = 0 } =
-        context || {};
+    const { total: totalResultCount = 0 } = context || {};
 
     // Get user download access
     const { userDownloadAccess } = useUserDownloadAccess(session);
@@ -96,6 +83,7 @@ export const SelectAllAboveTableComponent = (props) => {
                             )
                         }>
                         <button
+                            type="button"
                             className="download-button btn btn-primary btn-sm me-05 align-items-center pe-auto"
                             disabled={true}>
                             <i className="icon icon-download fas me-03" />
@@ -191,7 +179,8 @@ export class SelectAllFilesButton extends React.PureComponent {
         const nextWidth = Math.ceil(
             this.selectAllButtonRef.current.getBoundingClientRect().width
         );
-        if (nextWidth > 0 && this.state.progressTrackWidth !== nextWidth) {
+        const { progressTrackWidth } = this.state;
+        if (nextWidth > 0 && progressTrackWidth !== nextWidth) {
             this.setState({ progressTrackWidth: nextWidth });
         }
     }
@@ -410,8 +399,8 @@ export class SelectAllFilesButton extends React.PureComponent {
             (selecting
                 ? 'circle-notch icon-spin fas'
                 : isAllSelected
-                ? 'square far'
-                : 'check-square far');
+                    ? 'square far'
+                    : 'check-square far');
         const cls =
             'btn btn-sm me-05 align-items-center ' +
             (isAllSelected ? 'btn-secondary' : 'btn-outline-secondary');
@@ -446,8 +435,8 @@ export class SelectAllFilesButton extends React.PureComponent {
                         {selecting
                             ? `Selecting ${selectingProgress}%`
                             : isAllSelected
-                            ? 'Deselect'
-                            : 'Select'}{' '}
+                                ? 'Deselect'
+                                : 'Select'}{' '}
                     </span>
                     <span className="text-600">All</span>
                 </button>
@@ -531,7 +520,7 @@ export class SelectedItemsDownloadButton extends React.PureComponent {
         } = this.props;
         const { modalOpen } = this.state;
         const isDisabled =
-            typeof disabled === 'boolean' ? disabled : fileCountWithDupes === 0;
+            typeof disabled === 'boolean' ? disabled : selectedItems.size === 0;
         btnProps.className =
             'btn ' + (modalOpen ? 'active ' : '') + btnProps.className;
         return (
@@ -1124,6 +1113,12 @@ const DataDownloadOverviewStats = React.memo(function DataDownloadOverviewStats(
 
 const ModalCodeSnippets = React.memo(function ModalCodeSnippets(props) {
     const { filename, session, setIsAWSDownload, isAWSDownload } = props;
+    const onTabSelect = useCallback(
+        (k) => {
+            setIsAWSDownload(k === 'aws');
+        },
+        [setIsAWSDownload]
+    );
 
     // Assign html and plain values for each command
     const aws_cli = {
@@ -1195,9 +1190,7 @@ const ModalCodeSnippets = React.memo(function ModalCodeSnippets(props) {
             <Tabs
                 defaultActiveKey="curl"
                 variant="pills"
-                onSelect={(k) => {
-                    setIsAWSDownload(k === 'aws');
-                }}>
+                onSelect={onTabSelect}>
                 <Tab
                     eventKey="curl"
                     title={
@@ -1264,7 +1257,6 @@ const SelectedItemsDownloadStartButton = React.memo(
     function SelectedItemsDownloadStartButton(props) {
         const {
             suggestedFilename,
-            selectedItems,
             accessionArray = [],
             action,
             isAWSDownload,
@@ -1302,10 +1294,7 @@ const SelectedItemsDownloadStartButton = React.memo(
                         className="btn btn-primary mt-0 me-1 btn-block-xs-only"
                         data-tip="Details for each individual selected file delivered via a TSV spreadsheet.">
                         <i className="icon icon-fw icon-download fas me-1" />
-                        Download <b>
-                            {isAWSDownload ? 'AWS CLI ' : 'cURL'}
-                        </b>{' '}
-                        File Manifest
+                        Download <b>{isAWSDownload ? 'AWS CLI ' : 'cURL'}</b> File Manifest
                     </button>
                 </form>
             </>

--- a/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
+++ b/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
@@ -128,14 +128,13 @@ export class SelectAllFilesButton extends React.PureComponent {
         '@type',
         'file_sets.@id'
     ];
-    // Keep local batches intentionally small for easier debugging and request tracing.
-    // Production/staging continue to use a larger default for fewer round trips.
-    static defaultPageSize =
+    static isLocalhost =
         typeof window !== 'undefined' &&
         (window.location.hostname === 'localhost' ||
-            window.location.hostname === '127.0.0.1')
-            ? 25
-            : 500;
+            window.location.hostname === '127.0.0.1');
+    // Keep local batches intentionally small for easier debugging and request tracing.
+    // Production/staging continue to use a larger default for fewer round trips.
+    static defaultPageSize = SelectAllFilesButton.isLocalhost ? 25 : 500;
     static defaultConcurrentRequests = 4;
     static localhostBatchDelayMs = 1500;
     static propTypes = {
@@ -233,12 +232,11 @@ export class SelectAllFilesButton extends React.PureComponent {
         }
 
         const fetchedResults = [];
-        const isLocalhost =
-            typeof window !== 'undefined' &&
-            (window.location.hostname === 'localhost' ||
-                window.location.hostname === '127.0.0.1');
 
         // Fetch in bounded concurrent batches to avoid overwhelming the API.
+        // Intentional await-in-loop: each chunk waits for the previous chunk so we enforce a
+        // fixed concurrency cap across the full request set.
+        /* eslint-disable no-await-in-loop */
         for (
             let batchStart = 0;
             batchStart < pageStarts.length;
@@ -275,7 +273,10 @@ export class SelectAllFilesButton extends React.PureComponent {
             });
 
             // Dev-only pacing so progress UI can be observed with small local datasets.
-            if (isLocalhost && batchStart + batchStarts.length < pageStarts.length) {
+            if (
+                SelectAllFilesButton.isLocalhost &&
+                batchStart + batchStarts.length < pageStarts.length
+            ) {
                 await new Promise((resolve) => {
                     window.setTimeout(
                         resolve,
@@ -284,6 +285,7 @@ export class SelectAllFilesButton extends React.PureComponent {
                 });
             }
         }
+        /* eslint-enable no-await-in-loop */
 
         return fetchedResults;
     }

--- a/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
+++ b/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
@@ -156,29 +156,33 @@ export class SelectAllFilesButton extends React.PureComponent {
         );
         this.updateProgressTrackWidth = this.updateProgressTrackWidth.bind(this);
         this.selectAllButtonRef = React.createRef();
+        this.selectAllButtonResizeObserver = null;
         this.state = { selecting: false, selectingProgress: 0, progressTrackWidth: null };
     }
 
     componentDidMount() {
         this.updateProgressTrackWidth();
-        if (typeof window !== 'undefined') {
+        if (
+            typeof window !== 'undefined' &&
+            typeof window.ResizeObserver === 'function' &&
+            this.selectAllButtonRef.current
+        ) {
+            this.selectAllButtonResizeObserver = new window.ResizeObserver(() => {
+                this.updateProgressTrackWidth();
+            });
+            this.selectAllButtonResizeObserver.observe(this.selectAllButtonRef.current);
+        } else if (typeof window !== 'undefined') {
+            // Fallback for environments lacking ResizeObserver support.
             window.addEventListener('resize', this.updateProgressTrackWidth);
         }
     }
 
     componentWillUnmount() {
-        if (typeof window !== 'undefined') {
+        if (this.selectAllButtonResizeObserver) {
+            this.selectAllButtonResizeObserver.disconnect();
+            this.selectAllButtonResizeObserver = null;
+        } else if (typeof window !== 'undefined') {
             window.removeEventListener('resize', this.updateProgressTrackWidth);
-        }
-    }
-
-    componentDidUpdate(prevProps, prevState) {
-        const { selecting, selectingProgress } = this.state;
-        if (
-            prevState.selecting !== selecting ||
-            prevState.selectingProgress !== selectingProgress
-        ) {
-            this.updateProgressTrackWidth();
         }
     }
 

--- a/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
+++ b/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
@@ -154,7 +154,42 @@ export class SelectAllFilesButton extends React.PureComponent {
         this.fetchAllPagesForSelection = this.fetchAllPagesForSelection.bind(
             this
         );
-        this.state = { selecting: false, selectingProgress: 0 };
+        this.updateProgressTrackWidth = this.updateProgressTrackWidth.bind(this);
+        this.selectAllButtonRef = React.createRef();
+        this.state = { selecting: false, selectingProgress: 0, progressTrackWidth: null };
+    }
+
+    componentDidMount() {
+        this.updateProgressTrackWidth();
+        if (typeof window !== 'undefined') {
+            window.addEventListener('resize', this.updateProgressTrackWidth);
+        }
+    }
+
+    componentWillUnmount() {
+        if (typeof window !== 'undefined') {
+            window.removeEventListener('resize', this.updateProgressTrackWidth);
+        }
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+        const { selecting, selectingProgress } = this.state;
+        if (
+            prevState.selecting !== selecting ||
+            prevState.selectingProgress !== selectingProgress
+        ) {
+            this.updateProgressTrackWidth();
+        }
+    }
+
+    updateProgressTrackWidth() {
+        if (!this.selectAllButtonRef.current) return;
+        const nextWidth = Math.ceil(
+            this.selectAllButtonRef.current.getBoundingClientRect().width
+        );
+        if (nextWidth > 0 && this.state.progressTrackWidth !== nextWidth) {
+            this.setState({ progressTrackWidth: nextWidth });
+        }
     }
 
     getSelectAllConfig() {
@@ -358,7 +393,7 @@ export class SelectAllFilesButton extends React.PureComponent {
     }
 
     render() {
-        const { selecting, selectingProgress } = this.state;
+        const { selecting, selectingProgress, progressTrackWidth } = this.state;
         const { type } = this.props;
 
         const isAllSelected = this.isAllSelected();
@@ -392,6 +427,7 @@ export class SelectAllFilesButton extends React.PureComponent {
         return (
             <div className="d-inline-flex flex-column">
                 <button
+                    ref={this.selectAllButtonRef}
                     type="button"
                     id="select-all-files-button"
                     disabled={selecting || (!isAllSelected && !isEnabled)}
@@ -411,7 +447,16 @@ export class SelectAllFilesButton extends React.PureComponent {
                 {selecting ? (
                     <div
                         className="progress mt-03"
-                        style={{ height: '3px', minWidth: '120px' }}>
+                        style={{
+                            height: '3px',
+                            width:
+                                progressTrackWidth && Number.isFinite(progressTrackWidth)
+                                    ? `${progressTrackWidth}px`
+                                    : '100%',
+                            minWidth: '120px',
+                            overflow: 'hidden',
+                            boxSizing: 'border-box',
+                        }}>
                         <div
                             className="progress-bar"
                             role="progressbar"

--- a/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
+++ b/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
@@ -125,21 +125,108 @@ export class SelectAllFilesButton extends React.PureComponent {
         'display_title',
         '@id',
         '@type',
-        // 'file_sets.@id', //uncomment later
-        // comment below lines after testing SPC 0.1.100
-        'status',
-        'data_type',
-        'file_format.*',
-        'submission_centers.display_title',
-        'consortia.display_title',
-        'file_sets',
+        'file_sets.@id'
     ];
+    // Keep local batches intentionally small for easier debugging and request tracing.
+    // Production/staging continue to use a larger default for fewer round trips.
+    static defaultPageSize =
+        typeof window !== 'undefined' &&
+        (window.location.hostname === 'localhost' ||
+            window.location.hostname === '127.0.0.1')
+            ? 25
+            : 500;
+    static defaultConcurrentRequests = 4;
+    static propTypes = {
+        context: PropTypes.object,
+        selectedItems: PropTypes.object,
+        onSelectItem: PropTypes.func,
+        onResetSelectedItems: PropTypes.func,
+        type: PropTypes.string,
+        selectAllPageSize: PropTypes.number,
+        selectAllConcurrentRequests: PropTypes.number,
+    };
 
     constructor(props) {
         super(props);
         this.isAllSelected = this.isAllSelected.bind(this);
         this.handleSelectAll = this.handleSelectAll.bind(this);
+        this.fetchAllPagesForSelection = this.fetchAllPagesForSelection.bind(
+            this
+        );
         this.state = { selecting: false };
+    }
+
+    getSelectAllConfig() {
+        const {
+            context = {},
+            selectAllPageSize = SelectAllFilesButton.defaultPageSize,
+            selectAllConcurrentRequests = SelectAllFilesButton.defaultConcurrentRequests,
+        } = this.props;
+        const { total = 0 } = context;
+        const safeTotal = Number.isFinite(total) ? total : 0;
+        const safePageSize = Math.max(1, Number(selectAllPageSize) || 1);
+        const safeConcurrentRequests = Math.max(
+            1,
+            Number(selectAllConcurrentRequests) || 1
+        );
+        return {
+            total: safeTotal,
+            pageSize: safePageSize,
+            concurrentRequests: safeConcurrentRequests,
+        };
+    }
+
+    async fetchAllPagesForSelection(searchHref) {
+        const currentHrefParts = memoizedUrlParse(searchHref);
+        const currentHrefQuery = _.extend({}, currentHrefParts.query);
+        const { total, pageSize, concurrentRequests } = this.getSelectAllConfig();
+
+        currentHrefQuery.field = SelectAllFilesButton.fieldsToRequest;
+        currentHrefQuery.limit = pageSize;
+
+        delete currentHrefQuery.sort;
+
+        // Build pagination offsets (`from`) and request each page with `limit=pageSize`.
+        const pageStarts = [];
+        for (let from = 0; from < total; from += pageSize) {
+            pageStarts.push(from);
+        }
+        if (pageStarts.length === 0) {
+            pageStarts.push(0);
+        }
+
+        const fetchedResults = [];
+
+        // Fetch in bounded concurrent batches to avoid overwhelming the API.
+        for (
+            let batchStart = 0;
+            batchStart < pageStarts.length;
+            batchStart += concurrentRequests
+        ) {
+            const batchStarts = pageStarts.slice(
+                batchStart,
+                batchStart + concurrentRequests
+            );
+            const batchResponses = await Promise.all(
+                batchStarts.map((from) => {
+                    const query = { ...currentHrefQuery, from };
+                    const reqHref =
+                        currentHrefParts.pathname +
+                        '?' +
+                        queryString.stringify(query);
+                    return ajax.promise(reqHref);
+                })
+            );
+
+            batchResponses.forEach((resp) => {
+                const pageItems = (resp && resp['@graph']) || [];
+                if (Array.isArray(pageItems) && pageItems.length > 0) {
+                    fetchedResults.push(...pageItems);
+                }
+            });
+        }
+
+        return fetchedResults;
     }
 
     isEnabled() {
@@ -183,56 +270,57 @@ export class SelectAllFilesButton extends React.PureComponent {
 
         this.setState({ selecting: true }, () => {
             if (!this.isAllSelected()) {
-                const currentHrefParts = memoizedUrlParse(searchHref);
-                const currentHrefQuery = _.extend({}, currentHrefParts.query);
-                currentHrefQuery.field = SelectAllFilesButton.fieldsToRequest;
-                currentHrefQuery.limit = 'all';
+                this.fetchAllPagesForSelection(searchHref)
+                    .then((filesToSelect) => {
+                        onSelectItem(filesToSelect, true);
+                        this.setState({ selecting: false });
 
-                // Strip sort to avoid ES returning duplicate entries
-                // delete currentHrefQuery.sort; //temporarily commented for testing SPC 0.1.100
-
-                const reqHref =
-                    currentHrefParts.pathname +
-                    '?' +
-                    queryString.stringify(currentHrefQuery);
-
-                ajax.load(reqHref, (resp) => {
-                    const filesToSelect = resp['@graph'] || [];
-                    onSelectItem(filesToSelect, true);
-                    this.setState({ selecting: false });
-
-                    //analytics
-                    const extData = {
-                        item_list_name: analytics.hrefToListName(
-                            window && window.location.href
-                        ),
-                    };
-                    const products = analytics.transformItemsToProducts(
-                        filesToSelect,
-                        extData
-                    );
-                    const productsLength = Array.isArray(products)
-                        ? products.length
-                        : filesToSelect.length;
-                    analytics.event(
-                        'add_to_cart',
-                        'SelectAllFilesButton',
-                        'Select All',
-                        function () {
-                            console.info(
-                                `Adding ${productsLength} items from cart.`
-                            );
-                        },
-                        {
-                            items: Array.isArray(products) ? products : null,
-                            list_name: extData.item_list_name,
-                            value: productsLength,
-                            // filters: analytics.getStringifiedCurrentFilters(
-                            //     (context && context.filters) || null
-                            // ),
-                        }
-                    );
-                });
+                        //analytics
+                        const extData = {
+                            item_list_name: analytics.hrefToListName(
+                                window && window.location.href
+                            ),
+                        };
+                        const products = analytics.transformItemsToProducts(
+                            filesToSelect,
+                            extData
+                        );
+                        const productsLength = Array.isArray(products)
+                            ? products.length
+                            : filesToSelect.length;
+                        analytics.event(
+                            'add_to_cart',
+                            'SelectAllFilesButton',
+                            'Select All',
+                            function () {
+                                console.info(
+                                    `Adding ${productsLength} items from cart.`
+                                );
+                            },
+                            {
+                                items: Array.isArray(products)
+                                    ? products
+                                    : null,
+                                list_name: extData.item_list_name,
+                                value: productsLength,
+                                // filters: analytics.getStringifiedCurrentFilters(
+                                //     (context && context.filters) || null
+                                // ),
+                            }
+                        );
+                    })
+                    .catch((err) => {
+                        console.error(
+                            'Failed to fetch all pages for Select All',
+                            err
+                        );
+                        Alerts.queue({
+                            title: 'Select All Failed',
+                            message:
+                                'Unable to fetch all pages of files for selection. Please try again.',
+                        });
+                        this.setState({ selecting: false });
+                    });
             } else {
                 onResetSelectedItems();
                 this.setState({ selecting: false });

--- a/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
+++ b/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
@@ -18,6 +18,7 @@ import {
     logger,
     valueTransforms,
 } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
+import { Alerts } from '@hms-dbmi-bgm/shared-portal-components/es/components/ui/Alerts';
 import { display as dateTimeDisplay } from '@hms-dbmi-bgm/shared-portal-components/es/components/ui/LocalizedTime';
 import { useUserDownloadAccess } from '../../util/hooks';
 

--- a/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
+++ b/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
@@ -125,7 +125,14 @@ export class SelectAllFilesButton extends React.PureComponent {
         'display_title',
         '@id',
         '@type',
-        'file_sets.@id',
+        // 'file_sets.@id', //uncomment later
+        // comment below lines after testing SPC 0.1.100
+        'status',
+        'data_type',
+        'file_format.*',
+        'submission_centers.display_title',
+        'consortia.display_title',
+        'file_sets',
     ];
 
     constructor(props) {
@@ -182,7 +189,7 @@ export class SelectAllFilesButton extends React.PureComponent {
                 currentHrefQuery.limit = 'all';
 
                 // Strip sort to avoid ES returning duplicate entries
-                delete currentHrefQuery.sort;
+                // delete currentHrefQuery.sort; //temporarily commented for testing SPC 0.1.100
 
                 const reqHref =
                     currentHrefParts.pathname +


### PR DESCRIPTION
### Summary
This PR improves the **Select All** workflow for large file result sets by replacing `limit=all` with paginated requests and adding user-visible progress feedback.  
It also removes a fragile Babel Bluebird coupling that caused CI/CodeBuild failures.

### Changes
- Reworked `SelectAllFilesButton` to fetch results in pages using `from` + `limit` and merge results client-side.
- Added bounded parallelism for page requests (`Promise.all` in batches) with configurable knobs:
  - `selectAllPageSize`
  - `selectAllConcurrentRequests`
- Kept localhost-friendly defaults for testing:
  - smaller local page size
  - optional localhost-only artificial batch delay to make progress visibly trackable
- Added Select All progress UI:
  - button text updates while selecting (e.g. `Selecting 67% All`)
  - thin progress bar shown under button during selection
  - width measurement/refinement so progress bar aligns with dynamic button width
- Improved error handling for Select All batch fetch failures (user notification + cleanup state).
- Updated Babel config to remove `bluebird.coroutine` async transform dependency:
  - changed `@babel/transform-async-to-generator` usage to standard transform (no Bluebird module dependency).

### Why
- `limit=all` was causing production strain/failures with large result sets.
- Users needed visibility during long-running selection operations.
- CodeBuild/prod build failures were triggered by missing `bluebird` module despite local success.

### Impact
- Better production behavior for large Select All actions.
- Improved UX during long selects.
- More robust CI/build behavior across environments.

### Validation
- Local production build succeeds after Babel update (`npm run build`).
- Local clean install check confirmed Bluebird is only transitive under Cypress, not a reliable app dependency.
- Manual UI verification performed for Select All progress behavior and reset paths.

### Files touched
- `src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js`
- `babel.config.js`

### Notes
- No backend API contract changes in this PR.
- Current implementation keeps requested fields constrained to `fieldsToRequest` for selection payload efficiency.