### PR TITLE
Fix donor x assay matrix count inconsistencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@ smaht-portal
 Change Log
 ----------
 
+
+1.33.1
+======
+
+`PR 694: Fix donor x assay matrix count inconsistencies <https://github.com/smaht-dac/smaht-portal/pull/694>`_
+
+* Resolve count mismatches for CODEC, NanoSeq, and VISTA-Seq assay types between the data matrix and browse view
+
+
 1.33.0
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "1.33.0"
+version = "1.33.1"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/viz/Matrix/DataMatrix.js
+++ b/src/encoded/static/components/viz/Matrix/DataMatrix.js
@@ -864,7 +864,15 @@ export default class DataMatrix extends React.PureComponent {
         return _.reduce(rows, (memo, row) => {
             const columnValue = row?.[columnGrouping];
             const files = Number(row?.counts?.files) || 0;
+            const dataType = String(row?.data_type || '');
+            const isDsaLikeRow = dataType === 'DSA' || dataType === 'Chain File' || dataType === 'Sequence Interval';
             if (!columnValue || files <= 0) {
+                return memo;
+            }
+
+            // Keep raw assay totals for normal columns, but do not leak DSA-like rows
+            // back into their parent assay cells. DSA continues to use its own derived path.
+            if (isDsaLikeRow && columnValue !== 'DSA') {
                 return memo;
             }
 

--- a/src/encoded/static/components/viz/Matrix/DataMatrix.js
+++ b/src/encoded/static/components/viz/Matrix/DataMatrix.js
@@ -856,6 +856,40 @@ export default class DataMatrix extends React.PureComponent {
         return typeof assayValue === 'string' ? assayValue : null;
     }
 
+    static buildRawRegularCountOverrides(rows = [], groupingProperties = [], columnGrouping = null) {
+        if (!Array.isArray(rows) || rows.length === 0 || !Array.isArray(groupingProperties) || !columnGrouping) {
+            return {};
+        }
+
+        return _.reduce(rows, (memo, row) => {
+            const columnValue = row?.[columnGrouping];
+            const files = Number(row?.counts?.files) || 0;
+            if (!columnValue || files <= 0) {
+                return memo;
+            }
+
+            const pathValues = [];
+            for (let depth = 0; depth < groupingProperties.length; depth++) {
+                const groupingField = groupingProperties[depth];
+                const groupingValue = row?.[groupingField];
+                if (groupingValue == null || groupingValue === '') {
+                    break;
+                }
+                pathValues.push(String(groupingValue));
+                const pathKey = pathValues.join('||');
+                if (!memo[depth]) {
+                    memo[depth] = {};
+                }
+                if (!memo[depth][pathKey]) {
+                    memo[depth][pathKey] = {};
+                }
+                memo[depth][pathKey][String(columnValue)] = (memo[depth][pathKey][String(columnValue)] || 0) + files;
+            }
+
+            return memo;
+        }, {});
+    }
+
     loadSearchQueryResults() {
         const requestId = ++this.latestLoadRequestId;
         const {
@@ -885,6 +919,7 @@ export default class DataMatrix extends React.PureComponent {
             const updatedState = {};
 
             let transformedData = { all: [], row_totals: [], column_totals: [] };
+            const rawProcessedAllRows = [];
             const populatedRowGroups = {}; // not implemented yet
             // Helper to process each result row
             const processResultRow = (r, transformed) => {
@@ -931,6 +966,9 @@ export default class DataMatrix extends React.PureComponent {
                         });
                     }
                     transformed.push(cloned);
+                    if (transformed === transformedData.all) {
+                        rawProcessedAllRows.push(_.clone(cloned));
+                    }
                 }
                 if (autoPopulateRowGroupsProperty && cloned[autoPopulateRowGroupsProperty]) {
                     const rowGroupKey = cloned[autoPopulateRowGroupsProperty];
@@ -992,6 +1030,11 @@ export default class DataMatrix extends React.PureComponent {
                 }, {})
                 : null;
             updatedState['rowSummaryCountsByGroup'] = donorSummaryCounts ? { donor: donorSummaryCounts } : null;
+            updatedState['rawRegularCountOverrides'] = DataMatrix.buildRawRegularCountOverrides(
+                rawProcessedAllRows,
+                groupingProperties,
+                columnGrouping
+            );
             const availableDonorTissueAssays = _.uniq(_.compact(_.map(transformedData.all, (r) => r.assay)));
             updatedState['availableDonorTissueAssays'] = availableDonorTissueAssays;
             // Keep top-level included-properties count aligned with backend search context.
@@ -1734,6 +1777,7 @@ export default class DataMatrix extends React.PureComponent {
             // Use mode-appropriate summary overrides: donor/tissue mode may null these out
             // under assay filter to avoid inconsistencies with facet-driven contexts.
             rowSummaryCountsByGroup: effectiveRowSummaryCountsByGroup,
+            rawRegularCountOverrides: this.state.rawRegularCountOverrides || null,
             ...(countFor === 'total_coverage' && matrixMode === DataMatrix.MATRIX_MODES.TISSUE_ASSAY
                 ? { blockWidth: 60, blockHorizontalExtend: 10 }
                 : {}),
@@ -2126,9 +2170,6 @@ DataMatrix.browseFilteringTransformFuncs = {
         const hasAssayFilter = assayFilterList.length > 0;
         const hasDSAAssayFilter = assayFilterList.includes('DSA');
         const hasVariantCallSetsAssayFilter = assayFilterList.includes('Variant Call Sets');
-        const studies = filteringProperties['sample_summary.studies'];
-        const studiesList = Array.isArray(studies) ? studies : (typeof studies === 'string' ? [studies] : []);
-        const isProductionStudy = studiesList.includes('Production');
 
         if (hasDSAAssayFilter) {
             // extend data_type filter to include Chain File along with DSA
@@ -2148,10 +2189,9 @@ DataMatrix.browseFilteringTransformFuncs = {
         ) {
             // for non-DSA columns we exclude DSA-related data types;
             // for overall summary (no assay filter) keep all data types.
+            // Keep filtered/phased rows in their parent assay browse links so
+            // regular blocks and summary columns match raw backend assay totals.
             filteringProperties['data_type!'] = [...(filteringProperties['data_type!'] || []), 'DSA', 'Chain File', 'Sequence Interval'];
-            if (isProductionStudy) {
-                filteringProperties['analysis_details!'] = [...(filteringProperties['analysis_details!'] || []), 'Filtered', 'Phased'];
-            }
         }
         return filteringProperties;
     }

--- a/src/encoded/static/components/viz/Matrix/DataMatrix.js
+++ b/src/encoded/static/components/viz/Matrix/DataMatrix.js
@@ -1785,7 +1785,12 @@ export default class DataMatrix extends React.PureComponent {
             // Use mode-appropriate summary overrides: donor/tissue mode may null these out
             // under assay filter to avoid inconsistencies with facet-driven contexts.
             rowSummaryCountsByGroup: effectiveRowSummaryCountsByGroup,
-            rawRegularCountOverrides: this.state.rawRegularCountOverrides || null,
+            // Raw regular-cell overrides are only intended for Donor x Assay.
+            // Donor x Tissue derives its own filtered donor/tissue aggregates and
+            // should not reuse assay-oriented raw override maps.
+            rawRegularCountOverrides: matrixMode === DataMatrix.MATRIX_MODES.DONOR_ASSAY
+                ? (this.state.rawRegularCountOverrides || null)
+                : null,
             ...(countFor === 'total_coverage' && matrixMode === DataMatrix.MATRIX_MODES.TISSUE_ASSAY
                 ? { blockWidth: 60, blockHorizontalExtend: 10 }
                 : {}),

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -721,13 +721,19 @@ export class VisualBody extends React.PureComponent {
                 totalCoverage: sum.totalCoverage + getTotalCoverageFromItem(item)
             };
         }, { fileCount: 0, totalCoverage: 0 });
+        const effectiveFileCount = typeof summaryCounts?.files === 'number'
+            ? summaryCounts.files
+            : fileCount;
+        const effectiveTotalCoverage = typeof summaryCounts?.total_coverage === 'number'
+            ? summaryCounts.total_coverage
+            : totalCoverage;
         const donorCount = getUniqueDonorCountFromItems(dataForCounts);
         const isTissueColumnGrouping = (fieldChangeMap?.[columnGrouping] || columnGrouping) === 'sample_summary.tissues';
         const tissueCount = isTissueColumnGrouping
             ? getUniqueValueCountFromItems(effectiveBlockType === 'row-summary' ? rowSummaryItems : dataForCounts, columnGrouping)
             : 0;
         // Round totalCoverage to 2 decimal places since ES has floating point precision issues
-        const roundedTotalCoverage = totalCoverage > 0 ? Math.round(totalCoverage * 100) / 100 : 0;
+        const roundedTotalCoverage = effectiveTotalCoverage > 0 ? Math.round(effectiveTotalCoverage * 100) / 100 : 0;
         const totalCoverageDisplay = roundedTotalCoverage > 0 ? `${formatLocalizedNumber(roundedTotalCoverage, {
             minimumFractionDigits: 0,
             maximumFractionDigits: 2
@@ -793,7 +799,7 @@ export class VisualBody extends React.PureComponent {
                                     </div>
                                     <div className="col-4">
                                         <div className="label">Total Files</div>
-                                        <div className="value">{fileCount}</div>
+                                        <div className="value">{effectiveFileCount}</div>
                                     </div>
                                 </div>
                             ) : null}
@@ -810,7 +816,7 @@ export class VisualBody extends React.PureComponent {
                                         </div>
                                         <div className="col-4">
                                             <div className="label">{countFor === 'total_coverage' ? 'Total Coverage' : 'Total Files'}</div>
-                                            <div className="value">{countFor === 'total_coverage' ? totalCoverageDisplay : fileCount}</div>
+                                            <div className="value">{countFor === 'total_coverage' ? totalCoverageDisplay : effectiveFileCount}</div>
                                         </div>
                                     </div>
                                 </React.Fragment>
@@ -843,7 +849,7 @@ export class VisualBody extends React.PureComponent {
                                     }
                                     <div className="col-4">
                                         <div className="label">Total Files</div>
-                                        <div className="value">{fileCount}</div>
+                                        <div className="value">{effectiveFileCount}</div>
                                     </div>
                                 </div>
                             ) : null}
@@ -859,12 +865,12 @@ export class VisualBody extends React.PureComponent {
                                     </div>
                                     <div className="col-4">
                                         <div className="label">Total Files</div>
-                                        <div className="value">{fileCount}</div>
+                                        <div className="value">{effectiveFileCount}</div>
                                     </div>
                                 </div>
                             ) : null}
                             <div className="row footer-row p-1">
-                                {makeSearchButton(browseUrl, fileCount <= 0)}
+                                {makeSearchButton(browseUrl, effectiveFileCount <= 0)}
                             </div>
                         </div>
                         :

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -925,7 +925,7 @@ export class VisualBody extends React.PureComponent {
                     'summaryBackgroundColor', 'xAxisLabel', 'yAxisLabel', 'showAxisLabels', 'showColumnSummary',
                     'countFor', 'overallCounts', 'showUniqueDonorsAssayBand', 'shrinkEmptyColumns',
                     'blockWidth', 'blockHorizontalExtend', 'blockHorizontalSpacing', 'blockVerticalSpacing', 'rowSummaryCountsByGroup',
-                    'compactCoverageText', 'showCoverageSummaries', 'disableRowExpand', 'disableBlockOpen',
+                    'rawRegularCountOverrides', 'compactCoverageText', 'showCoverageSummaries', 'disableRowExpand', 'disableBlockOpen',
                     'headerLeftControls', 'hideFallbackColumnGroupHeader', 'hideFallbackRowGroupHeader', 'isGridRefreshing')}
                 blockPopover={this.blockPopover}
                 blockRenderedContents={VisualBody.blockRenderedContents}
@@ -1432,6 +1432,7 @@ export class StackedBlockVisual extends React.PureComponent {
                                         rowTotals={nestedRowTotals[k]}
                                         key={k}
                                         group={k}
+                                        groupPath={[]}
                                         depth={0}
                                         index={outerIdx}
                                         onSorterClick={this.handleSorterClick}
@@ -1616,6 +1617,7 @@ export class StackedBlockVisual extends React.PureComponent {
                                             rowTotals={nestedRowTotals[k]}
                                             key={k}
                                             group={k}
+                                            groupPath={[]}
                                             index={outerIdx}
                                         />
                                     );
@@ -1652,6 +1654,7 @@ export class StackedBlockVisual extends React.PureComponent {
                                 rowTotals={nestedRowTotals[k]}
                                 key={k}
                                 group={k}
+                                groupPath={[]}
                                 index={idx}
                             />
                         )
@@ -1909,6 +1912,16 @@ export class StackedBlockGroupedRow extends React.PureComponent {
         return foundGroup ? total : null;
     }
 
+    static getRawRegularOverrideForColumn(columnKey, props) {
+        const { rawRegularCountOverrides, depth, group, groupPath = [] } = props;
+        if (!rawRegularCountOverrides || columnKey == null || typeof depth !== 'number') return null;
+        const pathValues = [...groupPath, group].filter((value) => value != null && value !== '');
+        if (pathValues.length === 0) return null;
+        const pathKey = pathValues.map((value) => String(value)).join('||');
+        const overrideValue = rawRegularCountOverrides?.[depth]?.[pathKey]?.[String(columnKey)];
+        return typeof overrideValue === 'number' ? overrideValue : null;
+    }
+
     /** @todo Convert to functional memoized React component */
     static collapsedChildBlocks = memoize(function(data, rowTotals, props){
 
@@ -2049,7 +2062,8 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                                     // We have columnSubGrouping so these are -pairs- of (0) columnSubGrouping val, (1) blocks
                                     blockData = blockData[1];
                                 }
-                                const explicitOverrideFiles = derivedCollapsedCellOverrides[k];
+                                const rawOverrideFiles = StackedBlockGroupedRow.getRawRegularOverrideForColumn(k, props);
+                                const explicitOverrideFiles = typeof rawOverrideFiles === 'number' ? rawOverrideFiles : derivedCollapsedCellOverrides[k];
                                 const blockDataForRender = typeof explicitOverrideFiles === 'number'
                                     ? [{
                                         ...(blockData[0] || {}),
@@ -2465,6 +2479,7 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                 {columnKeys.map(function (columnKey, colIndex) {
                     const isPrimarySummaryBand = summaryBlockType === 'col-secondary-summary';
                     const totalsCounts = StackedBlockGroupedRow.getColumnTotalsEntry(columnKey, props)?.counts;
+                    const rawColumnTotalEntry = StackedBlockGroupedRow.getColumnTotalsEntry(columnKey, props);
                     const sectionRows = getAllSectionRows();
                     const derivedCoverageTotal = summaryCountFor === 'total_coverage'
                         ? _.reduce(props.groupedDataIndices[columnKey] || [], function(sum, item) {
@@ -2491,15 +2506,18 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                             ...(summaryCountFor === 'total_coverage' ? { total_coverage: totalsCounts?.total_coverage ?? derivedCoverageTotal ?? 0 } : null),
                             ...((typeof derivedDsaFiles === 'number') ? { files: derivedDsaFiles } : null)
                         };
+                    const useRawColumnTotal = rawColumnTotalEntry && (summaryCountFor === 'files' || summaryCountFor === 'tissue_files');
                     const columnSummaryData = summaryCountFor === 'donors'
                         ? [{ counts: { donors: donorsCount } }]
                         : summaryCountFor === 'total_coverage'
                             ? (props.showCoverageSummaries
                                 ? [{ counts: { total_coverage: summaryCounts?.total_coverage || 0 } }]
                                 : [])
-                            : (typeof derivedDsaFiles === 'number'
-                                ? [{ counts: { files: derivedDsaFiles } }]
-                                : getColumnSummaryData(columnKey));
+                            : (useRawColumnTotal
+                                ? rawColumnTotalEntry
+                                : (typeof derivedDsaFiles === 'number'
+                                    ? [{ counts: { files: derivedDsaFiles } }]
+                                    : getColumnSummaryData(columnKey)));
                     const columnTotal = props.groupedDataIndices[columnKey]?.length || 0;
                     const hasOpenBlock = props.openBlock?.columnIdx === colIndex && props.openBlock?.summaryRowType === summaryBlockType;
                     const hasActiveBlock = props.activeBlock?.columnIdx === colIndex && props.activeBlock?.summaryRowType === summaryBlockType;
@@ -2698,14 +2716,14 @@ export class StackedBlockGroupedRow extends React.PureComponent {
             rowHeight,
             rowGroupsExtendedByLowerKey,
             renderRow: (k) => (
-                <StackedBlockGroupedRow {...this.props} data={data[k]} key={k} group={k} depth={depth + 1} />
+                <StackedBlockGroupedRow {...this.props} data={data[k]} key={k} group={k} groupPath={[...(this.props.groupPath || []), group]} depth={depth + 1} />
             )
         });
 
         const renderChildRows = () => (
             <div className="child-blocks">
                 {open && childRowsKeys && _.map(childRowsKeys, (k) =>
-                    <StackedBlockGroupedRow {...this.props} data={data[k]} key={k} group={k} depth={depth + 1} />
+                    <StackedBlockGroupedRow {...this.props} data={data[k]} key={k} group={k} groupPath={[...(this.props.groupPath || []), group]} depth={depth + 1} />
                 )}
             </div>
         );

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -2068,7 +2068,9 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                                     // We have columnSubGrouping so these are -pairs- of (0) columnSubGrouping val, (1) blocks
                                     blockData = blockData[1];
                                 }
-                                const rawOverrideFiles = StackedBlockGroupedRow.getRawRegularOverrideForColumn(k, props);
+                                const rawOverrideFiles = (props.countFor === 'files' || props.countFor === 'tissue_files')
+                                    ? StackedBlockGroupedRow.getRawRegularOverrideForColumn(k, props)
+                                    : null;
                                 const explicitOverrideFiles = typeof rawOverrideFiles === 'number' ? rawOverrideFiles : derivedCollapsedCellOverrides[k];
                                 const blockDataForRender = typeof explicitOverrideFiles === 'number'
                                     ? [{


### PR DESCRIPTION
## Summary

This PR fixes count mismatches in the Donor x Assay matrix between:

- summary tiles
- regular cells
- summary popovers
- `/browse` results

## Root Cause

The matrix was mixing two sources:

- raw backend totals from `/data_matrix_aggregations`
- transformed rows used for derived columns like `DSA` and `Variant Call Sets`

That caused assay counts such as `CODEC`, `NanoSeq` and `VISTA-Seq` to differ depending on where they were displayed.

## Changes

- use raw backend totals for assay summary counts
- use raw row-path overrides for regular donor-assay cells
- keep `DSA` and `Variant Call Sets` special handling intact
- prevent DSA-like rows from inflating normal assay cells
- make summary popovers use the same totals as the visible summary tile

## Notes

`Variant Call Sets` can still overlap with parent assay columns under this model, so cross-column totals may exceed the grand total.

### Before
<img width="933" height="1019" alt="image" src="https://github.com/user-attachments/assets/c94eb00f-5c5d-462b-8bb0-a611ce359611" />

### After
<img width="933" height="1019" alt="image" src="https://github.com/user-attachments/assets/1714033d-356f-4f9a-9f8c-e2d65ce6f4d0" />

