### PR TITLE
Fix Recent Releases weekly navigation and September 2025 cutoff

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,18 @@ Change Log
 ----------
 
 
+1.33.2
+======
+
+`PR 695: Fix Recent Releases weekly navigation and September 2025 cutoff <https://github.com/smaht-dac/smaht-portal/pull/695>`_
+
+* Recover the missing Sep 2025 files - Include exclude_from_release_tracker-tagged files by default in /recent_release_days
+* Change the oldest navigable month from January 2025 to September 2025
+* Add explicit month context to home page weekly links
+* Preserve selected month context in Recent Releases URL state
+* Keep month focus stable when switching between Daily / Weekly / Monthly timeline modes
+
+
 1.33.1
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "1.33.1"
+version = "1.33.2"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/endpoints/recent_files_summary/recent_files_summary.py
+++ b/src/encoded/endpoints/recent_files_summary/recent_files_summary.py
@@ -556,7 +556,10 @@ def recent_release_days(request: PyramidRequest,
         statuses = request_args(request, "status", QUERY_FILE_STATUSES)
         categories = request_args(request, "category", QUERY_FILE_CATEGORIES)
         dataset = request_args(request, "dataset", QUERY_FILE_DATASET)
-        tags = request_args(request, "tag", QUERY_FILE_TAGS)
+        # For the calendar endpoint, include tagged files by default unless a caller
+        # explicitly provides tag filters. Some production release items are tagged
+        # exclude_from_release_tracker but should still appear in the timeline.
+        tags = request_args(request, "tag")
         base_query_arguments = {
             "type": types if types else None,
             "status": statuses if statuses else None,

--- a/src/encoded/static/components/static-pages/HomePage/DataReleaseTracker.js
+++ b/src/encoded/static/components/static-pages/HomePage/DataReleaseTracker.js
@@ -10,7 +10,7 @@ import { useUserDownloadAccess } from '../../util/hooks';
  * @param {number} count - Total file count for the week
  * @returns {JSX.Element}
  */
-const WeekGroup = ({ weekStart, weekEnd, count }) => {
+const WeekGroup = ({ weekStart, weekEnd, count, parentMonthKey = null }) => {
     const formatWeekDate = (date) =>
         date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 
@@ -23,7 +23,7 @@ const WeekGroup = ({ weekStart, weekEnd, count }) => {
         `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
     const weekHref =
         count > 0
-            ? `/recent-releases?view=weekly&date=${toDateKey(weekStart)}`
+            ? `/recent-releases?view=weekly&date=${toDateKey(weekStart)}${parentMonthKey ? `&month=${parentMonthKey}` : ''}`
             : null;
 
     return (
@@ -106,6 +106,7 @@ const DataReleaseItem = ({ data, releaseItemIndex, callout = null }) => {
                                     weekStart={weekStart}
                                     weekEnd={weekEnd}
                                     count={weekCount}
+                                    parentMonthKey={value}
                                 />
                             );
                         })}

--- a/src/encoded/static/components/static-pages/components/RecentReleasesTimelineMatrix.js
+++ b/src/encoded/static/components/static-pages/components/RecentReleasesTimelineMatrix.js
@@ -573,6 +573,44 @@ const buildWeekBucketsForMonth = (month = {}) => {
         .value();
 };
 
+// Rebuild a valid selection inside a specific month when the user switches
+// between Daily / Weekly / Monthly so we preserve month focus across views.
+const buildTimelineSelectionForMonth = (months = [], timelineMode = TIMELINE_MODES.WEEKLY, monthKey = null) => {
+    if (!monthKey || !months.length) return null;
+    const month = _.find(months, (item) => item?.value === monthKey) || null;
+    if (!month) return null;
+
+    if (timelineMode === TIMELINE_MODES.DAILY) {
+        // Prefer the first real release day inside the already focused month.
+        const firstDay = _.find(month.days || [], (day) => (day?.count || 0) > 0) || null;
+        return {
+            selectedDay: firstDay,
+            selectedTimelineTarget: firstDay,
+            selectedMonthKey: month.value
+        };
+    }
+
+    if (timelineMode === TIMELINE_MODES.WEEKLY) {
+        const firstWeek = _.find(buildWeekBucketsForMonth(month), (week) => (week?.count || 0) > 0) || null;
+        return {
+            selectedDay: null,
+            selectedTimelineTarget: firstWeek,
+            selectedMonthKey: month.value
+        };
+    }
+
+    return {
+        selectedDay: null,
+        selectedTimelineTarget: {
+            key: `month-${month.value}`,
+            fullLabel: month.label,
+            browseQuery: month.browseQuery,
+            matrixQuery: buildMatrixQueryFromBrowseQuery(month.browseQuery || '')
+        },
+        selectedMonthKey: month.value
+    };
+};
+
 export const RecentReleasesTimelineMatrix = ({ session }) => {
     const initialURLState = useMemo(() => getRecentReleasesURLState(), []);
     const [isLoading, setIsLoading] = useState(true);
@@ -655,6 +693,29 @@ export const RecentReleasesTimelineMatrix = ({ session }) => {
         : false;
     const canGoToOlderMonths = hasLocalOlderMonths || canFetchOlderMonths;
     const isOlderButtonDisabled = isLoadingOlderMonths || !canGoToOlderMonths;
+
+    const handleTimelineModeChange = (nextTimelineMode) => {
+        if (nextTimelineMode === timelineMode) return;
+        // Carry the currently focused month across view-mode changes instead of
+        // resetting to the newest month / first available bucket in the dataset.
+        const targetMonthKey = selectedMonthKey
+            || getMonthKeyFromDateString(selectedDay?.key)
+            || getMonthKeyFromDateString(selectedTimelineTarget?.key?.replace(/^month-/, ''))
+            || getMonthKeyFromDateString(selectedTimelineTarget?.from)
+            || months[0]?.value
+            || null;
+        const nextSelection = buildTimelineSelectionForMonth(months, nextTimelineMode, targetMonthKey);
+        if (targetMonthKey) {
+            setMonthWindowStartIndex(getMonthWindowStartIndexForTarget(months, TIMELINE_MONTH_WINDOW_SIZE[nextTimelineMode] || 1, targetMonthKey));
+        }
+        if (nextSelection) {
+            pendingTimelineSelectionRef.current = {
+                timelineMode: nextTimelineMode,
+                ...nextSelection
+            };
+        }
+        setTimelineMode(nextTimelineMode);
+    };
 
     useEffect(() => {
         if (!months?.length) return;
@@ -874,19 +935,19 @@ export const RecentReleasesTimelineMatrix = ({ session }) => {
                         <button
                             type="button"
                             className={`btn btn-sm ${timelineMode === TIMELINE_MODES.DAILY ? 'btn-primary active' : 'btn-outline-primary'}`}
-                            onClick={() => setTimelineMode(TIMELINE_MODES.DAILY)}>
+                            onClick={() => handleTimelineModeChange(TIMELINE_MODES.DAILY)}>
                             Daily
                         </button>
                         <button
                             type="button"
                             className={`btn btn-sm ${timelineMode === TIMELINE_MODES.WEEKLY ? 'btn-primary active' : 'btn-outline-primary'}`}
-                            onClick={() => setTimelineMode(TIMELINE_MODES.WEEKLY)}>
+                            onClick={() => handleTimelineModeChange(TIMELINE_MODES.WEEKLY)}>
                             Weekly
                         </button>
                         <button
                             type="button"
                             className={`btn btn-sm ${timelineMode === TIMELINE_MODES.MONTHLY ? 'btn-primary active' : 'btn-outline-primary'}`}
-                            onClick={() => setTimelineMode(TIMELINE_MODES.MONTHLY)}>
+                            onClick={() => handleTimelineModeChange(TIMELINE_MODES.MONTHLY)}>
                             Monthly
                         </button>
                     </div>

--- a/src/encoded/static/components/static-pages/components/RecentReleasesTimelineMatrix.js
+++ b/src/encoded/static/components/static-pages/components/RecentReleasesTimelineMatrix.js
@@ -33,7 +33,8 @@ const RELEASE_DATE_FACET_FIELDS = [
 ];
 const RECENT_RELEASES_URL_PARAMS = {
     VIEW: 'view',
-    DATE: 'date'
+    DATE: 'date',
+    MONTH: 'month'
 };
 
 const formatMonthLabel = (monthValue = '') => {
@@ -221,14 +222,16 @@ const getRecentReleasesURLState = () => {
     const queryParams = new URLSearchParams(queryString);
     const view = queryParams.get(RECENT_RELEASES_URL_PARAMS.VIEW);
     const date = queryParams.get(RECENT_RELEASES_URL_PARAMS.DATE);
+    const month = queryParams.get(RECENT_RELEASES_URL_PARAMS.MONTH);
 
     return {
         timelineMode: isValidTimelineMode(view) ? view : TIMELINE_MODES.WEEKLY,
-        selectedDate: date || null
+        selectedDate: date || null,
+        selectedMonthKey: getMonthKeyFromDateString(month)
     };
 };
 
-const buildRecentReleasesTargetFromDate = (months = [], timelineMode = TIMELINE_MODES.WEEKLY, selectedDate = null) => {
+const buildRecentReleasesTargetFromDate = (months = [], timelineMode = TIMELINE_MODES.WEEKLY, selectedDate = null, selectedMonthKey = null) => {
     if (!selectedDate || !months.length) {
         return null;
     }
@@ -246,7 +249,7 @@ const buildRecentReleasesTargetFromDate = (months = [], timelineMode = TIMELINE_
         const allWeeks = _.chain(months).map((month) => buildWeekBucketsForMonth(month)).flatten().value();
         const week = _.find(allWeeks, (item) => item?.from <= selectedDate && item?.to >= selectedDate) || null;
         return week ? {
-            monthKey: getMonthKeyFromDateString(selectedDate),
+            monthKey: selectedMonthKey || getMonthKeyFromDateString(selectedDate),
             selectedDay: null,
             selectedTimelineTarget: week
         } : null;
@@ -289,7 +292,7 @@ const getURLDateForSelectedTarget = (timelineMode = TIMELINE_MODES.WEEKLY, selec
     return selectedTimelineTarget?.key?.replace(/^month-/, '') || selectedTimelineTarget?.browseQuery?.match(/\d{4}-\d{2}/)?.[0] || null;
 };
 
-const syncRecentReleasesURLState = ({ timelineMode, selectedDate }) => {
+const syncRecentReleasesURLState = ({ timelineMode, selectedDate, selectedMonthKey }) => {
     if (typeof window === 'undefined') return;
     // Keep the URL in sync with the current calendar selection so reloading,
     // sharing, or opening in a new tab lands on the same Recent Releases state.
@@ -301,6 +304,11 @@ const syncRecentReleasesURLState = ({ timelineMode, selectedDate }) => {
         url.searchParams.set(RECENT_RELEASES_URL_PARAMS.DATE, selectedDate);
     } else {
         url.searchParams.delete(RECENT_RELEASES_URL_PARAMS.DATE);
+    }
+    if (selectedMonthKey) {
+        url.searchParams.set(RECENT_RELEASES_URL_PARAMS.MONTH, selectedMonthKey);
+    } else {
+        url.searchParams.delete(RECENT_RELEASES_URL_PARAMS.MONTH);
     }
     window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`);
 };
@@ -572,6 +580,7 @@ export const RecentReleasesTimelineMatrix = ({ session }) => {
     const [months, setMonths] = useState([]);
     const [selectedDay, setSelectedDay] = useState(null);
     const [selectedTimelineTarget, setSelectedTimelineTarget] = useState(null);
+    const [selectedMonthKey, setSelectedMonthKey] = useState(initialURLState.selectedMonthKey || null);
     const [monthWindowStartIndex, setMonthWindowStartIndex] = useState(0);
     const [timelineMode, setTimelineMode] = useState(initialURLState.timelineMode);
     const [detailViewMode, setDetailViewMode] = useState(DETAIL_VIEW_MODES.TABLE);
@@ -597,6 +606,7 @@ export const RecentReleasesTimelineMatrix = ({ session }) => {
                 setMonths(monthsWithGaps);
                 setSelectedDay(firstDay);
                 setSelectedTimelineTarget(firstDay);
+                setSelectedMonthKey(getMonthKeyFromDateString(firstDay?.key) || monthsWithGaps[0]?.value || null);
                 setMonthWindowStartIndex(0);
                 setIsLoading(false);
             },
@@ -609,6 +619,7 @@ export const RecentReleasesTimelineMatrix = ({ session }) => {
                 setMonths([]);
                 setSelectedDay(null);
                 setSelectedTimelineTarget(null);
+                setSelectedMonthKey(null);
                 setMonthWindowStartIndex(0);
                 setIsLoading(false);
             }
@@ -693,12 +704,18 @@ export const RecentReleasesTimelineMatrix = ({ session }) => {
         if (!months?.length) return;
         if (isApplyingURLStateRef.current && pendingURLTargetRef.current) {
             const requestedMonthKey = getMonthKeyFromDateString(pendingURLTargetRef.current);
-            const requestedTarget = buildRecentReleasesTargetFromDate(months, timelineMode, pendingURLTargetRef.current);
+            const requestedTarget = buildRecentReleasesTargetFromDate(
+                months,
+                timelineMode,
+                pendingURLTargetRef.current,
+                initialURLState.selectedMonthKey
+            );
 
             if (requestedTarget) {
                 setMonthWindowStartIndex(getMonthWindowStartIndexForTarget(months, monthWindowSize, requestedTarget.monthKey));
                 setSelectedDay(requestedTarget.selectedDay);
                 setSelectedTimelineTarget(requestedTarget.selectedTimelineTarget);
+                setSelectedMonthKey(requestedTarget.monthKey);
                 pendingURLTargetRef.current = null;
                 isApplyingURLStateRef.current = false;
                 return;
@@ -720,9 +737,14 @@ export const RecentReleasesTimelineMatrix = ({ session }) => {
         }
 
         if (pendingTimelineSelectionRef.current?.timelineMode === timelineMode) {
-            const { selectedDay: pendingSelectedDay = null, selectedTimelineTarget: pendingSelectedTimelineTarget = null } = pendingTimelineSelectionRef.current;
+            const {
+                selectedDay: pendingSelectedDay = null,
+                selectedTimelineTarget: pendingSelectedTimelineTarget = null,
+                selectedMonthKey: pendingSelectedMonthKey = null
+            } = pendingTimelineSelectionRef.current;
             setSelectedDay(pendingSelectedDay);
             setSelectedTimelineTarget(pendingSelectedTimelineTarget);
+            setSelectedMonthKey(pendingSelectedMonthKey);
             pendingTimelineSelectionRef.current = null;
             return;
         }
@@ -730,11 +752,13 @@ export const RecentReleasesTimelineMatrix = ({ session }) => {
         if (timelineMode === TIMELINE_MODES.DAILY) {
             if (selectedDay?.key) {
                 setSelectedTimelineTarget(selectedDay);
+                setSelectedMonthKey(getMonthKeyFromDateString(selectedDay.key));
                 return;
             }
             const firstDay = _.chain(months).pluck('days').flatten().find((day) => !!day).value() || null;
             setSelectedDay(firstDay);
             setSelectedTimelineTarget(firstDay);
+            setSelectedMonthKey(getMonthKeyFromDateString(firstDay?.key));
             return;
         }
         if (timelineMode === TIMELINE_MODES.WEEKLY) {
@@ -743,12 +767,15 @@ export const RecentReleasesTimelineMatrix = ({ session }) => {
                 .flatten()
                 .find((week) => (week?.count || 0) > 0)
                 .value() || null;
+            const firstWeekMonth = _.find(months, (month) => _.find(month.weeks || buildWeekBucketsForMonth(month), (week) => week?.key === firstWeek?.key)) || null;
             setSelectedDay(null);
             setSelectedTimelineTarget(firstWeek);
+            setSelectedMonthKey(firstWeekMonth?.value || getMonthKeyFromDateString(firstWeek?.from));
             return;
         }
         const firstMonth = _.find(months, (month) => (month?.count || 0) > 0) || null;
         setSelectedDay(null);
+        setSelectedMonthKey(firstMonth?.value || null);
         setSelectedTimelineTarget(firstMonth ? {
             key: `month-${firstMonth.value}`,
             fullLabel: firstMonth.label,
@@ -761,9 +788,10 @@ export const RecentReleasesTimelineMatrix = ({ session }) => {
         if (isLoading || isApplyingURLStateRef.current) return;
         syncRecentReleasesURLState({
             timelineMode,
-            selectedDate: getURLDateForSelectedTarget(timelineMode, selectedDay, selectedTimelineTarget)
+            selectedDate: getURLDateForSelectedTarget(timelineMode, selectedDay, selectedTimelineTarget),
+            selectedMonthKey
         });
-    }, [isLoading, timelineMode, selectedDay, selectedTimelineTarget]);
+    }, [isLoading, timelineMode, selectedDay, selectedTimelineTarget, selectedMonthKey]);
 
     if (isLoading) {
         return (
@@ -913,11 +941,13 @@ export const RecentReleasesTimelineMatrix = ({ session }) => {
                                                         pendingTimelineSelectionRef.current = {
                                                             timelineMode: TIMELINE_MODES.MONTHLY,
                                                             selectedDay: null,
+                                                            selectedMonthKey: month.value,
                                                             selectedTimelineTarget: nextMonthlyTarget
                                                         };
                                                         setTimelineMode(TIMELINE_MODES.MONTHLY);
                                                     } else {
                                                         setSelectedDay(null);
+                                                        setSelectedMonthKey(month.value);
                                                         setSelectedTimelineTarget(nextMonthlyTarget);
                                                     }
                                                 }}
@@ -958,10 +988,12 @@ export const RecentReleasesTimelineMatrix = ({ session }) => {
                                                         className={dayClasses}
                                                         onClick={cell.hasData ? () => {
                                                             setSelectedDay(cell.data);
+                                                            setSelectedMonthKey(month.value);
                                                             setSelectedTimelineTarget(cell.data);
                                                         } : undefined}
                                                         onFocus={cell.hasData ? () => {
                                                             setSelectedDay(cell.data);
+                                                            setSelectedMonthKey(month.value);
                                                             setSelectedTimelineTarget(cell.data);
                                                         } : undefined}
                                                         aria-pressed={isSelected}
@@ -988,6 +1020,7 @@ export const RecentReleasesTimelineMatrix = ({ session }) => {
                                                     className={`release-bucket-btn ${isSelected ? 'selected' : ''}`}
                                                     onClick={() => {
                                                         setSelectedDay(null);
+                                                        setSelectedMonthKey(month.value);
                                                         setSelectedTimelineTarget(week);
                                                     }}>
                                                     <span className="bucket-label">{week.label}</span>
@@ -1004,6 +1037,7 @@ export const RecentReleasesTimelineMatrix = ({ session }) => {
                                             className={`release-bucket-btn ${selectedTimelineTarget?.key === `month-${month.value}` ? 'selected' : ''}`}
                                             onClick={() => {
                                                 setSelectedDay(null);
+                                                setSelectedMonthKey(month.value);
                                                 setSelectedTimelineTarget({
                                                     key: `month-${month.value}`,
                                                     fullLabel: month.label,

--- a/src/encoded/static/components/static-pages/components/RecentReleasesTimelineMatrix.js
+++ b/src/encoded/static/components/static-pages/components/RecentReleasesTimelineMatrix.js
@@ -11,7 +11,7 @@ import { createBrowseFileColumnExtensionMap } from '../../browse/BrowseView';
 
 const WEEKDAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 const RECENT_MONTHS = 6;
-const OLDEST_NAVIGABLE_MONTH = '2025-01';
+const OLDEST_NAVIGABLE_MONTH = '2025-09';
 const TIMELINE_MODES = {
     DAILY: 'daily',
     WEEKLY: 'weekly',


### PR DESCRIPTION
## Summary

This PR contains follow-up fixes for the Recent Releases experience, focused on calendar coverage and more predictable navigation between the home page tracker and the dedicated Recent Releases page.

## Included changes

- Recover the missing Sep 2025 files - Include `exclude_from_release_tracker`-tagged files by default in `/recent_release_days`
- Change the oldest navigable month from **January 2025** to **September 2025**
- Add explicit `month` context to home page weekly links
- Preserve selected month context in Recent Releases URL state
- Keep month focus stable when switching between **Daily / Weekly / Monthly** timeline modes

## Why

These updates fix a few navigation edge cases that showed up during testing:

- some valid release items were missing from the calendar timeline
- the timeline could navigate farther back than intended
- cross-month weekly links could open with the wrong month focused
- switching timeline modes could jump to the first available data month instead of staying on the user’s current month
