### PR TITLE
Improve Data Matrix coverage summaries and loading behavior

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,20 @@ smaht-portal
 Change Log
 ----------
 
+
+1.30.2
+======
+
+`PR 687: Improve Data Matrix coverage summaries and loading behavior <https://github.com/smaht-dac/smaht-portal/pull/687>`_
+
+* added total coverage support to matrix summary rows and popovers
+* improved compact coverage value formatting and tooltip behavior
+* introduced a separate color range segment step for coverage values
+* reset incompatible count toggles when switching between matrix modes
+* refined loading-state rendering to avoid confusing stale data during tab/view transitions
+* adjusted matrix loading layout and spinner positioning for a more stable UX
+
+
 1.30.1
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "1.30.1"
+version = "1.30.2"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/static-pages/components/DataMatrixComparisonTabs.js
+++ b/src/encoded/static/components/static-pages/components/DataMatrixComparisonTabs.js
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
-import DataMatrix from '../../viz/Matrix/DataMatrix';
+import DataMatrix, { isLocalEnv } from '../../viz/Matrix/DataMatrix';
 
 export function DataMatrixComparisonTabs({ session, tabs }) {
     const tabConfigs = useMemo(() => tabs || [], [tabs]);
@@ -140,10 +140,12 @@ export function DataMatrixComparisonTabs({ session, tabs }) {
     const handleDataLoaded = useCallback((tabKey) => (payload = {}) => {
         const totalFiles = typeof payload.totalFiles === 'number' ? payload.totalFiles : 0;
         const hasData = typeof payload.hasData === 'boolean' ? payload.hasData : totalFiles > 0;
-        setTabDataState((prev) => ({
-            ...prev,
-            [tabKey]: { hasData, totalFiles, loaded: true }
-        }));
+        setTabDataState((prev) => {
+            return {
+                ...prev,
+                [tabKey]: { hasData, totalFiles, loaded: true }
+            };
+        });
     }, []);
 
     const hasAnyLoaded = tabConfigs.some((tab) => tabDataState[tab.key]?.loaded);
@@ -207,11 +209,6 @@ export function DataMatrixComparisonTabs({ session, tabs }) {
         <div key="data-matrix-tabs" className="data-matrix-container container-fluid px-0">
             <div className="row">
                 <div className="tabs-container d-flex flex-column" aria-busy={isLoading}>
-                    {isLoading ? (
-                        <div className="tabs-loading-overlay d-flex align-items-center justify-content-center">
-                            <i className="icon icon-spin icon-circle-notch fas" />
-                        </div>
-                    ) : null}
                     <div className="tab-headers d-flex flex-wrap gap-3">
                         {renderTabs.map((tab) => {
                             const isActive = tab.key === selectedTab?.key;
@@ -268,6 +265,8 @@ export function DataMatrixComparisonTabs({ session, tabs }) {
                                                 showCountFor={typeof selectedTab?.matrixProps?.showCountFor === 'boolean'
                                                     ? selectedTab.matrixProps.showCountFor
                                                     : true}
+                                                // Keep loading visible while iterating on matrix UX locally.
+                                                debugLoadingDelayMs={isLocalEnv() ? 2500 : 0}
                                                 key={(selectedTab.matrixProps && selectedTab.matrixProps.key) || selectedTab.key}
                                                 session={session}
                                                 onDataLoaded={handleDataLoaded(selectedTab.key)}

--- a/src/encoded/static/components/viz/Matrix/DataMatrix.js
+++ b/src/encoded/static/components/viz/Matrix/DataMatrix.js
@@ -14,6 +14,13 @@ import { compareTissueFacetTerms } from '../../util/data';
 import { FILE_BROWSE_HIDE_FACETS } from '../../browse/BrowseView';
 import { termTransformFxnWithOverrides } from '../../browse/SearchView';
 
+export function isLocalEnv() {
+    if (typeof window !== 'undefined' && window.location && window.location.href) {
+        return window.location.href.indexOf('localhost') >= 0 ||
+            window.location.href.indexOf('127.0.0.1') >= 0;
+    }
+    return false;
+}
 
 export default class DataMatrix extends React.PureComponent {
 
@@ -280,6 +287,7 @@ export default class DataMatrix extends React.PureComponent {
         "disableConfigurator": true,
         "idLabel": "",
         "onDataLoaded": null,
+        "debugLoadingDelayMs": 0,
         // allowedFields is for the configurator
         "allowedFields": [
             "donors.display_title",
@@ -354,6 +362,7 @@ export default class DataMatrix extends React.PureComponent {
         'disableConfigurator': PropTypes.bool,
         'idLabel': PropTypes.string,
         'onDataLoaded': PropTypes.func,
+        'debugLoadingDelayMs': PropTypes.number,
         'schemas': PropTypes.object,
         'allowedFields': PropTypes.arrayOf(PropTypes.string),
         'baseBrowseFilesPath': PropTypes.string,
@@ -512,6 +521,8 @@ export default class DataMatrix extends React.PureComponent {
             "summaryBackgroundColor": props.summaryBackgroundColor,
             "defaultOpen": props.defaultOpen,
             "countFor": "files",
+            // Distinguishes full shell loading (matrix mode switch) from inline refreshes (count toggles).
+            "loadingContext": null,
             "matrixMode": normalizedInitialMatrixMode,
             "donorTissueAssay": DataMatrix.DONOR_TISSUE_ALL_ASSAYS,
             "availableDonorTissueAssays": [],
@@ -523,7 +534,15 @@ export default class DataMatrix extends React.PureComponent {
             Object.assign(initialState, this.getNextStateForMatrixMode(normalizedInitialMatrixMode, initialState));
         }
         this.latestLoadRequestId = 0;
+        this.loadingDelayTimeout = null;
         this.state = initialState;
+    }
+
+    componentWillUnmount() {
+        if (this.loadingDelayTimeout) {
+            clearTimeout(this.loadingDelayTimeout);
+            this.loadingDelayTimeout = null;
+        }
     }
 
     componentDidMount() {
@@ -829,6 +848,7 @@ export default class DataMatrix extends React.PureComponent {
             resultItemPostProcessFuncKey,
             resultTransformedPostProcessFuncKey,
             onDataLoaded,
+            debugLoadingDelayMs = 0,
             autoPopulateRowGroupsExtendedMapFields,
             autoPopulateColumnGroupsMapFields
         } = this.props;
@@ -842,7 +862,6 @@ export default class DataMatrix extends React.PureComponent {
             columnGroups,
             matrixMode
         } = this.state;
-
         const commonCallback = (result) => {
             if (requestId !== this.latestLoadRequestId) {
                 return;
@@ -941,6 +960,7 @@ export default class DataMatrix extends React.PureComponent {
 
             updatedState[resultKey] = transformedData;
             updatedState['isFetching'] = false;
+            updatedState['loadingContext'] = null;
             updatedState['overallCounts'] = result.counts || null;
             updatedState['facetsForPanel'] = result.facets || [];
             updatedState['facetFiltersForPanel'] = result.filters || [];
@@ -1022,14 +1042,30 @@ export default class DataMatrix extends React.PureComponent {
                 updatedState['donorTissueAssay'] = hasCurrentAssay ? currentDonorTissueAssay : DataMatrix.DONOR_TISSUE_ALL_ASSAYS;
             }
 
-            this.setState(updatedState, () => ReactTooltip.rebuild());
-            if (typeof onDataLoaded === 'function') {
-                onDataLoaded({
-                    hasData: totalFiles > 0,
-                    totalFiles,
-                    query: this.state.query,
-                    results: transformedData
-                });
+            const commitLoadedState = () => {
+                if (requestId !== this.latestLoadRequestId) {
+                    return;
+                }
+                this.setState(updatedState, () => ReactTooltip.rebuild());
+                if (typeof onDataLoaded === 'function') {
+                    onDataLoaded({
+                        hasData: totalFiles > 0,
+                        totalFiles,
+                        query: this.state.query,
+                        results: transformedData
+                    });
+                }
+            };
+
+            if (this.loadingDelayTimeout) {
+                clearTimeout(this.loadingDelayTimeout);
+                this.loadingDelayTimeout = null;
+            }
+            // Optional local-only delay so the intermediate loading treatment is easier to tune.
+            if (debugLoadingDelayMs > 0) {
+                this.loadingDelayTimeout = setTimeout(commitLoadedState, debugLoadingDelayMs);
+            } else {
+                commitLoadedState();
             }
         };
 
@@ -1042,17 +1078,34 @@ export default class DataMatrix extends React.PureComponent {
             const updatedState = {};
             updatedState[resultKey] = false;
             updatedState['isFetching'] = false;
+            updatedState['loadingContext'] = null;
             updatedState['facetsForPanel'] = [];
             updatedState['facetFiltersForPanel'] = [];
-            this.setState(updatedState);
-            if (typeof onDataLoaded === 'function') {
-                onDataLoaded({
-                    hasData: false,
-                    totalFiles: 0,
-                    query: this.state.query,
-                    results: null,
-                    error: result
-                });
+            const commitLoadedState = () => {
+                if (requestId !== this.latestLoadRequestId) {
+                    return;
+                }
+                this.setState(updatedState);
+                if (typeof onDataLoaded === 'function') {
+                    onDataLoaded({
+                        hasData: false,
+                        totalFiles: 0,
+                        query: this.state.query,
+                        results: null,
+                        error: result
+                    });
+                }
+            };
+
+            if (this.loadingDelayTimeout) {
+                clearTimeout(this.loadingDelayTimeout);
+                this.loadingDelayTimeout = null;
+            }
+            // Keep error and empty states on the same delayed cadence while debugging loading UI.
+            if (debugLoadingDelayMs > 0) {
+                this.loadingDelayTimeout = setTimeout(commitLoadedState, debugLoadingDelayMs);
+            } else {
+                commitLoadedState();
             }
         };
         this.setState(
@@ -1415,7 +1468,15 @@ export default class DataMatrix extends React.PureComponent {
     }
 
     onMatrixModeChange(nextMatrixMode) {
-        this.setState((prevState) => this.getNextStateForMatrixMode(nextMatrixMode, prevState));
+        this.setState((prevState) => {
+            return {
+                ...this.getNextStateForMatrixMode(nextMatrixMode, prevState),
+                // Clear stale cells immediately on matrix-mode switches so the loading shell
+                // reflects the next mode instead of briefly showing the previous view's columns.
+                _results: null,
+                loadingContext: 'matrix-mode'
+            };
+        });
     }
 
     onApplyConfiguration({
@@ -1473,6 +1534,9 @@ export default class DataMatrix extends React.PureComponent {
     onCountForChange(e) {
         const nextValue = e && e.target ? e.target.value : 'files';
         this.setState((prevState) => {
+            const isCoverageToggleOnly =
+                (nextValue === 'files' && prevState.countFor === 'total_coverage') ||
+                (nextValue === 'total_coverage' && prevState.countFor === 'files');
             const nextState = {
                 countFor: nextValue,
                 matrixMode: (nextValue === 'donors' || nextValue === 'tissue_files')
@@ -1520,6 +1584,10 @@ export default class DataMatrix extends React.PureComponent {
                     colorRangeSegments: prevState.colorRangeSegments,
                     colorRangeSegmentStep: prevState.colorRangeSegmentStep
                 });
+            }
+
+            if (nextValue !== prevState.countFor && !isCoverageToggleOnly) {
+                nextState.loadingContext = 'count-toggle';
             }
 
             return nextState;
@@ -1573,20 +1641,18 @@ export default class DataMatrix extends React.PureComponent {
         return false;
     }
 
-    isLocalEnv() {
-        if (window && window.location && window.location.href) {
-            return window.location.href.indexOf('localhost') >= 0 ||
-                window.location.href.indexOf('127.0.0.1') >= 0;
-        }
-        return false;
-    }
+    // isLocalEnv() {
+    //     return isLocalEnv();
+    // }
 
     render() {
         const {
             headerFor, valueChangeMap, allowedFields, valueDelimiter,
             disableConfigurator = false, idLabel = '', additionalPopoverData = {},
             baseBrowseFilesPath, browseFilteringTransformFuncKey, showCountFor, showMatrixModeTabs,
-            showFacetTermsPanel, facetTermsPanelFields, donorTissueShrinkEmptyColumns
+            showFacetTermsPanel, facetTermsPanelFields, donorTissueShrinkEmptyColumns,
+            headerPadding, showUniqueDonorsAssayBand, schemas,
+            titleMap, statePrioritizationForGroups, fallbackNameForBlankField
         } = this.props;
         const {
             query, fieldChangeMap, columnGrouping, groupingProperties,
@@ -1595,15 +1661,15 @@ export default class DataMatrix extends React.PureComponent {
             colorRanges, xAxisLabel, yAxisLabel, showAxisLabels, showColumnSummary,
             colorRangeBaseColor, colorRangeSegments, colorRangeSegmentStep, summaryBackgroundColor,
             defaultOpen = false, totalFiles, countFor, overallCounts, facetsForPanel, facetFiltersForPanel, isFetching,
-            matrixMode, donorTissueAssay, availableDonorTissueAssays, rowSummaryCountsByGroup
+            matrixMode, donorTissueAssay, availableDonorTissueAssays, rowSummaryCountsByGroup, loadingContext,
+            _results: rawResults
         } = this.state;
 
-        const resultKey = "_results";
         const effectiveFacetHref = this.getEffectiveFacetHref(query?.url);
         const isTissueMatrixCount = matrixMode === DataMatrix.MATRIX_MODES.TISSUE_ASSAY;
-        const effectiveHeaderPadding = matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE ? 232 : this.props.headerPadding;
+        const effectiveHeaderPadding = matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE ? 232 : headerPadding;
         const effectiveYAxisLabel = isTissueMatrixCount ? 'Tissue' : yAxisLabel;
-        const effectiveResults = this.getDerivedDonorTissueResults(this.state[resultKey]);
+        const effectiveResults = this.getDerivedDonorTissueResults(rawResults);
         const effectiveOverallCounts = effectiveResults?.overallCounts || overallCounts;
         // Row-summary overrides are useful for donor/assay benchmarking rollups,
         // but in donor/tissue mode they can conflict with assay-dropdown totals.
@@ -1615,20 +1681,17 @@ export default class DataMatrix extends React.PureComponent {
         // Keep header included-properties count anchored to unfiltered backend context.
         const effectiveTotalFiles = totalFiles;
 
-        const isLoading =
-            // eslint-disable-next-line react/destructuring-assignment
-            this.state['_results'] === null && query && query.url !== null && typeof query.url !== 'undefined';
-        const isRefreshing = !!(isFetching && this.state['_results'] !== null && this.state['_results'] !== false);
-
-        if (isLoading) {
-            return (
-                <div>
-                    <div className="text-center mt-5 mb-5" style={{ fontSize: '2rem', opacity: 0.5 }}>
-                        <i className="mt-3 icon icon-spin icon-circle-notch fas" />
-                    </div>
-                </div>
-            );
-        }
+        const isLoading = rawResults === null && query && query.url !== null && typeof query.url !== 'undefined';
+        const isRefreshing = !!(isFetching && rawResults !== null && rawResults !== false);
+        // Count toggles keep the current header/labels visible; matrix-mode switches use the blank shell.
+        const isCountToggleRefreshing = isRefreshing && loadingContext === 'count-toggle';
+        const isTissueMatrix = matrixMode === DataMatrix.MATRIX_MODES.TISSUE_ASSAY;
+        const isDonorTissueMatrix = matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE;
+        const isCoverageView = countFor === 'total_coverage';
+        const showCountsPanel = showCountFor;
+        const shouldShowMatrixModeTabs = showCountFor && showMatrixModeTabs && idLabel !== 'benchmarking';
+        const showFacetsPanel = showFacetTermsPanel;
+        const showLeftPanel = showCountsPanel || showFacetsPanel;
         const bodyProps = {
             query, groupingProperties, fieldChangeMap, valueChangeMap, columnGrouping, colorRanges,
             columnGroups, showColumnGroups, columnGroupsExtended, showColumnGroupsExtended,
@@ -1636,7 +1699,7 @@ export default class DataMatrix extends React.PureComponent {
             summaryBackgroundColor, xAxisLabel, yAxisLabel: effectiveYAxisLabel, showAxisLabels, showColumnSummary, valueDelimiter,
             baseBrowseFilesPath,
             activeFacetHref: effectiveFacetHref || query?.url || null,
-            showUniqueDonorsAssayBand: this.props.showUniqueDonorsAssayBand,
+            showUniqueDonorsAssayBand,
             shrinkEmptyColumns: matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE
                 ? donorTissueShrinkEmptyColumns
                 : true,
@@ -1648,6 +1711,11 @@ export default class DataMatrix extends React.PureComponent {
             disableRowExpand: matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE,
             // Donor x Tissue blocks are informational; disable click-to-open highlighting/popover selection.
             disableBlockOpen: matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE,
+            isGridRefreshing: isCountToggleRefreshing,
+            // Avoid showing the fallback N/A germ-layer band while a donor/tissue refresh is in flight.
+            hideFallbackColumnGroupHeader: matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE && isRefreshing,
+            // Avoid showing the fallback row band while any matrix view is refreshing.
+            hideFallbackRowGroupHeader: isRefreshing,
             overallCounts: effectiveOverallCounts,
             // Use mode-appropriate summary overrides: donor/tissue mode may null these out
             // under assay filter to avoid inconsistencies with facet-driven contexts.
@@ -1712,14 +1780,6 @@ export default class DataMatrix extends React.PureComponent {
                 {configurator}
                 {headerFor || null}
                 {(showCountFor || showFacetTermsPanel) ? (() => {
-                    const isTissueMatrix = matrixMode === DataMatrix.MATRIX_MODES.TISSUE_ASSAY;
-                    const isDonorTissueMatrix = matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE;
-                    const isCoverageView = countFor === 'total_coverage';
-                    const showCountsPanel = showCountFor;
-                    const shouldShowMatrixModeTabs = showCountFor && showMatrixModeTabs && idLabel !== 'benchmarking';
-                    const showFacetsPanel = showFacetTermsPanel;
-                    const showLeftPanel = showFacetsPanel;
-
                     const assaySelect = isDonorTissueMatrix ? (
                         <div className="matrix-assay-select-control">
                             <div className="matrix-assay-select-inline">
@@ -1790,6 +1850,11 @@ export default class DataMatrix extends React.PureComponent {
                                     divCls="view-toggle p-1"
                                 />
                             </div>
+                            {isCountToggleRefreshing ? (
+                                <div className="matrix-inline-refresh-indicator" aria-hidden="true">
+                                    <i className="icon icon-spin icon-circle-notch fas" />
+                                </div>
+                            ) : null}
                         </div>
                     ) : null;
 
@@ -1854,12 +1919,19 @@ export default class DataMatrix extends React.PureComponent {
                                                             onFilter={this.onFacetFilter}
                                                             onFilterMultiple={this.onFacetFilterMultiple}
                                                             href={effectiveFacetHref || query?.url || null}
-                                                            schemas={this.props.schemas || null}
+                                                            schemas={schemas || null}
                                                         />
                                                     </div>
                                                 </div>
                                             );
-                                        })() : null}
+                                        })() : (
+                                            <div className="matrix-facet-terms-wrapper">
+                                                <div className="matrix-total-files-count">
+                                                    {typeof totalFiles === 'number' ? `${effectiveTotalFiles.toLocaleString()} Files` : 'Loading…'}
+                                                </div>
+                                                <div className="matrix-facet-terms-panel mt-1 search-view-controls-and-results" aria-hidden="true" style={{ minHeight: '160px' }} />
+                                            </div>
+                                        )}
                                     </div>
                                 ) : null}
                                 <div className="matrix-visual-panel flex-grow-1">
@@ -1890,13 +1962,14 @@ export default class DataMatrix extends React.PureComponent {
                                     <div className="matrix-visual-scroll-region">
                                         <div className="matrix-visual-scroll-content">
                                             <VisualBody
-                                                {..._.pick(this.props, 'titleMap', 'statePrioritizationForGroups', 'fallbackNameForBlankField')}
+                                                {...{ titleMap, statePrioritizationForGroups, fallbackNameForBlankField }}
                                                 {...bodyProps}
                                                 headerPadding={effectiveHeaderPadding}
                                                 headerLeftControls={headerLeftControls}
+                                                showLoadingHeaderLeftControls={loadingContext === 'count-toggle'}
                                                 columnSubGrouping=""// leave blank for now
-                                                // eslint-disable-next-line react/destructuring-assignment
-                                                results={effectiveResults}
+                                                isLoading={isLoading}
+                                                results={effectiveResults || { all: [], row_totals: [], column_totals: [] }}
                                                 defaultDepthsOpen={[defaultOpen, false, false]}
                                                 // keysToInclude={[]}
                                             />
@@ -1910,13 +1983,14 @@ export default class DataMatrix extends React.PureComponent {
                     <div className="matrix-visual-scroll-region">
                         <div className="matrix-visual-scroll-content">
                             <VisualBody
-                                {..._.pick(this.props, 'titleMap', 'statePrioritizationForGroups', 'fallbackNameForBlankField')}
+                                {...{ titleMap, statePrioritizationForGroups, fallbackNameForBlankField }}
                                 {...bodyProps}
                                 headerPadding={effectiveHeaderPadding}
                                 headerLeftControls={null}
+                                showLoadingHeaderLeftControls={false}
                                 columnSubGrouping=""// leave blank for now
-                                // eslint-disable-next-line react/destructuring-assignment
-                                results={effectiveResults}
+                                isLoading={isLoading}
+                                results={effectiveResults || { all: [], row_totals: [], column_totals: [] }}
                                 defaultDepthsOpen={[defaultOpen, false, false]}
                                 // keysToInclude={[]}
                             />
@@ -1932,7 +2006,7 @@ export default class DataMatrix extends React.PureComponent {
             <div id={`data-matrix-for_${idLabel}`} className={dataMatrixClassName} data-files-count={totalFiles}>
                 <div className={`row matrix-render-surface${isRefreshing ? ' is-refreshing' : ''}`}>
                     {body}
-                    {isRefreshing ? (
+                    {isRefreshing && !isCountToggleRefreshing ? (
                         <div className="matrix-refresh-overlay d-flex align-items-center justify-content-center">
                             <i className="icon icon-spin icon-circle-notch fas" />
                         </div>

--- a/src/encoded/static/components/viz/Matrix/DataMatrix.js
+++ b/src/encoded/static/components/viz/Matrix/DataMatrix.js
@@ -1652,10 +1652,6 @@ export default class DataMatrix extends React.PureComponent {
         return false;
     }
 
-    // isLocalEnv() {
-    //     return isLocalEnv();
-    // }
-
     render() {
         const {
             headerFor, valueChangeMap, allowedFields, valueDelimiter,

--- a/src/encoded/static/components/viz/Matrix/DataMatrix.js
+++ b/src/encoded/static/components/viz/Matrix/DataMatrix.js
@@ -276,7 +276,8 @@ export default class DataMatrix extends React.PureComponent {
         "columnSubGroupingOrder": [],
         "colorRangeBaseColor": "#47adff", // color hex or rgba code (if set, will override colorRanges)
         "colorRangeSegments": 5, // split color ranges into 5 equal parts
-        "colorRangeSegmentStep": 20, // step size for each segment
+        "colorRangeSegmentStep": 20, // step size for each files/donor segment
+        "coverageColorRangeSegmentStep": 200, // step size for each coverage segment
         "summaryBackgroundColor": "#ececff",
         "xAxisLabel": "Assay",
         "yAxisLabel": "Donor",
@@ -338,6 +339,7 @@ export default class DataMatrix extends React.PureComponent {
         'colorRangeBaseColor': PropTypes.string,
         'colorRangeSegments': PropTypes.number,
         'colorRangeSegmentStep': PropTypes.number,
+        'coverageColorRangeSegmentStep': PropTypes.number,
         'summaryBackgroundColor': PropTypes.string,
         'columnGroups': PropTypes.object,
         'showColumnGroups': PropTypes.bool,
@@ -463,6 +465,13 @@ export default class DataMatrix extends React.PureComponent {
         return colorRanges;
     }
 
+    getColorRangeSegmentStepForCountFor(countFor, state = this.state) {
+        if (countFor === 'total_coverage') {
+            return state.coverageColorRangeSegmentStep;
+        }
+        return state.colorRangeSegmentStep;
+    }
+
     constructor(props) {
         super(props);
         this.loadSearchQueryResults = this.loadSearchQueryResults.bind(this);
@@ -518,6 +527,7 @@ export default class DataMatrix extends React.PureComponent {
             "baseColorRangeBaseColor": props.colorRangeBaseColor,
             "colorRangeSegments": props.colorRangeSegments,
             "colorRangeSegmentStep": props.colorRangeSegmentStep,
+            "coverageColorRangeSegmentStep": props.coverageColorRangeSegmentStep,
             "summaryBackgroundColor": props.summaryBackgroundColor,
             "defaultOpen": props.defaultOpen,
             "countFor": "files",
@@ -1376,8 +1386,7 @@ export default class DataMatrix extends React.PureComponent {
             baseRowGroupsExtended,
             baseShowRowGroupsExtended,
             baseColorRangeBaseColor,
-            colorRangeSegments,
-            colorRangeSegmentStep
+            colorRangeSegments
         } = prevState;
         const { donorTissueColumnGroups } = this.props;
 
@@ -1409,7 +1418,7 @@ export default class DataMatrix extends React.PureComponent {
                 colorRanges: this.getColorRanges({
                     colorRangeBaseColor: countFor === 'donors' ? '#8989FF' : baseColorRangeBaseColor,
                     colorRangeSegments,
-                    colorRangeSegmentStep
+                    colorRangeSegmentStep: this.getColorRangeSegmentStepForCountFor(countFor, prevState)
                 })
             };
         }
@@ -1437,7 +1446,7 @@ export default class DataMatrix extends React.PureComponent {
                 colorRanges: this.getColorRanges({
                     colorRangeBaseColor: donorTissueBaseColor,
                     colorRangeSegments,
-                    colorRangeSegmentStep
+                    colorRangeSegmentStep: this.getColorRangeSegmentStepForCountFor('files', prevState)
                 }),
                 colorRangeBaseColor: donorTissueBaseColor
             };
@@ -1464,7 +1473,7 @@ export default class DataMatrix extends React.PureComponent {
             colorRanges: this.getColorRanges({
                 colorRangeBaseColor: baseColorRangeBaseColor,
                 colorRangeSegments,
-                colorRangeSegmentStep
+                colorRangeSegmentStep: this.getColorRangeSegmentStepForCountFor('files', prevState)
             })
         };
     }
@@ -1569,7 +1578,7 @@ export default class DataMatrix extends React.PureComponent {
                 nextState.colorRanges = this.getColorRanges({
                     colorRangeBaseColor: nextValue === 'donors' ? '#8989FF' : baseColorRangeBaseColor,
                     colorRangeSegments: prevState.colorRangeSegments,
-                    colorRangeSegmentStep: prevState.colorRangeSegmentStep
+                    colorRangeSegmentStep: this.getColorRangeSegmentStepForCountFor(nextValue, prevState)
                 });
             } else {
                 // In Donor x Tissue mode, files <-> coverage is display-only.
@@ -1584,7 +1593,7 @@ export default class DataMatrix extends React.PureComponent {
                 nextState.colorRanges = this.getColorRanges({
                     colorRangeBaseColor: baseColorRangeBaseColor,
                     colorRangeSegments: prevState.colorRangeSegments,
-                    colorRangeSegmentStep: prevState.colorRangeSegmentStep
+                    colorRangeSegmentStep: this.getColorRangeSegmentStepForCountFor(nextValue, prevState)
                 });
             }
 

--- a/src/encoded/static/components/viz/Matrix/DataMatrix.js
+++ b/src/encoded/static/components/viz/Matrix/DataMatrix.js
@@ -1443,10 +1443,9 @@ export default class DataMatrix extends React.PureComponent {
             };
         }
 
-        const countFor = prevState.countFor === 'total_coverage' ? 'total_coverage' : 'files';
         return {
             matrixMode: nextMatrixMode,
-            countFor,
+            countFor: 'files',
             query: {
                 ...prevState.query,
                 columnAggFields: baseColumnAggFields,

--- a/src/encoded/static/components/viz/Matrix/DataMatrix.js
+++ b/src/encoded/static/components/viz/Matrix/DataMatrix.js
@@ -559,6 +559,9 @@ export default class DataMatrix extends React.PureComponent {
             ((countFor === 'files' && pastState.countFor === 'total_coverage') ||
                 (countFor === 'total_coverage' && pastState.countFor === 'files'));
         const shouldFetchForCountForChange = countForChanged && !isCoverageToggleOnly;
+        if (isCoverageToggleOnly) {
+            ReactTooltip.rebuild();
+        }
         if (session !== pastProps.session ||
             !_.isEqual(query, pastState.query) ||
             !_.isEqual(fieldChangeMap, pastState.fieldChangeMap) ||
@@ -1704,9 +1707,12 @@ export default class DataMatrix extends React.PureComponent {
                 ? donorTissueShrinkEmptyColumns
                 : true,
             countFor,
-            // Donor x Tissue can exceed horizontal space in coverage view; keep default cell width here
-            // and render compact labels instead of widening cells.
-            compactCoverageText: countFor === 'total_coverage' && matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE,
+            // Donor-oriented coverage views keep the default cell width and rely on compact labels
+            // instead of widening each matrix cell.
+            compactCoverageText: countFor === 'total_coverage' && (
+                matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE ||
+                matrixMode === DataMatrix.MATRIX_MODES.DONOR_ASSAY
+            ),
             // Coverage summary totals are only meaningful in Donor x Tissue.
             showCoverageSummaries: matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE,
             // Donor x Tissue should not expose expand controls.
@@ -1722,7 +1728,7 @@ export default class DataMatrix extends React.PureComponent {
             // Use mode-appropriate summary overrides: donor/tissue mode may null these out
             // under assay filter to avoid inconsistencies with facet-driven contexts.
             rowSummaryCountsByGroup: effectiveRowSummaryCountsByGroup,
-            ...(countFor === 'total_coverage' && matrixMode !== DataMatrix.MATRIX_MODES.DONOR_TISSUE
+            ...(countFor === 'total_coverage' && matrixMode === DataMatrix.MATRIX_MODES.TISSUE_ASSAY
                 ? { blockWidth: 60, blockHorizontalExtend: 10 }
                 : {}),
             browseFilteringTransformFunc: browseFilteringTransformFuncKey

--- a/src/encoded/static/components/viz/Matrix/DataMatrix.js
+++ b/src/encoded/static/components/viz/Matrix/DataMatrix.js
@@ -1707,6 +1707,8 @@ export default class DataMatrix extends React.PureComponent {
             // Donor x Tissue can exceed horizontal space in coverage view; keep default cell width here
             // and render compact labels instead of widening cells.
             compactCoverageText: countFor === 'total_coverage' && matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE,
+            // Coverage summary totals are only meaningful in Donor x Tissue.
+            showCoverageSummaries: matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE,
             // Donor x Tissue should not expose expand controls.
             disableRowExpand: matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE,
             // Donor x Tissue blocks are informational; disable click-to-open highlighting/popover selection.

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -39,6 +39,77 @@ function getCountValueFromItem(item, countField) {
     return 0;
 }
 
+function formatCompactedNumericValue(value, {
+    decimalsByThreshold = null,
+    units = [
+        { threshold: 1e9, suffix: 'B' },
+        { threshold: 1e6, suffix: 'M' },
+        { threshold: 1e3, suffix: 'K' }
+    ]
+} = {}) {
+    const normalizedValue = Number(value) || 0;
+    if (normalizedValue === 0) {
+        return {
+            display: '0',
+            tooltipValue: '0',
+            isCompacted: false
+        };
+    }
+
+    const absValue = Math.abs(normalizedValue);
+    const matchingUnit = units.find(({ threshold }) => absValue >= threshold) || null;
+    if (!matchingUnit) {
+        return {
+            display: normalizedValue.toLocaleString(),
+            tooltipValue: normalizedValue.toLocaleString(),
+            isCompacted: false
+        };
+    }
+
+    const scaledValue = normalizedValue / matchingUnit.threshold;
+    const decimals = typeof decimalsByThreshold === 'function'
+        ? decimalsByThreshold(scaledValue, matchingUnit)
+        : (scaledValue >= 100 ? 0 : 1);
+    const formattedValue = `${parseFloat(scaledValue.toFixed(decimals)).toLocaleString()}${matchingUnit.suffix}`;
+
+    return {
+        display: formattedValue,
+        tooltipValue: normalizedValue.toLocaleString(),
+        isCompacted: !!matchingUnit
+    };
+}
+
+function formatCoverageDisplayValue(value, compact = false) {
+    const normalizedValue = Number(value) || 0;
+    if (normalizedValue <= 0) {
+        return {
+            display: '0X',
+            tooltipValue: '0',
+            isCompacted: false
+        };
+    }
+
+    const compactedValue = formatCompactedNumericValue(normalizedValue, {
+        decimalsByThreshold: (scaledValue) => (scaledValue >= 100 ? 0 : 1)
+    });
+
+    if (compactedValue.isCompacted) {
+        return {
+            ...compactedValue,
+            display: `${compactedValue.display}X`
+        };
+    }
+
+    const roundedValue = compact
+        ? Math.round(normalizedValue)
+        : (normalizedValue < 100 ? Math.round(normalizedValue * 10) / 10 : Math.round(normalizedValue));
+    return {
+        display: `${roundedValue.toLocaleString()}X`,
+        tooltipValue: normalizedValue.toLocaleString(),
+        isCompacted: false
+    };
+}
+
 function renderVerticalRowGroupsExtended({
     rowGroupsExtended,
     rowGroupsExtendedKeys,
@@ -201,16 +272,15 @@ export class VisualBody extends React.PureComponent {
             const compactCoverageText = typeof blockProps?.compactCoverageText === 'boolean'
                 ? blockProps.compactCoverageText
                 : (blockType === 'col-summary' || blockType === 'row-summary' || blockType === 'col-secondary-summary');
-            const rounded = compactCoverageText
-                ? Math.round(blockSum)
-                : (blockSum < 100 ? Math.round(blockSum * 10) / 10 : Math.round(blockSum));
-            const tooltipValue = rounded.toLocaleString();
-            const display = `${rounded.toLocaleString()}X`;
+            const { display, tooltipValue, isCompacted } = formatCoverageDisplayValue(blockSum, compactCoverageText);
             const fontSize = compactCoverageText
                 ? (display.length > 6 ? '0.60rem' : (display.length > 4 ? '0.66rem' : '0.72rem'))
                 : (display.length > 7 ? '0.72rem' : (display.length > 5 ? '0.8rem' : '0.9rem'));
             return (
-                <span style={{ fontSize }} data-count={blockSum} data-tip={tooltipValue}>
+                <span
+                    style={{ fontSize }}
+                    data-count={blockSum}
+                    {...(isCompacted ? { 'data-tip': `${tooltipValue}X` } : {})}>
                     {display}
                 </span>
             );
@@ -218,9 +288,12 @@ export class VisualBody extends React.PureComponent {
 
         if (blockSum >= 1000){
             const decimal = blockSum >= 10000 ? 0 : 1;
+            const compactedValue = formatCompactedNumericValue(blockSum, {
+                decimalsByThreshold: (scaledValue) => (scaledValue >= 10 ? 0 : decimal)
+            });
             return (
                 <span style={{ 'fontSize' : '0.80rem', 'position' : 'relative', 'top' : -1 }} data-count={blockSum} data-tip={blockSum}>
-                    { roundLargeNumber(blockSum, decimal) }
+                    { compactedValue.isCompacted ? compactedValue.display : roundLargeNumber(blockSum, decimal) }
                 </span>
             );
         }
@@ -2704,6 +2777,16 @@ const Block = React.memo(function Block(props){
             })()
             : _.reduce(argData, function (sum, item) { return sum + getCountValueFromItem(item, effectiveCountFor); }, 0))
         : (argData ? getCountValueFromItem(argData, effectiveCountFor) : 0);
+    const shouldShowCoverageSummary = !!props.showCoverageSummaries;
+    const shouldShowCompactCoverageTooltip = (() => {
+        if (countFor !== 'total_coverage') return false;
+        if (!(blockType === 'col-summary' || blockType === 'row-summary' || blockType === 'col-secondary-summary')) return false;
+        if (!shouldShowCoverageSummary) return false;
+        const compactCoverageText = typeof props.compactCoverageText === 'boolean'
+            ? props.compactCoverageText
+            : true;
+        return formatCoverageDisplayValue(blockValue, compactCoverageText).isCompacted;
+    })();
     const hideCoverageBlock = countFor === 'total_coverage' && blockType === 'regular' && blockValue <= 0;
     if (hideCoverageBlock) {
         popover = null;
@@ -2771,6 +2854,7 @@ const Block = React.memo(function Block(props){
             data-place="bottom"
             data-block-value={blockValue}
             data-block-type={blockType || 'regular'}
+            {...(shouldShowCompactCoverageTooltip ? { 'data-tip': `${Number(blockValue || 0).toLocaleString()}X` } : {})}
             onMouseEnter={() => typeof handleBlockMouseEnter === 'function' && handleBlockMouseEnter(colIndex, rowIndex, group, rowGroupKey, summaryRowType)}
             onMouseLeave={handleBlockMouseLeave}
             onClick={()=> !hideCoverageBlock && popover && handleBlockClick(colIndex, rowIndex, group, rowGroupKey, summaryRowType)}>

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -113,6 +113,51 @@ export function extendListObjectsWithIndex(objList){
 // Example: <VisualBody results={{ all: data, row_totals: totals }} groupingProperties={['donor','tissue']} columnGrouping="assay" />
 export class VisualBody extends React.PureComponent {
 
+    constructor(props){
+        super(props);
+        this.blockPopover = this.blockPopover.bind(this);
+        this.loadingContainerRef = null;
+        this.state = {
+            loadingIndicatorLayout: null
+        };
+        this.updateLoadingIndicatorLayout = this.updateLoadingIndicatorLayout.bind(this);
+    }
+
+    componentDidMount() {
+        const { isLoading } = this.props;
+        if (isLoading) {
+            this.updateLoadingIndicatorLayout();
+        }
+        window.addEventListener('resize', this.updateLoadingIndicatorLayout, { passive: true });
+    }
+
+    componentDidUpdate(prevProps) {
+        const { isLoading, xAxisLabel, yAxisLabel, showAxisLabels } = this.props;
+        const { loadingIndicatorLayout } = this.state;
+        if (isLoading) {
+            const loadingStateChanged = prevProps.isLoading !== isLoading;
+            if (loadingStateChanged) {
+                this.updateLoadingIndicatorLayout();
+                return;
+            }
+            if (
+                prevProps.xAxisLabel !== xAxisLabel ||
+                prevProps.yAxisLabel !== yAxisLabel ||
+                prevProps.showAxisLabels !== showAxisLabels
+            ) {
+                this.updateLoadingIndicatorLayout();
+            }
+        } else if (prevProps.isLoading) {
+            if (loadingIndicatorLayout !== null) {
+                this.setState({ loadingIndicatorLayout: null });
+            }
+        }
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener('resize', this.updateLoadingIndicatorLayout);
+    }
+
     static blockRenderedContents(data, blockProps){
         const countFor = blockProps && blockProps.countFor ? blockProps.countFor : 'files';
         const blockType = blockProps && blockProps.blockType ? blockProps.blockType : 'regular';
@@ -237,9 +282,28 @@ export class VisualBody extends React.PureComponent {
         return null;
     }
 
-    constructor(props){
-        super(props);
-        this.blockPopover = this.blockPopover.bind(this);
+    updateLoadingIndicatorLayout() {
+        if (!this.loadingContainerRef) return;
+        const matrixPanelContent = this.loadingContainerRef.closest('.matrix-panel-content');
+        const tabsEl = matrixPanelContent ? matrixPanelContent.querySelector('.matrix-mode-tabs') : null;
+        const { loadingIndicatorLayout } = this.state;
+        if (!tabsEl) {
+            if (loadingIndicatorLayout !== null) {
+                this.setState({ loadingIndicatorLayout: null });
+            }
+            return;
+        }
+        const containerRect = this.loadingContainerRef.getBoundingClientRect();
+        const tabsRect = tabsEl.getBoundingClientRect();
+        // Center the loading spinner to the inner mode-tab strip instead of the full viewport width.
+        const nextLayout = {
+            width: Math.round(tabsRect.width),
+            marginLeft: Math.max(0, Math.round(tabsRect.left - containerRect.left))
+        };
+        const prevLayout = loadingIndicatorLayout;
+        if (!prevLayout || prevLayout.width !== nextLayout.width || prevLayout.marginLeft !== nextLayout.marginLeft) {
+            this.setState({ loadingIndicatorLayout: nextLayout });
+        }
     }
 
     findKeyByValue(obj, value) {
@@ -388,7 +452,7 @@ export class VisualBody extends React.PureComponent {
                 );
                 //2. traverse rowAggFields to see if facetField exists there
                 if (!compositeFacetPairs && Array.isArray(rowAggFields)) {
-                    for (let field in rowAggFields) {
+                    for (const field in rowAggFields) {
                         compositeFacetPairs = VisualBody.getFacetPairs(
                             facetField,
                             facetTerm,
@@ -711,7 +775,39 @@ export class VisualBody extends React.PureComponent {
     }
 
     render(){
-        const { results: { all, row_totals, column_totals }, disableRowExpand = false } = this.props;
+        const {
+            disableRowExpand = false,
+            isLoading = false,
+            showAxisLabels = false,
+            xAxisLabel,
+            yAxisLabel,
+            headerLeftControls = null,
+            showLoadingHeaderLeftControls = false,
+            results = { all: [], row_totals: [], column_totals: [] }
+        } = this.props;
+        const { all, row_totals, column_totals } = results;
+        if (isLoading) {
+            const { loadingIndicatorLayout } = this.state;
+            const loadingIndicatorStyle = loadingIndicatorLayout || undefined;
+            return (
+                <div className="stacked-block-viz-container is-loading" ref={(el) => { this.loadingContainerRef = el; }}>
+                    {showAxisLabels ? (
+                        <div className="axis-container flex-grow-1" style={{ position: 'relative', minHeight: '120px' }}>
+                            <div className="x-axis">{xAxisLabel || 'X'}</div>
+                            <div className="y-axis">{yAxisLabel || 'Y'}</div>
+                        </div>
+                    ) : null}
+                    {showLoadingHeaderLeftControls && headerLeftControls ? (
+                        <div className="matrix-loading-header-controls">
+                            {headerLeftControls}
+                        </div>
+                    ) : null}
+                    <div className="matrix-loading-indicator text-center" style={{ fontSize: '2rem', opacity: 0.5, ...loadingIndicatorStyle }}>
+                        <i className="mt-3 icon icon-spin icon-circle-notch fas" />
+                    </div>
+                </div>
+            );
+        }
         return (
             <StackedBlockVisual data={all} rowTotals={row_totals} columnTotals={column_totals} checkCollapsibility={!disableRowExpand}
                 {..._.pick(this.props,
@@ -724,7 +820,7 @@ export class VisualBody extends React.PureComponent {
                     'countFor', 'overallCounts', 'showUniqueDonorsAssayBand', 'shrinkEmptyColumns',
                     'blockWidth', 'blockHorizontalExtend', 'blockHorizontalSpacing', 'blockVerticalSpacing', 'rowSummaryCountsByGroup',
                     'compactCoverageText', 'disableRowExpand', 'disableBlockOpen',
-                    'headerLeftControls')}
+                    'headerLeftControls', 'hideFallbackColumnGroupHeader', 'hideFallbackRowGroupHeader', 'isGridRefreshing')}
                 blockPopover={this.blockPopover}
                 blockRenderedContents={VisualBody.blockRenderedContents}
             />
@@ -922,13 +1018,14 @@ export class StackedBlockVisual extends React.PureComponent {
 
     componentDidUpdate(prevProps) {
         const { activeBlock, openBlock } = this.state;
+        const { columnGrouping, groupingProperties, countFor, data, rowTotals, columnTotals } = this.props;
         const layoutChanged =
-            prevProps.columnGrouping !== this.props.columnGrouping ||
-            !_.isEqual(prevProps.groupingProperties, this.props.groupingProperties) ||
-            prevProps.countFor !== this.props.countFor ||
-            prevProps.data !== this.props.data ||
-            prevProps.rowTotals !== this.props.rowTotals ||
-            prevProps.columnTotals !== this.props.columnTotals;
+            prevProps.columnGrouping !== columnGrouping ||
+            !_.isEqual(prevProps.groupingProperties, groupingProperties) ||
+            prevProps.countFor !== countFor ||
+            prevProps.data !== data ||
+            prevProps.rowTotals !== rowTotals ||
+            prevProps.columnTotals !== columnTotals;
 
         if (layoutChanged && (activeBlock || openBlock)) {
             this.setState({ activeBlock: null, openBlock: null });
@@ -1144,8 +1241,17 @@ export class StackedBlockVisual extends React.PureComponent {
         columnsAndHeaderProps,
         columnToRowsMappingFunc
     }) {
-        const { rowGroups, showColumnSummary, showColumnGroups, columnGroups, columnGrouping } = this.props;
-        const { activeBlock, openBlock } = this.state;
+        const {
+            rowGroups,
+            showColumnSummary,
+            showColumnGroups,
+            columnGroups,
+            columnGrouping,
+            blockWidth,
+            blockHorizontalSpacing,
+            blockHorizontalExtend
+        } = this.props;
+        const { activeBlock, openBlock, sorting, sortField } = this.state;
 
         // Resolve row keys for a group (including the fallback N/A group).
         const getRowKeysForGroup = (groupKey, values) => {
@@ -1188,7 +1294,7 @@ export class StackedBlockVisual extends React.PureComponent {
                         const containerSectionStyle = getContainerSectionStyle(backgroundColor, textColor, groupKeyIdx);
                         const labelSectionStyle = {};
                         const columnKeys = getColumnKeys();
-                        const columnWidth = (this.props.blockWidth + (this.props.blockHorizontalSpacing * 2)) + this.props.blockHorizontalExtend;
+                        const columnWidth = (blockWidth + (blockHorizontalSpacing * 2)) + blockHorizontalExtend;
                         const headerItemStyle = {};
 
                         return _.map(rowKeys, (k, idx) => {
@@ -1223,8 +1329,8 @@ export class StackedBlockVisual extends React.PureComponent {
                                         depth={0}
                                         index={outerIdx}
                                         onSorterClick={this.handleSorterClick}
-                                        sorting={this.state.sorting}
-                                        sortField={this.state.sortField}
+                                        sorting={sorting}
+                                        sortField={sortField}
                                         handleBlockMouseEnter={this.handleBlockMouseEnter}
                                         handleBlockMouseLeave={this.handleBlockMouseLeave}
                                         handleBlockClick={this.handleBlockClick}
@@ -1242,7 +1348,7 @@ export class StackedBlockVisual extends React.PureComponent {
     }
 
     renderContents(){
-        const { data : propData, rowTotals: propRowTotals, columnTotals: propColumnTotals, groupingProperties, columnGrouping, columnGroups, showColumnGroups, rowGroups, showRowGroups, rowGroupsExtended, showRowGroupsExtended, showColumnSummary, blockHeight, blockVerticalSpacing, shrinkEmptyColumns = true } = this.props;
+        const { data : propData, rowTotals: propRowTotals, columnTotals: propColumnTotals, groupingProperties, columnGrouping, columnGroups, showColumnGroups, rowGroups, showRowGroups, rowGroupsExtended, showRowGroupsExtended, showColumnSummary, blockHeight, blockVerticalSpacing, shrinkEmptyColumns = true, hideFallbackRowGroupHeader = false } = this.props;
         const { mounted, sorting, sortField, activeBlock, openBlock } = this.state;
         if (!mounted) return null;
         // prepare data
@@ -1302,13 +1408,17 @@ export class StackedBlockVisual extends React.PureComponent {
 
         const leftAxisKeys = sortLeftAxisKeys(_.keys(nestedData));
         const hasRowGroups = showRowGroups && rowGroups && _.keys(rowGroups).length > 0;
-        const rowGroupsKeys = hasRowGroups ? [..._.keys(rowGroups), FALLBACK_GROUP_NAME] : null;
+        const rowGroupsKeys = hasRowGroups
+            ? [..._.keys(rowGroups), ...(hideFallbackRowGroupHeader ? [] : [FALLBACK_GROUP_NAME])]
+            : null;
         const hasRowGroupsExtendedTopLevel = Array.isArray(groupingProperties) &&
             groupingProperties.length === 1 &&
             showRowGroupsExtended &&
             rowGroupsExtended &&
             _.keys(rowGroupsExtended).length > 0;
-        const rowGroupsExtendedKeys = hasRowGroupsExtendedTopLevel ? [..._.keys(rowGroupsExtended), FALLBACK_GROUP_NAME] : null;
+        const rowGroupsExtendedKeys = hasRowGroupsExtendedTopLevel
+            ? [..._.keys(rowGroupsExtended), ...(hideFallbackRowGroupHeader ? [] : [FALLBACK_GROUP_NAME])]
+            : null;
 
         // convert to { columnGrouping: [groupingProperties] }
         // Example: rows=[{ assay:'WGS', donor:'D1' },{ assay:'WGS', donor:'D2' },{ assay:'RNA', donor:'D1' }]
@@ -1448,12 +1558,13 @@ export class StackedBlockVisual extends React.PureComponent {
 
     render() {
         const { openBlock, activeBlock } = this.state;
+        const { countFor, yAxisLabel, isGridRefreshing } = this.props;
         let className = "stacked-block-viz-container";
-        if (this.props.countFor) {
-            className += ` count-for-${this.props.countFor}`;
+        if (countFor) {
+            className += ` count-for-${countFor}`;
         }
-        if (this.props.yAxisLabel) {
-            const yAxisClass = String(this.props.yAxisLabel).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+        if (yAxisLabel) {
+            const yAxisClass = String(yAxisLabel).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
             if (yAxisClass) {
                 className += ` matrix-yaxis-${yAxisClass}`;
             }
@@ -1463,6 +1574,9 @@ export class StackedBlockVisual extends React.PureComponent {
         }
         if (openBlock) {
             className += ' has-open-block';
+        }
+        if (isGridRefreshing) {
+            className += ' is-refreshing-grid';
         }
         return (
             <div
@@ -1624,9 +1738,7 @@ export class StackedBlockGroupedRow extends React.PureComponent {
     static resolveOverrideFieldForRows(rows, props) {
         const overridesByField = props.rowSummaryCountsByGroup;
         if (!overridesByField || typeof overridesByField !== 'object') return null;
-        return _.find(_.keys(overridesByField), (field) => {
-            return _.some(rows || [], (row) => row && row[field] != null);
-        });
+        return _.find(_.keys(overridesByField), (field) => _.some(rows || [], (row) => row && row[field] != null));
     }
 
     // Computes the overall files count from row summary overrides by summing one
@@ -1797,9 +1909,7 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                 if (typeof rowSummaryFiles === 'number' && columnKeys.indexOf('DSA') > -1) {
                     // For collapsed rows, derive DSA as:
                     // row summary files - sum(non-DSA column files).
-                    const sumFilesForColumn = (columnKey) => _.reduce(blocksByColumnGroup[columnKey] || [], (sum, row) => {
-                        return sum + (Number(row?.counts?.files) || 0);
-                    }, 0);
+                    const sumFilesForColumn = (columnKey) => _.reduce(blocksByColumnGroup[columnKey] || [], (sum, row) => sum + (Number(row?.counts?.files) || 0), 0);
                     const sumNonDsaFiles = _.reduce(columnKeys, (sum, columnKey) => {
                         if (columnKey === 'DSA') return sum;
                         return sum + sumFilesForColumn(columnKey);
@@ -1929,7 +2039,7 @@ export class StackedBlockGroupedRow extends React.PureComponent {
             sorting, sortField, onSorterClick, groupedDataIndices, openBlock, activeBlock,
             columnGroups, showColumnGroups, columnGroupsExtended, showColumnGroupsExtended,
             xAxisLabel, yAxisLabel, showAxisLabels, showColumnSummary,
-            overallCounts, countFor, headerLeftControls
+            overallCounts, countFor, headerLeftControls, hideFallbackColumnGroupHeader = false, hideFallbackRowGroupHeader = false
         } = props;
 
         const rowHeight = blockHeight + (blockVerticalSpacing * 2) + 1;
@@ -1939,7 +2049,9 @@ export class StackedBlockGroupedRow extends React.PureComponent {
 
         const hasColumnGroups = showColumnGroups && columnGroups && _.keys(columnGroups).length > 0;
         const hasColumnGroupsExtended = showColumnGroupsExtended && columnGroupsExtended && _.keys(columnGroupsExtended).length > 0;
-        const columnGroupsKeys = hasColumnGroups ? [..._.keys(columnGroups), FALLBACK_GROUP_NAME] : null;
+        const columnGroupsKeys = hasColumnGroups
+            ? [..._.keys(columnGroups), ...(hideFallbackColumnGroupHeader ? [] : [FALLBACK_GROUP_NAME])]
+            : null;
 
         const extPadding = 60 + (hasColumnGroups ? 26 : 0) + (hasColumnGroupsExtended ? 30 : 0);
         const labelSectionStyle = {
@@ -2309,11 +2421,11 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                             ? (props.overallCounts?.files ?? overallFilesOverride ?? _.reduce(sectionRows, function (sum, item) {
                                 return sum + (Number(item?.counts?.files) || 0);
                             }, 0))
-                        : summaryCountFor === 'files'
-                            ? (overallFilesOverride ?? _.reduce(sectionRows, function (sum, item) {
-                                return sum + (Number(item?.counts?.files) || 0);
-                            }, 0))
-                            : props.overallCounts?.[summaryCountFor];
+                            : summaryCountFor === 'files'
+                                ? (overallFilesOverride ?? _.reduce(sectionRows, function (sum, item) {
+                                    return sum + (Number(item?.counts?.files) || 0);
+                                }, 0))
+                                : props.overallCounts?.[summaryCountFor];
                     if (overallValue == null) return null;
                     const overallHeaderItemStyle = StackedBlockGroupedRow.getHeaderItemStyleForKey('overall-summary', props);
                     const overallSummaryBlockStyle = getSummaryBlockStyle('overall-summary');
@@ -2322,39 +2434,40 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                     const hasActiveBlock = props.activeBlock?.columnIdx === columnKeys.length
                         && props.activeBlock?.summaryRowType === summaryBlockType;
                     return (
-                    <div
-                        key={`col-summary-overall-${summaryCountFor}`}
-                        className={`column-group-header overall-summary ${summaryBlockType === 'col-secondary-summary' ? 'col-secondary-summary' : ''}${hasOpenBlock ? ' open-block-column' : ''}${hasActiveBlock ? ' active-block-column' : ''}`}
-                        style={overallHeaderItemStyle}>
                         <div
-                            className="block-container-group"
-                            style={overallSummaryBlockStyle}
-                            data-block-count={1}
-                            data-group-key="overall-summary">
-                            <Block
-                                {..._.omit(props, 'group')}
-                                key={`overall-summary-block-${summaryCountFor}`}
-                                data={{ counts: summaryCountFor === 'donors'
-                                    ? { ...props.overallCounts, donors: overallValue }
-                                    : (summaryCountFor === 'files' || summaryCountFor === 'tissue_files')
-                                        ? { ...props.overallCounts, files: overallValue }
-                                    : props.overallCounts
-                                }}
-                                colIndex={columnKeys.length}
-                                blockType={summaryBlockType === 'col-secondary-summary' ? 'col-summary' : summaryBlockType}
-                                popoverPrimaryTitle={props.rowGroupKey}
-                                columnKey="overall-summary"
-                                countFor={summaryCountFor}
-                                summaryCounts={summaryCountFor === 'donors'
-                                    ? { ...props.overallCounts, donors: overallValue }
-                                    : (summaryCountFor === 'files' || summaryCountFor === 'tissue_files')
-                                        ? { ...props.overallCounts, files: overallValue }
-                                        : props.overallCounts
-                                }
-                                summaryRowType={summaryBlockType}
-                            />
+                            key={`col-summary-overall-${summaryCountFor}`}
+                            className={`column-group-header overall-summary ${summaryBlockType === 'col-secondary-summary' ? 'col-secondary-summary' : ''}${hasOpenBlock ? ' open-block-column' : ''}${hasActiveBlock ? ' active-block-column' : ''}`}
+                            style={overallHeaderItemStyle}>
+                            <div
+                                className="block-container-group"
+                                style={overallSummaryBlockStyle}
+                                data-block-count={1}
+                                data-group-key="overall-summary">
+                                <Block
+                                    {..._.omit(props, 'group')}
+                                    key={`overall-summary-block-${summaryCountFor}`}
+                                    data={{
+                                        counts: summaryCountFor === 'donors'
+                                            ? { ...props.overallCounts, donors: overallValue }
+                                            : (summaryCountFor === 'files' || summaryCountFor === 'tissue_files')
+                                                ? { ...props.overallCounts, files: overallValue }
+                                                : props.overallCounts
+                                    }}
+                                    colIndex={columnKeys.length}
+                                    blockType={summaryBlockType === 'col-secondary-summary' ? 'col-summary' : summaryBlockType}
+                                    popoverPrimaryTitle={props.rowGroupKey}
+                                    columnKey="overall-summary"
+                                    countFor={summaryCountFor}
+                                    summaryCounts={summaryCountFor === 'donors'
+                                        ? { ...props.overallCounts, donors: overallValue }
+                                        : (summaryCountFor === 'files' || summaryCountFor === 'tissue_files')
+                                            ? { ...props.overallCounts, files: overallValue }
+                                            : props.overallCounts
+                                    }
+                                    summaryRowType={summaryBlockType}
+                                />
+                            </div>
                         </div>
-                    </div>
                     );
                 })()}
             </div>
@@ -2394,7 +2507,7 @@ export class StackedBlockGroupedRow extends React.PureComponent {
             groupingProperties, depth, titleMap, group, blockHeight, blockVerticalSpacing, blockHorizontalSpacing,
             data, rowTotals, index, showGroupingPropertyTitles, checkCollapsibility,
             activeBlock, openBlock,
-            rowGroupsExtended, showRowGroupsExtended } = this.props;
+            rowGroupsExtended, showRowGroupsExtended, hideFallbackRowGroupHeader = false, fallbackNameForBlankField = 'None' } = this.props;
         const { open: stateOpen } = this.state;
 
         const getGroupingPropertyTitle = () => {
@@ -2432,7 +2545,9 @@ export class StackedBlockGroupedRow extends React.PureComponent {
             ((!Array.isArray(data) && data && hasIdentifiableChildren) ? ' may-collapse' : '');
 
         const hasRowGroupsExtended = showRowGroupsExtended && rowGroupsExtended && _.keys(rowGroupsExtended).length > 0;
-        const rowGroupsExtendedKeys = hasRowGroupsExtended ? [..._.keys(rowGroupsExtended), FALLBACK_GROUP_NAME] : null;
+        const rowGroupsExtendedKeys = hasRowGroupsExtended
+            ? [..._.keys(rowGroupsExtended), ...(hideFallbackRowGroupHeader ? [] : [FALLBACK_GROUP_NAME])]
+            : null;
         const rowGroupsExtendedByLowerKey = hasRowGroupsExtended ? _.reduce(_.keys(rowGroupsExtended), (memo, k) => {
             const lk = k.toLowerCase();
             if (memo[lk] == null) memo[lk] = k;
@@ -2448,6 +2563,9 @@ export class StackedBlockGroupedRow extends React.PureComponent {
         const labelContainerClassName = 'label-container' + (hasOpenBlock ? ' open-block-row' : '') + (hasActiveBlock ? ' active-block-row' : '');
         const groupingPropertyTitle = getGroupingPropertyTitle();
         const toggleIcon = getToggleIcon();
+        const displayGroup = (typeof group === 'undefined' || group === null || group === '' || group === 'undefined' || group === 'null' || group === fallbackNameForBlankField)
+            ? ''
+            : group;
 
         const renderRowGroupsExtended = () => renderVerticalRowGroupsExtended({
             rowGroupsExtended,
@@ -2477,8 +2595,8 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                                     <small className="text-400 mb-0 mt-0">{groupingPropertyTitle}</small>
                                     : null}
                                 <h4 className="text-truncate"
-                                    data-tip={group && typeof group === 'string' && group.length > 20 ? group : null}>
-                                    {toggleIcon}<span className="inner">{group}</span>
+                                    data-tip={displayGroup && typeof displayGroup === 'string' && displayGroup.length > 20 ? displayGroup : null}>
+                                    {toggleIcon}<span className="inner">{displayGroup}</span>
                                 </h4>
                             </div>
                         </div>

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -443,7 +443,7 @@ export class VisualBody extends React.PureComponent {
             rowGroupsExtended, additionalPopoverData = {}, baseBrowseFilesPath,
             browseFilteringTransformFunc, activeFacetHref
         } = this.props;
-        const { depth, blockType = null, popoverPrimaryTitle, rowGroups, rowGroupKey, columnKey, summaryCounts = null } = blockProps;
+        const { depth, blockType = null, popoverPrimaryTitle, rowGroups, rowGroupKey, columnKey, summaryCounts = null, countFor = 'files' } = blockProps;
         const effectiveBlockType = blockType === 'col-secondary-summary' ? 'col-summary' : blockType;
         let isGroup = (Array.isArray(data) && data.length >= 1) || false;
         let aggrData;
@@ -728,6 +728,10 @@ export class VisualBody extends React.PureComponent {
             : 0;
         // Round totalCoverage to 2 decimal places since ES has floating point precision issues
         const roundedTotalCoverage = totalCoverage > 0 ? Math.round(totalCoverage * 100) / 100 : 0;
+        const totalCoverageDisplay = roundedTotalCoverage > 0 ? `${formatLocalizedNumber(roundedTotalCoverage, {
+            minimumFractionDigits: 0,
+            maximumFractionDigits: 2
+        })}X` : '--';
         const formatGermLayerValue = (value) => (value && value !== 'No value' ? value : '--');
 
         // Render
@@ -794,20 +798,22 @@ export class VisualBody extends React.PureComponent {
                                 </div>
                             ) : null}
                             {effectiveBlockType === 'col-summary' ? (
-                                <div className="row secondary-row pb-1 mt-1">
-                                    <div className="col-4">
-                                        <div className="label me-05">{StackedBlockVisual.pluralize(primaryGrpPropTitle)}</div>
-                                        <div className="value">{primaryGrpPropUniqueCount || '--'}</div>
+                                <React.Fragment>
+                                    <div className="row secondary-row pb-1 mt-1">
+                                        <div className="col-4">
+                                            <div className="label me-05">{StackedBlockVisual.pluralize(primaryGrpPropTitle)}</div>
+                                            <div className="value">{primaryGrpPropUniqueCount || '--'}</div>
+                                        </div>
+                                        <div className="col-4">
+                                            <div className="label">{secondaryGrpPropCategoryValue ? 'Germ Layer' : (isTissueGrouping ? 'Total Donors' : StackedBlockVisual.pluralize(secondaryGrpPropTitle))}</div>
+                                            <div className="value">{secondaryGrpPropCategoryValue ? formatGermLayerValue(secondaryGrpPropCategoryValue) : (isTissueGrouping ? (donorCount || '--') : (secondaryGrpPropUniqueCount || '--'))}</div>
+                                        </div>
+                                        <div className="col-4">
+                                            <div className="label">{countFor === 'total_coverage' ? 'Total Coverage' : 'Total Files'}</div>
+                                            <div className="value">{countFor === 'total_coverage' ? totalCoverageDisplay : fileCount}</div>
+                                        </div>
                                     </div>
-                                    <div className="col-4">
-                                        <div className="label">{secondaryGrpPropCategoryValue ? 'Germ Layer' : (isTissueGrouping ? 'Total Donors' : StackedBlockVisual.pluralize(secondaryGrpPropTitle))}</div>
-                                        <div className="value">{secondaryGrpPropCategoryValue ? formatGermLayerValue(secondaryGrpPropCategoryValue) : (isTissueGrouping ? (donorCount || '--') : (secondaryGrpPropUniqueCount || '--'))}</div>
-                                    </div>
-                                    <div className="col-4">
-                                        <div className="label">Total Files</div>
-                                        <div className="value">{fileCount}</div>
-                                    </div>
-                                </div>
+                                </React.Fragment>
                             ) : null}
                             {effectiveBlockType === 'row-summary' && depth === 0 ? (
                                 <div className="row secondary-row pb-1 mt-1">

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -552,7 +552,7 @@ export class VisualBody extends React.PureComponent {
                 );
                 //2. traverse rowAggFields to see if facetField exists there
                 if (!compositeFacetPairs && Array.isArray(rowAggFields)) {
-                    for (const field in rowAggFields) {
+                    for (const field of rowAggFields) {
                         compositeFacetPairs = VisualBody.getFacetPairs(
                             facetField,
                             facetTerm,

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -191,14 +191,16 @@ export class VisualBody extends React.PureComponent {
         // For total_coverage, we want to display the value with "X" and
         // use a different formatting logic. For other count types, we display the raw count with standard formatting.
         if (countFor === 'total_coverage') {
-            if (blockType === 'col-summary') {
+            const shouldShowCoverageSummary = !!blockProps?.showCoverageSummaries;
+            if (!shouldShowCoverageSummary && (blockType === 'col-summary' || blockType === 'row-summary' || blockType === 'col-secondary-summary')) {
                 return <span data-count={blockSum}>&nbsp;</span>;
             }
-            if (blockType === 'row-summary') {
-                return <span data-count={blockSum}>-</span>;
-            }
             if (blockSum <= 0) return <span data-count={blockSum}>0</span>;
-            const compactCoverageText = !!(blockProps && blockProps.compactCoverageText);
+            // Summary cells are narrower than the regular coverage tiles, so
+            // prefer the compact formatter there unless a caller overrides it.
+            const compactCoverageText = typeof blockProps?.compactCoverageText === 'boolean'
+                ? blockProps.compactCoverageText
+                : (blockType === 'col-summary' || blockType === 'row-summary' || blockType === 'col-secondary-summary');
             const rounded = compactCoverageText
                 ? Math.round(blockSum)
                 : (blockSum < 100 ? Math.round(blockSum * 10) / 10 : Math.round(blockSum));
@@ -819,7 +821,7 @@ export class VisualBody extends React.PureComponent {
                     'summaryBackgroundColor', 'xAxisLabel', 'yAxisLabel', 'showAxisLabels', 'showColumnSummary',
                     'countFor', 'overallCounts', 'showUniqueDonorsAssayBand', 'shrinkEmptyColumns',
                     'blockWidth', 'blockHorizontalExtend', 'blockHorizontalSpacing', 'blockVerticalSpacing', 'rowSummaryCountsByGroup',
-                    'compactCoverageText', 'disableRowExpand', 'disableBlockOpen',
+                    'compactCoverageText', 'showCoverageSummaries', 'disableRowExpand', 'disableBlockOpen',
                     'headerLeftControls', 'hideFallbackColumnGroupHeader', 'hideFallbackRowGroupHeader', 'isGridRefreshing')}
                 blockPopover={this.blockPopover}
                 blockRenderedContents={VisualBody.blockRenderedContents}
@@ -1822,7 +1824,7 @@ export class StackedBlockGroupedRow extends React.PureComponent {
             'groupedDataIndices', 'columnGrouping', 'blockPopover', 'colorRanges', 'summaryBackgroundColor',
             'activeBlock', 'openBlock', 'handleBlockMouseEnter', 'handleBlockMouseLeave', 'handleBlockClick', 'group', 'popoverPrimaryTitle',
             // Generic summary overrides keyed by grouping field and row value.
-            'countFor', 'rowSummaryCountsByGroup', 'compactCoverageText');
+            'countFor', 'rowSummaryCountsByGroup', 'compactCoverageText', 'showCoverageSummaries');
         const getContainerGroupStyle = function(columnKey = 'overall-summary') {
             const width = StackedBlockGroupedRow.getColumnWidthForKey(columnKey, props);
             return {
@@ -2354,6 +2356,11 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                     const isPrimarySummaryBand = summaryBlockType === 'col-secondary-summary';
                     const totalsCounts = StackedBlockGroupedRow.getColumnTotalsEntry(columnKey, props)?.counts;
                     const sectionRows = getAllSectionRows();
+                    const derivedCoverageTotal = summaryCountFor === 'total_coverage'
+                        ? _.reduce(props.groupedDataIndices[columnKey] || [], function(sum, item) {
+                            return sum + getCountValueFromItem(item, 'total_coverage');
+                        }, 0)
+                        : null;
                     // Apply derived fallback only for DSA column summary files.
                     // Other columns continue using backend/standard summary paths.
                     const shouldDeriveDsaFiles = (summaryCountFor === 'files' || summaryCountFor === 'tissue_files')
@@ -2371,12 +2378,15 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                         : {
                             ...(totalsCounts || {}),
                             donors: donorsCount,
+                            ...(summaryCountFor === 'total_coverage' ? { total_coverage: totalsCounts?.total_coverage ?? derivedCoverageTotal ?? 0 } : null),
                             ...((typeof derivedDsaFiles === 'number') ? { files: derivedDsaFiles } : null)
                         };
                     const columnSummaryData = summaryCountFor === 'donors'
                         ? [{ counts: { donors: donorsCount } }]
                         : summaryCountFor === 'total_coverage'
-                            ? []
+                            ? (props.showCoverageSummaries
+                                ? [{ counts: { total_coverage: summaryCounts?.total_coverage || 0 } }]
+                                : [])
                             : (typeof derivedDsaFiles === 'number'
                                 ? [{ counts: { files: derivedDsaFiles } }]
                                 : getColumnSummaryData(columnKey));
@@ -2407,7 +2417,7 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                     );
                 })}
                 {(() => {
-                    if (summaryCountFor === 'total_coverage') return null;
+                    if (summaryCountFor === 'total_coverage' && !props.showCoverageSummaries) return null;
                     const isPrimarySummaryBand = summaryBlockType === 'col-secondary-summary';
                     const sectionRows = getAllSectionRows();
                     // If row summary overrides exist for this grouping field, use them for the
@@ -2417,6 +2427,10 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                         ? (isPrimarySummaryBand
                             ? getOverallPrimaryGroupCountFromRows()
                             : (props.overallCounts?.donors ?? props.overallCounts?.donor_count ?? getUniqueDonorCountFromRows(sectionRows)))
+                        : summaryCountFor === 'total_coverage'
+                            ? (props.overallCounts?.total_coverage ?? _.reduce(sectionRows, function(sum, item) {
+                                return sum + getCountValueFromItem(item, 'total_coverage');
+                            }, 0))
                         : summaryCountFor === 'tissue_files'
                             ? (props.overallCounts?.files ?? overallFilesOverride ?? _.reduce(sectionRows, function (sum, item) {
                                 return sum + (Number(item?.counts?.files) || 0);
@@ -2691,8 +2705,7 @@ const Block = React.memo(function Block(props){
             : _.reduce(argData, function (sum, item) { return sum + getCountValueFromItem(item, effectiveCountFor); }, 0))
         : (argData ? getCountValueFromItem(argData, effectiveCountFor) : 0);
     const hideCoverageBlock = countFor === 'total_coverage' && blockType === 'regular' && blockValue <= 0;
-    const hideCoverageSummaryBlock = countFor === 'total_coverage' && blockType === 'col-summary';
-    if (hideCoverageBlock || hideCoverageSummaryBlock) {
+    if (hideCoverageBlock) {
         popover = null;
     }
 
@@ -2724,7 +2737,7 @@ const Block = React.memo(function Block(props){
             : (openBlock?.rowKey === group));
 
     // Apply open/active styles
-    if (hideCoverageBlock || hideCoverageSummaryBlock) {
+    if (hideCoverageBlock) {
         style['backgroundColor'] = 'transparent';
         style['borderColor'] = 'transparent';
         style['pointerEvents'] = 'none';
@@ -2760,7 +2773,7 @@ const Block = React.memo(function Block(props){
             data-block-type={blockType || 'regular'}
             onMouseEnter={() => typeof handleBlockMouseEnter === 'function' && handleBlockMouseEnter(colIndex, rowIndex, group, rowGroupKey, summaryRowType)}
             onMouseLeave={handleBlockMouseLeave}
-            onClick={()=> !(hideCoverageBlock || hideCoverageSummaryBlock) && popover && handleBlockClick(colIndex, rowIndex, group, rowGroupKey, summaryRowType)}>
+            onClick={()=> !hideCoverageBlock && popover && handleBlockClick(colIndex, rowIndex, group, rowGroupKey, summaryRowType)}>
             {contents}
         </div>
     );

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -39,6 +39,28 @@ function getCountValueFromItem(item, countField) {
     return 0;
 }
 
+function formatLocalizedNumber(value, options = undefined) {
+    const normalizedValue = Number(value) || 0;
+    const {
+        minimumFractionDigits = 0,
+        maximumFractionDigits = 3
+    } = options || {};
+    const fixedValue = normalizedValue.toFixed(maximumFractionDigits);
+    let [integerPart, fractionPart = ''] = fixedValue.split('.');
+    integerPart = integerPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+
+    if (maximumFractionDigits === 0) {
+        return integerPart;
+    }
+
+    fractionPart = fractionPart.replace(/0+$/, '');
+    if (fractionPart.length < minimumFractionDigits) {
+        fractionPart = fractionPart.padEnd(minimumFractionDigits, '0');
+    }
+
+    return fractionPart.length > 0 ? `${integerPart}.${fractionPart}` : integerPart;
+}
+
 function formatCompactedNumericValue(value, {
     decimalsByThreshold = null,
     units = [
@@ -60,8 +82,8 @@ function formatCompactedNumericValue(value, {
     const matchingUnit = units.find(({ threshold }) => absValue >= threshold) || null;
     if (!matchingUnit) {
         return {
-            display: normalizedValue.toLocaleString(),
-            tooltipValue: normalizedValue.toLocaleString(),
+            display: formatLocalizedNumber(normalizedValue),
+            tooltipValue: formatLocalizedNumber(normalizedValue),
             isCompacted: false
         };
     }
@@ -70,11 +92,14 @@ function formatCompactedNumericValue(value, {
     const decimals = typeof decimalsByThreshold === 'function'
         ? decimalsByThreshold(scaledValue, matchingUnit)
         : (scaledValue >= 100 ? 0 : 1);
-    const formattedValue = `${parseFloat(scaledValue.toFixed(decimals)).toLocaleString()}${matchingUnit.suffix}`;
+    const formattedValue = `${formatLocalizedNumber(parseFloat(scaledValue.toFixed(decimals)), {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: decimals
+    })}${matchingUnit.suffix}`;
 
     return {
         display: formattedValue,
-        tooltipValue: normalizedValue.toLocaleString(),
+        tooltipValue: formatLocalizedNumber(normalizedValue),
         isCompacted: !!matchingUnit
     };
 }
@@ -104,8 +129,8 @@ function formatCoverageDisplayValue(value, compact = false) {
         ? Math.round(normalizedValue)
         : (normalizedValue < 100 ? Math.round(normalizedValue * 10) / 10 : Math.round(normalizedValue));
     return {
-        display: `${roundedValue.toLocaleString()}X`,
-        tooltipValue: normalizedValue.toLocaleString(),
+        display: `${formatLocalizedNumber(roundedValue)}X`,
+        tooltipValue: formatLocalizedNumber(normalizedValue),
         isCompacted: false
     };
 }
@@ -292,7 +317,7 @@ export class VisualBody extends React.PureComponent {
                 decimalsByThreshold: (scaledValue) => (scaledValue >= 10 ? 0 : decimal)
             });
             return (
-                <span style={{ 'fontSize' : '0.80rem', 'position' : 'relative', 'top' : -1 }} data-count={blockSum} data-tip={blockSum}>
+                <span style={{ 'fontSize' : '0.80rem', 'position' : 'relative', 'top' : -1 }} data-count={blockSum}>
                     { compactedValue.isCompacted ? compactedValue.display : roundLargeNumber(blockSum, decimal) }
                 </span>
             );
@@ -2787,6 +2812,12 @@ const Block = React.memo(function Block(props){
             : true;
         return formatCoverageDisplayValue(blockValue, compactCoverageText).isCompacted;
     })();
+    const compactedCountTooltip = (() => {
+        if (countFor === 'total_coverage') {
+            return shouldShowCompactCoverageTooltip ? `${formatLocalizedNumber(blockValue)}X` : null;
+        }
+        return blockValue >= 1000 ? formatLocalizedNumber(blockValue) : null;
+    })();
     const hideCoverageBlock = countFor === 'total_coverage' && blockType === 'regular' && blockValue <= 0;
     if (hideCoverageBlock) {
         popover = null;
@@ -2854,7 +2885,7 @@ const Block = React.memo(function Block(props){
             data-place="bottom"
             data-block-value={blockValue}
             data-block-type={blockType || 'regular'}
-            {...(shouldShowCompactCoverageTooltip ? { 'data-tip': `${Number(blockValue || 0).toLocaleString()}X` } : {})}
+            {...(compactedCountTooltip ? { 'data-tip': compactedCountTooltip } : {})}
             onMouseEnter={() => typeof handleBlockMouseEnter === 'function' && handleBlockMouseEnter(colIndex, rowIndex, group, rowGroupKey, summaryRowType)}
             onMouseLeave={handleBlockMouseLeave}
             onClick={()=> !hideCoverageBlock && popover && handleBlockClick(colIndex, rowIndex, group, rowGroupKey, summaryRowType)}>

--- a/src/encoded/static/scss/encoded/modules/_charts.scss
+++ b/src/encoded/static/scss/encoded/modules/_charts.scss
@@ -1579,8 +1579,21 @@ body[data-path="/statistics"] {
     }
 
     .matrix-visual-metric-controls {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
         margin-left: 0;
         margin-bottom: 0.5rem;
+    }
+
+    .matrix-inline-refresh-indicator {
+        color: #6f8093;
+        font-size: 1.15rem;
+        line-height: 1;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 1.15rem;
     }
 
     .matrix-mode-body {
@@ -1804,6 +1817,54 @@ body[data-path="/statistics"] {
         padding-right: 40px;
         padding-left: 10px;
         border-left: 1px solid #e2e8ef;
+
+        &.is-loading {
+            display: block;
+            width: 100%;
+            min-height: 420px;
+            position: relative;
+        }
+
+        &.is-refreshing-grid {
+            // Leave headers/toggles readable, but visibly mute stale cells until the refreshed counts arrive.
+            .grouping.header-section-upper .header-summary,
+            .grouping.header-section-upper .column-group-header .stacked-block,
+            > .grouping.depth-0.open,
+            .vertical-container-label {
+                opacity: 0.28;
+                filter: saturate(0.55);
+                transition: opacity 140ms ease, filter 140ms ease;
+            }
+
+            .stacked-block {
+                pointer-events: none;
+            }
+        }
+
+        .matrix-loading-indicator {
+            width: 100%;
+            min-height: 260px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .matrix-loading-header-controls {
+            position: relative;
+            z-index: 2;
+            width: 240px;
+            margin-left: 12px;
+            margin-top: 16px;
+            margin-bottom: -10px;
+
+            .matrix-top-controls,
+            .matrix-visual-metric-controls {
+                margin-left: 0 !important;
+                margin-bottom: 0 !important;
+                justify-content: flex-start;
+                width: 100%;
+            }
+        }
 
         .grouping.header-section-upper {
             position: relative;


### PR DESCRIPTION
## Summary

This PR improves coverage-related behavior in the Production Data Matrix views, with a focus on clearer summaries, better loading states, and more appropriate coverage-specific formatting.

## What changed

- added total coverage support to matrix summary rows and popovers
- improved compact coverage value formatting and tooltip behavior
- introduced a separate color range segment step for coverage values
- reset incompatible count toggles when switching between matrix modes
- refined loading-state rendering to avoid confusing stale data during tab/view transitions
- adjusted matrix loading layout and spinner positioning for a more stable UX
- updated chart styling to support the new loading and summary presentation

## Notes

- coverage formatting now uses coverage-specific display rules instead of reusing file-count assumptions
- coverage color segmentation can be configured independently from file-count segmentation
- donor x tissue and donor x assay views now behave more predictably when switching between `Files` and `Coverage`

<img width="1696" height="1037" alt="resim" src="https://github.com/user-attachments/assets/9509d4e7-619e-48c5-b283-025ab2f57779" />
