### PR TITLE
Fix data matrix popover totals and donor counts in tissue/assay summaries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,18 @@ smaht-portal
 Change Log
 ----------
 
+
+2.1.0
+=====
+
+`PR 698: Fix data matrix popover totals and donor counts in tissue/assay summaries <https://github.com/smaht-dac/smaht-portal/pull/698>`_
+
+* added a shared helper to compute unique donor counts from grouped items
+* improved Tissue x Assay popover details:
+* updated column total aggregation so donor counts, file totals, and coverage totals are merged correctly across matching column entries
+* preserved grouped row metadata when overriding collapsed DSA file totals, so popovers still have the right contextual information
+
+
 2.0.0
 =====
 

--- a/docs/public/data_matrix_comparison.jsx
+++ b/docs/public/data_matrix_comparison.jsx
@@ -47,6 +47,7 @@
                 "showMatrixModeTabs": false,
                 "showColumnSummary": false,
                 "showFacetTermsPanel": true,
+                "dedupeBenchmarkingDsaAcrossTissues": true,
                 "idLabel": "benchmarking",
                 "baseBrowseFilesPath": "/search/"
             }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "2.0.0"
+version = "2.1.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/item-pages/ProtectedDonorView.js
+++ b/src/encoded/static/components/item-pages/ProtectedDonorView.js
@@ -240,6 +240,7 @@ const ProtectedDonorView = React.memo(function ProtectedDonorView(props) {
                                     session={session}
                                     yAxisLabel="Tissue" // Only one donor, so y-axis is Tissue
                                     showUniqueDonorsAssayBand={false}
+                                    dedupeBenchmarkingDsaAcrossTissues={study !== 'Production'}
                                     baseBrowseFilesPath={study === 'Production' ? "/browse/" : "/search/"}
                                 />
                             </div>

--- a/src/encoded/static/components/item-pages/PublicDonorView.js
+++ b/src/encoded/static/components/item-pages/PublicDonorView.js
@@ -328,6 +328,7 @@ const PublicDonorView = React.memo(function PublicDonorView(props) {
                                     session={session}
                                     yAxisLabel="Tissue" // Only one donor, so y-axis is Tissue
                                     showUniqueDonorsAssayBand={false}
+                                    dedupeBenchmarkingDsaAcrossTissues={study !== 'Production'}
                                     baseBrowseFilesPath={
                                         study === 'Production'
                                             ? '/browse/'

--- a/src/encoded/static/components/viz/Matrix/DataMatrix.js
+++ b/src/encoded/static/components/viz/Matrix/DataMatrix.js
@@ -914,6 +914,7 @@ export default class DataMatrix extends React.PureComponent {
             fieldChangeMap,
             groupingProperties,
             columnGrouping,
+            rowGroups,
             autoPopulateRowGroupsProperty,
             rowGroupsExtended,
             columnGroups,
@@ -1025,19 +1026,43 @@ export default class DataMatrix extends React.PureComponent {
             updatedState['overallCounts'] = result.counts || null;
             updatedState['facetsForPanel'] = result.facets || [];
             updatedState['facetFiltersForPanel'] = result.filters || [];
-            // Build generic row-summary overrides from backend facet counts.
-            // This keeps visual components dimension-agnostic (not donor-specific).
-            const donorFacet = _.findWhere(result.facets || [], { field: 'donors.display_title' });
-            const donorValueMap = valueChangeMap?.donor || {};
-            const donorSummaryCounts = donorFacet && Array.isArray(donorFacet.terms)
-                ? _.reduce(donorFacet.terms, (memo, term) => {
-                    const key = donorValueMap[term?.key] || term?.key;
-                    if (!key || key === 'No value') return memo;
-                    memo[key] = { files: Number(term?.doc_count) || 0 };
-                    return memo;
-                }, {})
-                : null;
-            updatedState['rowSummaryCountsByGroup'] = donorSummaryCounts ? { donor: donorSummaryCounts } : null;
+            // Build row-summary overrides from backend facet counts.
+            // Benchmarking uses two different row-group sections:
+            // - cell lines should summarize by dataset
+            // - benchmarking donors should summarize by donor
+            // Keep the summary map section-aware so those rows can diverge.
+            const buildFacetSummaryCounts = (facetField, valueMap = null) => {
+                const facet = _.findWhere(result.facets || [], { field: facetField });
+                return facet && Array.isArray(facet.terms)
+                    ? _.reduce(facet.terms, (memo, term) => {
+                        const key = valueMap?.[term?.key] || term?.key;
+                        if (!key || key === 'No value') return memo;
+                        memo[key] = { files: Number(term?.doc_count) || 0 };
+                        return memo;
+                    }, {})
+                    : null;
+            };
+            const donorSummaryCounts = buildFacetSummaryCounts('donors.display_title', valueChangeMap?.donor || {});
+            const datasetSummaryCounts = buildFacetSummaryCounts('dataset', valueChangeMap?.donor || {});
+            const hasRowGroups = rowGroups && _.keys(rowGroups).length > 0;
+            if (hasRowGroups) {
+                const rowGroupSummaryCounts = {};
+                _.forEach(rowGroups, (rowGroupConfig, rowGroupKey) => {
+                    const customUrlParams = rowGroupConfig?.customUrlParams || '';
+                    const usesDonorSummary = typeof customUrlParams === 'string' && customUrlParams.indexOf('dataset=tissue') >= 0;
+                    const summaryCounts = usesDonorSummary
+                        ? donorSummaryCounts
+                        : datasetSummaryCounts;
+                    if (summaryCounts) {
+                        rowGroupSummaryCounts[rowGroupKey] = usesDonorSummary
+                            ? { donor: summaryCounts }
+                            : { dataset: summaryCounts };
+                    }
+                });
+                updatedState['rowSummaryCountsByGroup'] = _.keys(rowGroupSummaryCounts).length > 0 ? rowGroupSummaryCounts : null;
+            } else {
+                updatedState['rowSummaryCountsByGroup'] = donorSummaryCounts ? { donor: donorSummaryCounts } : null;
+            }
             updatedState['rawRegularCountOverrides'] = DataMatrix.buildRawRegularCountOverrides(
                 rawProcessedAllRows,
                 groupingProperties,

--- a/src/encoded/static/components/viz/Matrix/DataMatrix.js
+++ b/src/encoded/static/components/viz/Matrix/DataMatrix.js
@@ -866,8 +866,14 @@ export default class DataMatrix extends React.PureComponent {
         return _.reduce(rows, (memo, row) => {
             const columnValue = row?.[columnGrouping];
             const files = Number(row?.counts?.files) || 0;
-            const dataType = String(row?.data_type || '');
-            const isDsaLikeRow = dataType === 'DSA' || dataType === 'Chain File' || dataType === 'Sequence Interval';
+            const dataTypes = _.chain([row?.data_type])
+                .flatten()
+                .compact()
+                .map((value) => String(value))
+                .value();
+            const isDsaLikeRow = _.some(dataTypes, (dataType) =>
+                dataType === 'DSA' || dataType === 'Chain File' || dataType === 'Sequence Interval'
+            );
             if (!columnValue || files <= 0) {
                 return memo;
             }
@@ -1075,7 +1081,7 @@ export default class DataMatrix extends React.PureComponent {
                 updatedState['rowSummaryCountsByGroup'] = donorSummaryCounts ? { donor: donorSummaryCounts } : null;
             }
             updatedState['rawRegularCountOverrides'] = DataMatrix.buildRawRegularCountOverrides(
-                rawProcessedAllRows,
+                dedupeBenchmarkingDsaAcrossTissues ? transformedData.all : rawProcessedAllRows,
                 groupingProperties,
                 columnGrouping,
                 { dedupeBenchmarkingDsaAcrossTissues }
@@ -1749,6 +1755,7 @@ export default class DataMatrix extends React.PureComponent {
             baseBrowseFilesPath, browseFilteringTransformFuncKey, showCountFor, showMatrixModeTabs,
             showFacetTermsPanel, facetTermsPanelFields, donorTissueShrinkEmptyColumns,
             headerPadding, showUniqueDonorsAssayBand, schemas,
+            dedupeBenchmarkingDsaAcrossTissues = false,
             titleMap, statePrioritizationForGroups, fallbackNameForBlankField
         } = this.props;
         const {
@@ -1822,6 +1829,7 @@ export default class DataMatrix extends React.PureComponent {
             // Use mode-appropriate summary overrides: donor/tissue mode may null these out
             // under assay filter to avoid inconsistencies with facet-driven contexts.
             rowSummaryCountsByGroup: effectiveRowSummaryCountsByGroup,
+            dedupeBenchmarkingDsaAcrossTissues,
             // Donor x Assay and Tissue x Assay both benefit from raw per-row
             // file overrides to keep summary columns aligned with visible cells.
             // Donor x Tissue derives its own filtered donor/tissue aggregates

--- a/src/encoded/static/components/viz/Matrix/DataMatrix.js
+++ b/src/encoded/static/components/viz/Matrix/DataMatrix.js
@@ -1008,7 +1008,7 @@ export default class DataMatrix extends React.PureComponent {
                 transformed.push(cloned);
             };
 
-            // result = resultItemPostProcessFuncKey && this.isLocalEnv() ? BENCHMARKING_TEST_DATA : (matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE ? PRODUCTION_TEST_DATA_DT : PRODUCTION_TEST_DATA_DA);
+            // result = resultItemPostProcessFuncKey ? BENCHMARKING_TEST_DATA : (matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE ? PRODUCTION_TEST_DATA_DT : (matrixMode === DataMatrix.MATRIX_MODES.DONOR_ASSAY ? PRODUCTION_TEST_DATA_DA : PRODUCTION_TEST_DATA_TA));
 
             _.forEach(result.data, (r) => processResultRow(r, transformedData.all));
             _.forEach(result.row_totals, (r) => processResultRow(r, transformedData.row_totals));
@@ -1810,10 +1810,11 @@ export default class DataMatrix extends React.PureComponent {
             // Use mode-appropriate summary overrides: donor/tissue mode may null these out
             // under assay filter to avoid inconsistencies with facet-driven contexts.
             rowSummaryCountsByGroup: effectiveRowSummaryCountsByGroup,
-            // Raw regular-cell overrides are only intended for Donor x Assay.
-            // Donor x Tissue derives its own filtered donor/tissue aggregates and
-            // should not reuse assay-oriented raw override maps.
-            rawRegularCountOverrides: matrixMode === DataMatrix.MATRIX_MODES.DONOR_ASSAY
+            // Donor x Assay and Tissue x Assay both benefit from raw per-row
+            // file overrides to keep summary columns aligned with visible cells.
+            // Donor x Tissue derives its own filtered donor/tissue aggregates
+            // and should not reuse assay-oriented raw override maps.
+            rawRegularCountOverrides: matrixMode !== DataMatrix.MATRIX_MODES.DONOR_TISSUE
                 ? (this.state.rawRegularCountOverrides || null)
                 : null,
             ...(countFor === 'total_coverage' && matrixMode === DataMatrix.MATRIX_MODES.TISSUE_ASSAY

--- a/src/encoded/static/components/viz/Matrix/DataMatrix.js
+++ b/src/encoded/static/components/viz/Matrix/DataMatrix.js
@@ -308,6 +308,7 @@ export default class DataMatrix extends React.PureComponent {
         "showCountFor": false,
         "showMatrixModeTabs": true,
         "showUniqueDonorsAssayBand": true,
+        "dedupeBenchmarkingDsaAcrossTissues": false,
         "showFacetTermsPanel": false,
         "facetTermsPanelFields": null,
         "excludePrimaryColumnNoValue": true,
@@ -373,6 +374,7 @@ export default class DataMatrix extends React.PureComponent {
         'showCountFor': PropTypes.bool,
         'showMatrixModeTabs': PropTypes.bool,
         'showUniqueDonorsAssayBand': PropTypes.bool,
+        'dedupeBenchmarkingDsaAcrossTissues': PropTypes.bool,
         'showFacetTermsPanel': PropTypes.bool,
         'facetTermsPanelFields': PropTypes.arrayOf(PropTypes.string),
         'excludePrimaryColumnNoValue': PropTypes.bool,
@@ -856,7 +858,7 @@ export default class DataMatrix extends React.PureComponent {
         return typeof assayValue === 'string' ? assayValue : null;
     }
 
-    static buildRawRegularCountOverrides(rows = [], groupingProperties = [], columnGrouping = null) {
+    static buildRawRegularCountOverrides(rows = [], groupingProperties = [], columnGrouping = null, { dedupeBenchmarkingDsaAcrossTissues = false } = {}) {
         if (!Array.isArray(rows) || rows.length === 0 || !Array.isArray(groupingProperties) || !columnGrouping) {
             return {};
         }
@@ -891,7 +893,15 @@ export default class DataMatrix extends React.PureComponent {
                 if (!memo[depth][pathKey]) {
                     memo[depth][pathKey] = {};
                 }
-                memo[depth][pathKey][String(columnValue)] = (memo[depth][pathKey][String(columnValue)] || 0) + files;
+                const currentValue = memo[depth][pathKey][String(columnValue)] || 0;
+                // Benchmarking DSA-like files can be linked to multiple tissues for the
+                // same donor. Keep the donor-level override de-duplicated by taking the
+                // largest per-child bucket instead of summing repeated references.
+                if (dedupeBenchmarkingDsaAcrossTissues && isDsaLikeRow && depth === 0) {
+                    memo[depth][pathKey][String(columnValue)] = Math.max(currentValue, files);
+                } else {
+                    memo[depth][pathKey][String(columnValue)] = currentValue + files;
+                }
             }
 
             return memo;
@@ -907,7 +917,8 @@ export default class DataMatrix extends React.PureComponent {
             onDataLoaded,
             debugLoadingDelayMs = 0,
             autoPopulateRowGroupsExtendedMapFields,
-            autoPopulateColumnGroupsMapFields
+            autoPopulateColumnGroupsMapFields,
+            dedupeBenchmarkingDsaAcrossTissues = false
         } = this.props;
         const {
             query: { url: requestUrl, columnAggFields: propColumnAggFields, rowAggFields: propRowAggFields },
@@ -1066,7 +1077,8 @@ export default class DataMatrix extends React.PureComponent {
             updatedState['rawRegularCountOverrides'] = DataMatrix.buildRawRegularCountOverrides(
                 rawProcessedAllRows,
                 groupingProperties,
-                columnGrouping
+                columnGrouping,
+                { dedupeBenchmarkingDsaAcrossTissues }
             );
             const availableDonorTissueAssays = _.uniq(_.compact(_.map(transformedData.all, (r) => r.assay)));
             updatedState['availableDonorTissueAssays'] = availableDonorTissueAssays;

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -1715,7 +1715,7 @@ export class StackedBlockVisual extends React.PureComponent {
                     {StackedBlockGroupedRow.columnsAndHeader(columnsAndHeaderProps)}
                     {
                         _.map(leftAxisKeys, (k, idx) =>
-                            <StackedBlockGroupedRow 
+                            <StackedBlockGroupedRow
                                 {...sharedRowProps}
                                 data={nestedData[k]}
                                 rowTotals={nestedRowTotals[k]}
@@ -1959,8 +1959,17 @@ export class StackedBlockGroupedRow extends React.PureComponent {
 
     // Returns the override field (e.g. donor, tissue) that is both configured in
     // rowSummaryCountsByGroup and present on the provided rows.
-    static resolveOverrideFieldForRows(rows, props) {
+    static getRowSummaryOverridesForContext(props) {
         const overridesByField = props.rowSummaryCountsByGroup;
+        if (!overridesByField || typeof overridesByField !== 'object') return null;
+        if (props.rowGroupKey && overridesByField[props.rowGroupKey] && typeof overridesByField[props.rowGroupKey] === 'object') {
+            return overridesByField[props.rowGroupKey];
+        }
+        return overridesByField;
+    }
+
+    static resolveOverrideFieldForRows(rows, props) {
+        const overridesByField = StackedBlockGroupedRow.getRowSummaryOverridesForContext(props);
         if (!overridesByField || typeof overridesByField !== 'object') return null;
         return _.find(_.keys(overridesByField), (field) => _.some(rows || [], (row) => row && row[field] != null));
     }
@@ -1970,7 +1979,7 @@ export class StackedBlockGroupedRow extends React.PureComponent {
     static getOverallFilesFromRowSummaryOverrides(rows, props) {
         const overrideField = StackedBlockGroupedRow.resolveOverrideFieldForRows(rows, props);
         if (!overrideField) return null;
-        const overridesForField = props.rowSummaryCountsByGroup?.[overrideField];
+        const overridesForField = StackedBlockGroupedRow.getRowSummaryOverridesForContext(props)?.[overrideField];
         if (!overridesForField) return null;
         const groupValues = _.chain(rows || [])
             .map((row) => row?.[overrideField])
@@ -1998,7 +2007,7 @@ export class StackedBlockGroupedRow extends React.PureComponent {
         if (!Array.isArray(rows) || rows.length === 0) return null;
         const overrideField = StackedBlockGroupedRow.resolveOverrideFieldForRows(rows, props);
         if (!overrideField) return null;
-        const overridesForField = props.rowSummaryCountsByGroup?.[overrideField];
+        const overridesForField = StackedBlockGroupedRow.getRowSummaryOverridesForContext(props)?.[overrideField];
         if (!overridesForField) return null;
         const columnField = props.columnGrouping;
         let foundGroup = false;
@@ -2277,8 +2286,8 @@ export class StackedBlockGroupedRow extends React.PureComponent {
 
     /**
      * renders the column headers and axis labels
-     * @param {*} props 
-     * @returns 
+     * @param {*} props
+     * @returns
      */
     static columnsAndHeader(props) {
         const {
@@ -2521,17 +2530,49 @@ export class StackedBlockGroupedRow extends React.PureComponent {
         };
         const groupingBandLabel = secondarySummaryBandLabelByMetric[props.countFor] || `Total ${label}`;
 
+        const parseCustomUrlParams = (customUrlParams) => {
+            if (!customUrlParams || typeof customUrlParams !== 'string') return {};
+            try {
+                return queryString.parse(customUrlParams);
+            } catch (e) {
+                return {};
+            }
+        };
+
+        const rowMatchesCustomUrlParams = (row, customUrlParams) => {
+            const parsedParams = parseCustomUrlParams(customUrlParams);
+            const paramKeys = Object.keys(parsedParams);
+            if (paramKeys.length === 0) return true;
+
+            return paramKeys.every((key) => {
+                const isNegative = key.endsWith('!');
+                const fieldName = isNegative ? key.slice(0, -1) : key;
+                const expectedValues = Array.isArray(parsedParams[key]) ? parsedParams[key] : [parsedParams[key]];
+                const rowValue = row?.[fieldName];
+                const rowValues = Array.isArray(rowValue)
+                    ? rowValue.map((value) => String(value))
+                    : [String(rowValue)];
+
+                if (isNegative) {
+                    return rowValues.every((value) => !expectedValues.map(String).includes(value));
+                }
+
+                return rowValues.some((value) => expectedValues.map(String).includes(value));
+            });
+        };
+
+        const currentRowGroupCustomUrlParams = props.rowGroups?.[props.rowGroupKey]?.customUrlParams || null;
+
         const getColumnSummaryData = (columnKey) => {
-            const result = [];
             const values = props.groupedDataIndices[columnKey] || [];
-            values.forEach((val) => result.push(val));
-            return result;
+            return values.filter((row) => rowMatchesCustomUrlParams(row, currentRowGroupCustomUrlParams));
         };
 
         const getAllSectionRows = () => {
             const rowsById = {};
             Object.keys(props.groupedDataIndices || {}).forEach((ck) => {
                 (props.groupedDataIndices[ck] || []).forEach((row, idx) => {
+                    if (!rowMatchesCustomUrlParams(row, currentRowGroupCustomUrlParams)) return;
                     const rowKey = row && typeof row.index !== 'undefined' ? `idx-${row.index}` : `fallback-${ck}-${idx}`;
                     rowsById[rowKey] = row;
                 });
@@ -2540,7 +2581,7 @@ export class StackedBlockGroupedRow extends React.PureComponent {
         };
 
         const getPrimaryGroupCountFromGroupedRows = (columnKey) => {
-            const rows = props.groupedDataIndices[columnKey] || [];
+            const rows = getColumnSummaryData(columnKey);
             const primaryGroupField = Array.isArray(props.groupingProperties) ? props.groupingProperties[0] : 'donor';
             const primaryGroupSet = new Set();
             rows.forEach((row) => {
@@ -2555,7 +2596,7 @@ export class StackedBlockGroupedRow extends React.PureComponent {
         };
 
         const getDonorCountFromGroupedRows = (columnKey) => {
-            const rows = props.groupedDataIndices[columnKey] || [];
+            const rows = getColumnSummaryData(columnKey);
             const donorSet = new Set();
             let maxRowDonorCount = 0;
 
@@ -2580,6 +2621,7 @@ export class StackedBlockGroupedRow extends React.PureComponent {
             const primaryGroupSet = new Set();
             Object.keys(props.groupedDataIndices || {}).forEach((ck) => {
                 (props.groupedDataIndices[ck] || []).forEach((row) => {
+                    if (!rowMatchesCustomUrlParams(row, currentRowGroupCustomUrlParams)) return;
                     const primaryGroupValue = row && row[primaryGroupField];
                     if (Array.isArray(primaryGroupValue)) {
                         primaryGroupValue.forEach((d) => { if (d != null) primaryGroupSet.add(String(d)); });
@@ -2620,14 +2662,16 @@ export class StackedBlockGroupedRow extends React.PureComponent {
             <div className="blocks-container d-flex header-summary">
                 {columnKeys.map(function (columnKey, colIndex) {
                     const isPrimarySummaryBand = summaryBlockType === 'col-secondary-summary';
-                    const totalsCounts = StackedBlockGroupedRow.getColumnTotalsEntry(columnKey, props)?.counts;
-                    const rawColumnTotalEntry = StackedBlockGroupedRow.getColumnTotalsEntry(columnKey, props);
+                    const sectionColumnRows = getColumnSummaryData(columnKey);
                     const sectionRows = getAllSectionRows();
                     const derivedCoverageTotal = summaryCountFor === 'total_coverage'
-                        ? _.reduce(props.groupedDataIndices[columnKey] || [], function(sum, item) {
+                        ? _.reduce(sectionColumnRows, function(sum, item) {
                             return sum + getCountValueFromItem(item, 'total_coverage');
                         }, 0)
                         : null;
+                    const sectionFilesTotal = _.reduce(sectionColumnRows, function(sum, item) {
+                        return sum + getCountValueFromItem(item, 'files');
+                    }, 0);
                     // Apply derived fallback only for DSA column summary files.
                     // Other columns continue using backend/standard summary paths.
                     const shouldDeriveDsaFiles = summaryCountFor === 'files'
@@ -2638,20 +2682,24 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                         ? StackedBlockGroupedRow.getDerivedColumnFilesFromRowSummary(sectionRows, columnKey, props)
                         : null;
                     const groupedRowsDonorCount = getDonorCountFromGroupedRows(columnKey);
-                    const shouldPreferGroupedRowDonorCount = summaryCountFor === 'donors'
-                        && Array.isArray(props.groupingProperties)
-                        && props.groupingProperties[0] !== 'donor';
                     const donorsCount = isPrimarySummaryBand
                         ? getPrimaryGroupCountFromGroupedRows(columnKey)
-                        : (shouldPreferGroupedRowDonorCount
-                            ? (groupedRowsDonorCount
-                                ?? totalsCounts?.donors
-                                ?? totalsCounts?.donor_count
-                                ?? getPrimaryGroupCountFromGroupedRows(columnKey))
-                            : (totalsCounts?.donors
-                                ?? totalsCounts?.donor_count
-                                ?? groupedRowsDonorCount
-                                ?? getPrimaryGroupCountFromGroupedRows(columnKey)));
+                        : (groupedRowsDonorCount || getPrimaryGroupCountFromGroupedRows(columnKey));
+                    const totalsCounts = {
+                        files: sectionFilesTotal,
+                        total_coverage: derivedCoverageTotal ?? 0,
+                        donors: donorsCount,
+                        donor_count: donorsCount
+                    };
+                    const rawColumnTotalEntry = sectionColumnRows.length > 0
+                        ? {
+                            ...sectionColumnRows[0],
+                            counts: {
+                                ...(sectionColumnRows[0]?.counts || {}),
+                                ...totalsCounts
+                            }
+                        }
+                        : null;
                     const summaryCounts = {
                         ...(totalsCounts || {}),
                         donors: donorsCount,
@@ -2669,8 +2717,8 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                                 ? rawColumnTotalEntry
                                 : (typeof derivedDsaFiles === 'number'
                                     ? [{ counts: { files: derivedDsaFiles } }]
-                                    : getColumnSummaryData(columnKey)));
-                    const columnTotal = props.groupedDataIndices[columnKey]?.length || 0;
+                                    : sectionColumnRows));
+                    const columnTotal = sectionColumnRows.length || 0;
                     const hasOpenBlock = props.openBlock?.columnIdx === colIndex && props.openBlock?.summaryRowType === summaryBlockType;
                     const hasActiveBlock = props.activeBlock?.columnIdx === colIndex && props.activeBlock?.summaryRowType === summaryBlockType;
                     const className = 'column-group-header' + (hasOpenBlock ? ' open-block-column' : '') + (hasActiveBlock ? ' active-block-column' : '');

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -761,6 +761,10 @@ export class VisualBody extends React.PureComponent {
             minimumFractionDigits: 0,
             maximumFractionDigits: 2
         })}X` : '--';
+        const regularCoverageDisplay = roundedTotalCoverage > 0 ? `${formatLocalizedNumber(roundedTotalCoverage, {
+            minimumFractionDigits: 0,
+            maximumFractionDigits: 2
+        })}X` : '--';
         const formattedFileCount = typeof effectiveFileCount === 'number' ? formatLocalizedNumber(effectiveFileCount) : effectiveFileCount;
         const formatGermLayerValue = (value) => (value && value !== 'No value' ? value : '--');
 
@@ -824,7 +828,7 @@ export class VisualBody extends React.PureComponent {
                                     </div>
                                     <div className="col-4">
                                         <div className="label">Total Coverage</div>
-                                        <div className="value">{roundedTotalCoverage > 0 ? roundedTotalCoverage + 'X' : '--'}</div>
+                                        <div className="value">{regularCoverageDisplay}</div>
                                     </div>
                                     <div className="col-4">
                                         <div className="label">Total Files</div>

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -748,6 +748,7 @@ export class VisualBody extends React.PureComponent {
                 : totalCoverage);
         const donorCount = getUniqueDonorCountFromItems(dataForCounts);
         const isTissueColumnGrouping = (fieldChangeMap?.[columnGrouping] || columnGrouping) === 'sample_summary.tissues';
+        const assayCount = getUniqueValueCountFromItems(dataForCounts, 'assay');
         const tissueCount = isTissueColumnGrouping
             ? getUniqueValueCountFromItems(effectiveBlockType === 'row-summary' ? rowSummaryItems : dataForCounts, columnGrouping)
             : 0;
@@ -776,12 +777,17 @@ export class VisualBody extends React.PureComponent {
                                         <div className="value">{primaryGrpPropValue || '--'}</div>
                                     </div>
                                     <div className="col-4">
-                                        {depth > 0 || additionalPopoverData?.[primaryGrpPropValue]?.["secondary"] ? (
+                                        {isTissueGrouping || isTissueColumnGrouping ? (
+                                            <React.Fragment>
+                                                <div className="label">{yAxisGroupingTitle}</div>
+                                                <div className="value">{yAxisGroupingValue || '--'}</div>
+                                            </React.Fragment>
+                                        ) : (depth > 0 || additionalPopoverData?.[primaryGrpPropValue]?.["secondary"] ? (
                                             <React.Fragment>
                                                 <div className="label">{secondaryGrpPropTitle}</div>
                                                 <div className="value">{additionalPopoverData?.[primaryGrpPropValue]?.["secondary"] || secondaryGrpPropValue}</div>
                                             </React.Fragment>
-                                        ) : null}
+                                        ) : null)}
                                     </div>
                                     <div className="col-4">
                                         <div className="label me-05">{'Germ Layer'}</div>
@@ -813,8 +819,8 @@ export class VisualBody extends React.PureComponent {
                             {effectiveBlockType === 'regular' ? (
                                 <div className="row secondary-row pb-1 mt-1">
                                     <div className="col-4">
-                                        <div className="label me-05">{yAxisGroupingTitle}</div>
-                                        <div className="value">{yAxisGroupingValue || '--'}</div>
+                                        <div className="label me-05">{isTissueGrouping ? 'Total Donors' : (isTissueColumnGrouping ? 'Total Assays' : yAxisGroupingTitle)}</div>
+                                        <div className="value">{isTissueGrouping ? (donorCount || '--') : (isTissueColumnGrouping ? (assayCount || '--') : (yAxisGroupingValue || '--'))}</div>
                                     </div>
                                     <div className="col-4">
                                         <div className="label">Total Coverage</div>
@@ -830,7 +836,15 @@ export class VisualBody extends React.PureComponent {
                                 <React.Fragment>
                                     <div className="row secondary-row pb-1 mt-1">
                                         <div className="col-4">
-                                            <div className="label me-05">{StackedBlockVisual.pluralize(primaryGrpPropTitle)}</div>
+                                            <div className="label me-05">
+                                                {
+                                                    primaryGrpProp === 'donor'
+                                                        ? 'Total Donors'
+                                                        : (primaryGrpProp === 'tissue'
+                                                            ? 'Total Tissues'
+                                                            : StackedBlockVisual.pluralize(primaryGrpPropTitle))
+                                                }
+                                            </div>
                                             <div className="value">{primaryGrpPropUniqueCount || '--'}</div>
                                         </div>
                                         <div className="col-4">

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -296,7 +296,9 @@ export class VisualBody extends React.PureComponent {
         const countFor = blockProps && blockProps.countFor ? blockProps.countFor : 'files';
         const blockType = blockProps && blockProps.blockType ? blockProps.blockType : 'regular';
         const countField = countFor === 'tissue_files' ? 'files' : countFor;
-        const blockSum = Array.isArray(data)
+        const blockSum = typeof blockProps?.computedBlockValue === 'number'
+            ? blockProps.computedBlockValue
+            : (Array.isArray(data)
             ? (countField === 'donors'
                 ? (() => {
                     const uniqueDonorCount = getUniqueDonorCountFromItems(data);
@@ -306,7 +308,7 @@ export class VisualBody extends React.PureComponent {
                     }, 0);
                 })()
                 : _.reduce(data, function (sum, item) { return sum + getCountValueFromItem(item, countField); }, 0))
-            : (data ? getCountValueFromItem(data, countField) : 0);
+            : (data ? getCountValueFromItem(data, countField) : 0));
 
         // For total_coverage, we want to display the value with "X" and
         // use a different formatting logic. For other count types, we display the raw count with standard formatting.
@@ -2176,11 +2178,12 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                 const rowSummaryFiles = (props.countFor === 'files' || props.countFor === 'tissue_files')
                     ? props.rowSummaryCountsByGroup?.[currentGroupingField]?.[props.group]?.files
                     : null;
+                const shouldUseBenchmarkingDsaCollapsedSummaryOverride = !!props.dedupeBenchmarkingDsaAcrossTissues && columnKeys.indexOf('DSA') > -1;
+                const sumFilesForColumn = (columnKey) => _.reduce(blocksByColumnGroup[columnKey] || [], (sum, row) => sum + (Number(row?.counts?.files) || 0), 0);
                 const derivedCollapsedCellOverrides = {};
-                if (typeof rowSummaryFiles === 'number' && columnKeys.indexOf('DSA') > -1) {
+                if (shouldUseBenchmarkingDsaCollapsedSummaryOverride && typeof rowSummaryFiles === 'number') {
                     // For collapsed rows, derive DSA as:
                     // row summary files - sum(non-DSA column files).
-                    const sumFilesForColumn = (columnKey) => _.reduce(blocksByColumnGroup[columnKey] || [], (sum, row) => sum + (Number(row?.counts?.files) || 0), 0);
                     const sumNonDsaFiles = _.reduce(columnKeys, (sum, columnKey) => {
                         if (columnKey === 'DSA') return sum;
                         return sum + sumFilesForColumn(columnKey);
@@ -2236,6 +2239,17 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                         </div>
                     );
                 });
+                const effectiveCollapsedRowSummaryFiles = shouldUseBenchmarkingDsaCollapsedSummaryOverride && (props.countFor === 'files' || props.countFor === 'tissue_files')
+                    ? _.reduce(columnKeys, (sum, columnKey) => {
+                        const rawOverrideFiles = StackedBlockGroupedRow.getRawRegularOverrideForColumn(columnKey, props);
+                        const explicitOverrideFiles = typeof rawOverrideFiles === 'number'
+                            ? rawOverrideFiles
+                            : derivedCollapsedCellOverrides[columnKey];
+                        return sum + (typeof explicitOverrideFiles === 'number'
+                            ? explicitOverrideFiles
+                            : sumFilesForColumn(columnKey));
+                    }, 0)
+                    : null;
                 // add summary column block
                 let rowSummaryBlock = null;
                 const totalRowCount = _.reduce(_.map(blocksByColumnGroup, function(b){ return b.length; }), function(m, n){ return m + n; }, 0);
@@ -2256,9 +2270,12 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                             counts: { ...(filteredRowTotalChildBlocks[0]?.counts || {}), ...overrideCounts }
                         }]
                         : filteredRowTotalChildBlocks;
-                    const summaryCounts = (typeof overrideFiles === 'number')
+                    const summaryCountsBase = (typeof overrideFiles === 'number')
                         ? { ...(filteredRowTotalChildBlocks[0]?.counts || {}), ...overrideCounts }
                         : (filteredRowTotalChildBlocks[0]?.counts || null);
+                    const summaryCounts = typeof effectiveCollapsedRowSummaryFiles === 'number'
+                        ? { ...(summaryCountsBase || {}), files: effectiveCollapsedRowSummaryFiles }
+                        : summaryCountsBase;
                     rowSummaryBlock = (
                         <div className="block-container-group" style={getContainerGroupStyle('overall-summary')}
                             key={'total'} data-block-count={totalRowCount} data-group-key={'row-summary'}>
@@ -2269,6 +2286,7 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                                 rowTotals={rowTotalsForBlock}
                                 rowIndex={props.index}
                                 blockType="row-summary"
+                                computedBlockValue={effectiveCollapsedRowSummaryFiles}
                                 summaryCounts={summaryCounts}
                             />
                         </div>
@@ -3069,7 +3087,10 @@ const Block = React.memo(function Block(props){
     // use the exact rendered count instead of re-deriving from grouped rows.
     let popover = null;
     if (typeof blockPopover === 'function'){
-        popover = blockPopover.apply(blockPopover, [argData, { ...props, computedBlockValue: blockValue }, parentGrouping]);
+        popover = blockPopover.apply(blockPopover, [argData, {
+            ...props,
+            computedBlockValue: typeof props?.computedBlockValue === 'number' ? props.computedBlockValue : blockValue
+        }, parentGrouping]);
     }
 
     if (hideCoverageBlock) {

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -2710,6 +2710,7 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                     const shouldDeriveDsaFiles = summaryCountFor === 'files'
                         && summaryBlockType === 'col-summary'
                         && columnKey === 'DSA'
+                        && (!props.dedupeBenchmarkingDsaAcrossTissues || typeof rawOverrideSectionFilesTotal !== 'number')
                         && !!props.rowSummaryCountsByGroup;
                     const derivedDsaFiles = shouldDeriveDsaFiles
                         ? StackedBlockGroupedRow.getDerivedColumnFilesFromRowSummary(sectionRows, columnKey, props)

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -508,8 +508,19 @@ export class VisualBody extends React.PureComponent {
         // Title area values
         const yAxisGroupingTitle = (columnGrouping && titleMap[columnGrouping]) || columnGrouping || null;
         const yAxisGroupingValue = aggrData[columnGrouping] || (isGroup ? data[0][columnGrouping] : data[columnGrouping]) || columnKey;
+        const groupedItems = Array.isArray(data) ? data : (data ? [data] : []);
+        const groupedGermLayers = _.chain(groupedItems)
+            .map((item) => item?.germLayer)
+            .flatten()
+            .compact()
+            .filter((value) => value !== 'No value')
+            .map((value) => String(value))
+            .uniq()
+            .value();
         // e.g. Germ Layer (Ectoderm, Mesoderm, Endoderm ...etc) if available
-        let secondaryGrpPropCategoryValue = aggrData.germLayer || null;
+        let secondaryGrpPropCategoryValue = groupedGermLayers.length > 1
+            ? 'Multiple'
+            : (groupedGermLayers[0] || aggrData.germLayer || null);
         if (!secondaryGrpPropCategoryValue && rowGroupsExtended) {
             const rowGroupSourceValues = _.uniq(_.compact([secondaryGrpPropValue, primaryGrpPropValue, yAxisGroupingValue]));
             for (const rowGroupSourceValue of rowGroupSourceValues) {
@@ -2133,13 +2144,17 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                                     : null;
                                 const explicitOverrideFiles = typeof rawOverrideFiles === 'number' ? rawOverrideFiles : derivedCollapsedCellOverrides[k];
                                 const blockDataForRender = typeof explicitOverrideFiles === 'number'
-                                    ? [{
-                                        ...(blockData[0] || {}),
+                                    ? (blockData || []).map((item, itemIdx) => ({
+                                        ...item,
                                         counts: {
-                                            ...(blockData[0]?.counts || {}),
-                                            files: explicitOverrideFiles
+                                            ...(item?.counts || {}),
+                                            // Preserve the full grouped row set for popover metadata
+                                            // (e.g. multiple germ layers), while still rendering the
+                                            // overridden collapsed total by assigning it to the first
+                                            // row and zeroing the rest.
+                                            files: itemIdx === 0 ? explicitOverrideFiles : 0
                                         }
-                                    }]
+                                    }))
                                     : blockData;
                                 return <Block key={i} {...commonProps} {...{ parentGrouping, subGrouping }} data={blockDataForRender} indexInGroup={i} rowIndex={props.index} colIndex={colIdx} blockType="regular" />;
                             }) }

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -2046,6 +2046,33 @@ export class StackedBlockGroupedRow extends React.PureComponent {
         return typeof overrideValue === 'number' ? overrideValue : null;
     }
 
+    static getRawRegularOverrideTotalForColumn(rows, columnKey, props) {
+        const primaryGroupingField = Array.isArray(props.groupingProperties) ? props.groupingProperties[0] : null;
+        if (!primaryGroupingField || !props.rawRegularCountOverrides || columnKey == null) return null;
+
+        const primaryGroups = _.chain(rows || [])
+            .map((row) => row?.[primaryGroupingField])
+            .flatten()
+            .compact()
+            .map((value) => String(value))
+            .uniq()
+            .value();
+
+        if (primaryGroups.length === 0) return null;
+
+        let foundOverride = false;
+        const total = _.reduce(primaryGroups, (memo, groupValue) => {
+            const overrideValue = props.rawRegularCountOverrides?.[0]?.[groupValue]?.[String(columnKey)];
+            if (typeof overrideValue === 'number') {
+                foundOverride = true;
+                return memo + overrideValue;
+            }
+            return memo;
+        }, 0);
+
+        return foundOverride ? total : null;
+    }
+
     /** @todo Convert to functional memoized React component */
     static collapsedChildBlocks = memoize(function(data, rowTotals, props){
 
@@ -2669,9 +2696,15 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                             return sum + getCountValueFromItem(item, 'total_coverage');
                         }, 0)
                         : null;
-                    const sectionFilesTotal = _.reduce(sectionColumnRows, function(sum, item) {
+                    const summedSectionFilesTotal = _.reduce(sectionColumnRows, function(sum, item) {
                         return sum + getCountValueFromItem(item, 'files');
                     }, 0);
+                    const rawOverrideSectionFilesTotal = (summaryCountFor === 'files' || summaryCountFor === 'tissue_files')
+                        ? StackedBlockGroupedRow.getRawRegularOverrideTotalForColumn(sectionRows, columnKey, props)
+                        : null;
+                    const sectionFilesTotal = typeof rawOverrideSectionFilesTotal === 'number'
+                        ? rawOverrideSectionFilesTotal
+                        : summedSectionFilesTotal;
                     // Apply derived fallback only for DSA column summary files.
                     // Other columns continue using backend/standard summary paths.
                     const shouldDeriveDsaFiles = summaryCountFor === 'files'

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -732,15 +732,20 @@ export class VisualBody extends React.PureComponent {
                 totalCoverage: sum.totalCoverage + getTotalCoverageFromItem(item)
             };
         }, { fileCount: 0, totalCoverage: 0 });
+        const rowSummaryFilesFromItems = _.reduce(rowSummaryItems, function(sum, item) {
+            return sum + getFilesCountFromItem(item);
+        }, 0);
         const shouldUseComputedSummaryValue = (
             (effectiveBlockType === 'col-summary' || effectiveBlockType === 'row-summary') &&
             typeof computedBlockValue === 'number'
         );
         const effectiveFileCount = ((countFor === 'files' || countFor === 'tissue_files') && shouldUseComputedSummaryValue)
             ? computedBlockValue
-            : (typeof summaryCounts?.files === 'number'
-                ? summaryCounts.files
-                : fileCount);
+            : (effectiveBlockType === 'row-summary' && countFor === 'donors' && rowSummaryFilesFromItems > 0)
+                ? rowSummaryFilesFromItems
+                : (typeof summaryCounts?.files === 'number'
+                    ? summaryCounts.files
+                    : fileCount);
         const effectiveTotalCoverage = (countFor === 'total_coverage' && shouldUseComputedSummaryValue)
             ? computedBlockValue
             : (typeof summaryCounts?.total_coverage === 'number'

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -39,6 +39,44 @@ function getCountValueFromItem(item, countField) {
     return 0;
 }
 
+function getUniqueDonorCountFromItems(items) {
+    if (!Array.isArray(items)) return null;
+    const donorSet = new Set();
+    const donorCountCandidates = [];
+
+    const addDonorValue = (value) => {
+        if (Array.isArray(value)) {
+            value.forEach(addDonorValue);
+            return;
+        }
+        if (value == null) return;
+        if (typeof value === 'object') {
+            addDonorValue(value.display_title ?? value.accession ?? value.title ?? value.uuid);
+            return;
+        }
+        donorSet.add(String(value));
+    };
+
+    const addDonorCountCandidate = (value) => {
+        const numericValue = Number(value);
+        if (Number.isFinite(numericValue)) {
+            donorCountCandidates.push(numericValue);
+        }
+    };
+
+    items.forEach((item) => {
+        if (!item) return;
+        addDonorValue(item.donor);
+        addDonorValue(item.donors);
+        addDonorCountCandidate(item?.counts?.donors);
+        addDonorCountCandidate(item?.counts?.donor_count);
+    });
+
+    if (donorSet.size > 0) return donorSet.size;
+    if (donorCountCandidates.length > 0) return Math.max(...donorCountCandidates);
+    return null;
+}
+
 function formatLocalizedNumber(value, options = undefined) {
     const normalizedValue = Number(value) || 0;
     const {
@@ -258,20 +296,6 @@ export class VisualBody extends React.PureComponent {
         const countFor = blockProps && blockProps.countFor ? blockProps.countFor : 'files';
         const blockType = blockProps && blockProps.blockType ? blockProps.blockType : 'regular';
         const countField = countFor === 'tissue_files' ? 'files' : countFor;
-        const getUniqueDonorCountFromItems = (items) => {
-            if (!Array.isArray(items)) return null;
-            const donorSet = new Set();
-            items.forEach((item) => {
-                if (!item) return;
-                const donorValue = item.donor;
-                if (Array.isArray(donorValue)) {
-                    donorValue.forEach((d) => { if (d != null) donorSet.add(String(d)); });
-                } else if (donorValue != null) {
-                    donorSet.add(String(donorValue));
-                }
-            });
-            return donorSet.size > 0 ? donorSet.size : null;
-        };
         const blockSum = Array.isArray(data)
             ? (countField === 'donors'
                 ? (() => {
@@ -669,18 +693,9 @@ export class VisualBody extends React.PureComponent {
             return primaryGroupingField === 'sample_summary.tissues';
         })();
 
-        const getUniqueDonorCountFromItems = (items) => {
-            const donorSet = new Set();
-            (items || []).forEach((item) => {
-                if (!item) return;
-                const donorValue = item.donor;
-                if (Array.isArray(donorValue)) {
-                    donorValue.forEach((d) => { if (d != null) donorSet.add(String(d)); });
-                } else if (donorValue != null) {
-                    donorSet.add(String(donorValue));
-                }
-            });
-            if (donorSet.size > 0) return donorSet.size;
+        const getResolvedDonorCountFromItems = (items) => {
+            const uniqueDonorCount = getUniqueDonorCountFromItems(items);
+            if (uniqueDonorCount !== null) return uniqueDonorCount;
 
             // Tissue x Assay file summaries can be backed by aggregated rows that do not
             // carry donor identifiers, so fall back to the aggregate donor totals.
@@ -751,7 +766,7 @@ export class VisualBody extends React.PureComponent {
             : (typeof summaryCounts?.total_coverage === 'number'
                 ? summaryCounts.total_coverage
                 : totalCoverage);
-        const donorCount = getUniqueDonorCountFromItems(dataForCounts);
+        const donorCount = getResolvedDonorCountFromItems(dataForCounts);
         const isTissueColumnGrouping = (fieldChangeMap?.[columnGrouping] || columnGrouping) === 'sample_summary.tissues';
         const assayCount = getUniqueValueCountFromItems(dataForCounts, 'assay');
         const tissueCount = isTissueColumnGrouping
@@ -2940,20 +2955,6 @@ const Block = React.memo(function Block(props){
 
     const countFor = props.countFor || 'files';
     const effectiveCountFor = countFor === 'tissue_files' ? 'files' : countFor;
-    const getUniqueDonorCountFromItems = (items) => {
-        if (!Array.isArray(items)) return null;
-        const donorSet = new Set();
-        items.forEach((item) => {
-            if (!item) return;
-            const donorValue = item.donor;
-            if (Array.isArray(donorValue)) {
-                donorValue.forEach((d) => { if (d != null) donorSet.add(String(d)); });
-            } else if (donorValue != null) {
-                donorSet.add(String(donorValue));
-            }
-        });
-        return donorSet.size > 0 ? donorSet.size : null;
-    };
     const blockValue = Array.isArray(argData)
         ? (effectiveCountFor === 'donors'
             ? (() => {

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -443,7 +443,7 @@ export class VisualBody extends React.PureComponent {
             rowGroupsExtended, additionalPopoverData = {}, baseBrowseFilesPath,
             browseFilteringTransformFunc, activeFacetHref
         } = this.props;
-        const { depth, blockType = null, popoverPrimaryTitle, rowGroups, rowGroupKey, columnKey, summaryCounts = null, countFor = 'files' } = blockProps;
+        const { depth, blockType = null, popoverPrimaryTitle, rowGroups, rowGroupKey, columnKey, summaryCounts = null, countFor = 'files', computedBlockValue = null } = blockProps;
         const effectiveBlockType = blockType === 'col-secondary-summary' ? 'col-summary' : blockType;
         let isGroup = (Array.isArray(data) && data.length >= 1) || false;
         let aggrData;
@@ -721,23 +721,35 @@ export class VisualBody extends React.PureComponent {
                 totalCoverage: sum.totalCoverage + getTotalCoverageFromItem(item)
             };
         }, { fileCount: 0, totalCoverage: 0 });
-        const effectiveFileCount = typeof summaryCounts?.files === 'number'
-            ? summaryCounts.files
-            : fileCount;
-        const effectiveTotalCoverage = typeof summaryCounts?.total_coverage === 'number'
-            ? summaryCounts.total_coverage
-            : totalCoverage;
+        const shouldUseComputedSummaryValue = (
+            (effectiveBlockType === 'col-summary' || effectiveBlockType === 'row-summary') &&
+            typeof computedBlockValue === 'number'
+        );
+        const effectiveFileCount = ((countFor === 'files' || countFor === 'tissue_files') && shouldUseComputedSummaryValue)
+            ? computedBlockValue
+            : (typeof summaryCounts?.files === 'number'
+                ? summaryCounts.files
+                : fileCount);
+        const effectiveTotalCoverage = (countFor === 'total_coverage' && shouldUseComputedSummaryValue)
+            ? computedBlockValue
+            : (typeof summaryCounts?.total_coverage === 'number'
+                ? summaryCounts.total_coverage
+                : totalCoverage);
         const donorCount = getUniqueDonorCountFromItems(dataForCounts);
         const isTissueColumnGrouping = (fieldChangeMap?.[columnGrouping] || columnGrouping) === 'sample_summary.tissues';
         const tissueCount = isTissueColumnGrouping
             ? getUniqueValueCountFromItems(effectiveBlockType === 'row-summary' ? rowSummaryItems : dataForCounts, columnGrouping)
             : 0;
+        const effectiveSecondaryGrpPropUniqueCount = (effectiveBlockType === 'row-summary' && secondaryGrpProp)
+            ? (getUniqueValueCountFromItems(rowSummaryItems, secondaryGrpProp) || secondaryGrpPropUniqueCount)
+            : secondaryGrpPropUniqueCount;
         // Round totalCoverage to 2 decimal places since ES has floating point precision issues
         const roundedTotalCoverage = effectiveTotalCoverage > 0 ? Math.round(effectiveTotalCoverage * 100) / 100 : 0;
         const totalCoverageDisplay = roundedTotalCoverage > 0 ? `${formatLocalizedNumber(roundedTotalCoverage, {
             minimumFractionDigits: 0,
             maximumFractionDigits: 2
         })}X` : '--';
+        const formattedFileCount = typeof effectiveFileCount === 'number' ? formatLocalizedNumber(effectiveFileCount) : effectiveFileCount;
         const formatGermLayerValue = (value) => (value && value !== 'No value' ? value : '--');
 
         // Render
@@ -799,7 +811,7 @@ export class VisualBody extends React.PureComponent {
                                     </div>
                                     <div className="col-4">
                                         <div className="label">Total Files</div>
-                                        <div className="value">{effectiveFileCount}</div>
+                                        <div className="value">{formattedFileCount}</div>
                                     </div>
                                 </div>
                             ) : null}
@@ -816,7 +828,7 @@ export class VisualBody extends React.PureComponent {
                                         </div>
                                         <div className="col-4">
                                             <div className="label">{countFor === 'total_coverage' ? 'Total Coverage' : 'Total Files'}</div>
-                                            <div className="value">{countFor === 'total_coverage' ? totalCoverageDisplay : effectiveFileCount}</div>
+                                            <div className="value">{countFor === 'total_coverage' ? totalCoverageDisplay : formattedFileCount}</div>
                                         </div>
                                     </div>
                                 </React.Fragment>
@@ -835,7 +847,7 @@ export class VisualBody extends React.PureComponent {
                                             {isTissueGrouping
                                                 ? (donorCount || '--')
                                                 : (isTissueColumnGrouping ? (tissueCount || '--')
-                                                    : (secondaryGrpPropUniqueCount || additionalPopoverData?.[primaryGrpPropValue]?.["secondaryCategory"] || '--'))}
+                                                    : (effectiveSecondaryGrpPropUniqueCount || additionalPopoverData?.[primaryGrpPropValue]?.["secondaryCategory"] || '--'))}
                                         </div>
                                     </div>
                                     {additionalPopoverData?.[primaryGrpPropValue]?.["secondary"] ?
@@ -849,7 +861,7 @@ export class VisualBody extends React.PureComponent {
                                     }
                                     <div className="col-4">
                                         <div className="label">Total Files</div>
-                                        <div className="value">{effectiveFileCount}</div>
+                                        <div className="value">{formattedFileCount}</div>
                                     </div>
                                 </div>
                             ) : null}
@@ -865,7 +877,7 @@ export class VisualBody extends React.PureComponent {
                                     </div>
                                     <div className="col-4">
                                         <div className="label">Total Files</div>
-                                        <div className="value">{effectiveFileCount}</div>
+                                        <div className="value">{formattedFileCount}</div>
                                     </div>
                                 </div>
                             ) : null}
@@ -1802,17 +1814,65 @@ export class StackedBlockGroupedRow extends React.PureComponent {
         return props.fieldChangeMap?.[props.columnGrouping] || props.columnGrouping;
     }
 
-    static getColumnTotalsEntry(columnKey, props) {
-        if (!Array.isArray(props.columnTotals)) return null;
+    static getColumnTotalsEntries(columnKey, props) {
+        if (!Array.isArray(props.columnTotals)) return [];
 
-        // DataMatrix normalizes column_totals to the UI grouping alias (e.g. assay),
-        // but some callers may still pass raw backend-shaped totals. Prefer the UI key
-        // and fall back to the original backend field for safety.
         const transformedField = props.columnGrouping;
         const resolvedColumnGroupingField = StackedBlockGroupedRow.getResolvedColumnGroupingField(props);
 
-        return _.findWhere(props.columnTotals, { [transformedField]: columnKey })
-            || _.findWhere(props.columnTotals, { [resolvedColumnGroupingField]: columnKey });
+        return _.filter(props.columnTotals, (columnTotal) => (
+            columnTotal?.[transformedField] === columnKey
+            || columnTotal?.[resolvedColumnGroupingField] === columnKey
+        ));
+    }
+
+    static getColumnTotalsEntry(columnKey, props) {
+        const matchingEntries = StackedBlockGroupedRow.getColumnTotalsEntries(columnKey, props);
+        if (matchingEntries.length === 0) return null;
+
+        const transformedField = props.columnGrouping;
+        const resolvedColumnGroupingField = StackedBlockGroupedRow.getResolvedColumnGroupingField(props);
+        const groupedRows = Array.isArray(props.groupedDataIndices?.[columnKey]) ? props.groupedDataIndices[columnKey] : [];
+        const uniqueDonors = _.chain(groupedRows)
+            .map((row) => row?.donor)
+            .flatten()
+            .compact()
+            .map((value) => String(value))
+            .uniq()
+            .value();
+        const groupedRowDonorCount = _.reduce(groupedRows, (maxCount, row) => {
+            const rowDonorCount = row?.counts?.donors ?? row?.counts?.donor_count ?? 0;
+            return Math.max(maxCount, rowDonorCount);
+        }, 0);
+        const donorCount = uniqueDonors.length > 0
+            ? uniqueDonors.length
+            : Math.max(
+                groupedRowDonorCount,
+                _.reduce(matchingEntries, (maxCount, entry) => {
+                    const entryDonorCount = entry?.counts?.donors ?? entry?.counts?.donor_count ?? 0;
+                    return Math.max(maxCount, entryDonorCount);
+                }, 0)
+            );
+
+        return _.reduce(matchingEntries, (memo, entry, index) => {
+            if (index === 0) {
+                memo = {
+                    ...entry,
+                    [transformedField]: columnKey,
+                    [resolvedColumnGroupingField]: columnKey,
+                    counts: {
+                        ...(entry?.counts || {}),
+                        files: 0,
+                        total_coverage: 0,
+                        donors: donorCount,
+                        donor_count: donorCount
+                    }
+                };
+            }
+            memo.counts.files += Number(entry?.counts?.files) || 0;
+            memo.counts.total_coverage += Number(entry?.counts?.total_coverage) || 0;
+            return memo;
+        }, null);
     }
 
     static getColumnHasCoverage(columnKey, props) {
@@ -2441,6 +2501,27 @@ export class StackedBlockGroupedRow extends React.PureComponent {
             return primaryGroupSet.size;
         };
 
+        const getDonorCountFromGroupedRows = (columnKey) => {
+            const rows = props.groupedDataIndices[columnKey] || [];
+            const donorSet = new Set();
+            let maxRowDonorCount = 0;
+
+            rows.forEach((row) => {
+                const donorValue = row && row.donor;
+                if (Array.isArray(donorValue)) {
+                    donorValue.forEach((d) => { if (d != null) donorSet.add(String(d)); });
+                } else if (donorValue != null) {
+                    donorSet.add(String(donorValue));
+                }
+                const rowDonorCount = row?.counts?.donors ?? row?.counts?.donor_count ?? 0;
+                if (rowDonorCount > maxRowDonorCount) {
+                    maxRowDonorCount = rowDonorCount;
+                }
+            });
+
+            return donorSet.size > 0 ? donorSet.size : maxRowDonorCount;
+        };
+
         const getOverallPrimaryGroupCountFromRows = () => {
             const primaryGroupField = Array.isArray(props.groupingProperties) ? props.groupingProperties[0] : 'donor';
             const primaryGroupSet = new Set();
@@ -2496,24 +2577,34 @@ export class StackedBlockGroupedRow extends React.PureComponent {
                         : null;
                     // Apply derived fallback only for DSA column summary files.
                     // Other columns continue using backend/standard summary paths.
-                    const shouldDeriveDsaFiles = (summaryCountFor === 'files' || summaryCountFor === 'tissue_files')
+                    const shouldDeriveDsaFiles = summaryCountFor === 'files'
                         && summaryBlockType === 'col-summary'
                         && columnKey === 'DSA'
                         && !!props.rowSummaryCountsByGroup;
                     const derivedDsaFiles = shouldDeriveDsaFiles
                         ? StackedBlockGroupedRow.getDerivedColumnFilesFromRowSummary(sectionRows, columnKey, props)
                         : null;
+                    const groupedRowsDonorCount = getDonorCountFromGroupedRows(columnKey);
+                    const shouldPreferGroupedRowDonorCount = summaryCountFor === 'donors'
+                        && Array.isArray(props.groupingProperties)
+                        && props.groupingProperties[0] !== 'donor';
                     const donorsCount = isPrimarySummaryBand
                         ? getPrimaryGroupCountFromGroupedRows(columnKey)
-                        : (totalsCounts?.donors ?? totalsCounts?.donor_count ?? getPrimaryGroupCountFromGroupedRows(columnKey));
-                    const summaryCounts = isPrimarySummaryBand
-                        ? { donors: donorsCount }
-                        : {
-                            ...(totalsCounts || {}),
-                            donors: donorsCount,
-                            ...(summaryCountFor === 'total_coverage' ? { total_coverage: totalsCounts?.total_coverage ?? derivedCoverageTotal ?? 0 } : null),
-                            ...((typeof derivedDsaFiles === 'number') ? { files: derivedDsaFiles } : null)
-                        };
+                        : (shouldPreferGroupedRowDonorCount
+                            ? (groupedRowsDonorCount
+                                ?? totalsCounts?.donors
+                                ?? totalsCounts?.donor_count
+                                ?? getPrimaryGroupCountFromGroupedRows(columnKey))
+                            : (totalsCounts?.donors
+                                ?? totalsCounts?.donor_count
+                                ?? groupedRowsDonorCount
+                                ?? getPrimaryGroupCountFromGroupedRows(columnKey)));
+                    const summaryCounts = {
+                        ...(totalsCounts || {}),
+                        donors: donorsCount,
+                        ...(summaryCountFor === 'total_coverage' ? { total_coverage: totalsCounts?.total_coverage ?? derivedCoverageTotal ?? 0 } : null),
+                        ...((typeof derivedDsaFiles === 'number') ? { files: derivedDsaFiles } : null)
+                    };
                     const useRawColumnTotal = rawColumnTotalEntry && (summaryCountFor === 'files' || summaryCountFor === 'tissue_files');
                     const columnSummaryData = summaryCountFor === 'donors'
                         ? [{ counts: { donors: donorsCount } }]
@@ -2809,12 +2900,6 @@ const Block = React.memo(function Block(props){
         contents = blockRenderedContents.apply(blockRenderedContents, blockFxnArguments);
     }
 
-    // Build optional popover
-    let popover = null;
-    if (typeof blockPopover === 'function'){
-        popover = blockPopover.apply(blockPopover, blockFxnArguments);
-    }
-
     const countFor = props.countFor || 'files';
     const effectiveCountFor = countFor === 'tissue_files' ? 'files' : countFor;
     const getUniqueDonorCountFromItems = (items) => {
@@ -2857,6 +2942,14 @@ const Block = React.memo(function Block(props){
         return blockValue >= 1000 ? formatLocalizedNumber(blockValue) : null;
     })();
     const hideCoverageBlock = countFor === 'total_coverage' && blockType === 'regular' && blockValue <= 0;
+
+    // Build optional popover after blockValue is known so summary popovers can
+    // use the exact rendered count instead of re-deriving from grouped rows.
+    let popover = null;
+    if (typeof blockPopover === 'function'){
+        popover = blockPopover.apply(blockPopover, [argData, { ...props, computedBlockValue: blockValue }, parentGrouping]);
+    }
+
     if (hideCoverageBlock) {
         popover = null;
     }

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -783,10 +783,6 @@ export class VisualBody extends React.PureComponent {
             minimumFractionDigits: 0,
             maximumFractionDigits: 2
         })}X` : '--';
-        const regularCoverageDisplay = roundedTotalCoverage > 0 ? `${formatLocalizedNumber(roundedTotalCoverage, {
-            minimumFractionDigits: 0,
-            maximumFractionDigits: 2
-        })}X` : '--';
         const formattedFileCount = typeof effectiveFileCount === 'number' ? formatLocalizedNumber(effectiveFileCount) : effectiveFileCount;
         const formatGermLayerValue = (value) => (value && value !== 'No value' ? value : '--');
 
@@ -850,7 +846,7 @@ export class VisualBody extends React.PureComponent {
                                     </div>
                                     <div className="col-4">
                                         <div className="label">Total Coverage</div>
-                                        <div className="value">{regularCoverageDisplay}</div>
+                                        <div className="value">{totalCoverageDisplay}</div>
                                     </div>
                                     <div className="col-4">
                                         <div className="label">Total Files</div>

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -992,7 +992,7 @@ export class VisualBody extends React.PureComponent {
                     'summaryBackgroundColor', 'xAxisLabel', 'yAxisLabel', 'showAxisLabels', 'showColumnSummary',
                     'countFor', 'overallCounts', 'showUniqueDonorsAssayBand', 'shrinkEmptyColumns',
                     'blockWidth', 'blockHorizontalExtend', 'blockHorizontalSpacing', 'blockVerticalSpacing', 'rowSummaryCountsByGroup',
-                    'rawRegularCountOverrides', 'compactCoverageText', 'showCoverageSummaries', 'disableRowExpand', 'disableBlockOpen',
+                    'rawRegularCountOverrides', 'dedupeBenchmarkingDsaAcrossTissues', 'compactCoverageText', 'showCoverageSummaries', 'disableRowExpand', 'disableBlockOpen',
                     'headerLeftControls', 'hideFallbackColumnGroupHeader', 'hideFallbackRowGroupHeader', 'isGridRefreshing')}
                 blockPopover={this.blockPopover}
                 blockRenderedContents={VisualBody.blockRenderedContents}
@@ -2092,7 +2092,8 @@ export class StackedBlockGroupedRow extends React.PureComponent {
             'groupedDataIndices', 'columnGrouping', 'blockPopover', 'colorRanges', 'summaryBackgroundColor',
             'activeBlock', 'openBlock', 'handleBlockMouseEnter', 'handleBlockMouseLeave', 'handleBlockClick', 'group', 'popoverPrimaryTitle',
             // Generic summary overrides keyed by grouping field and row value.
-            'countFor', 'rowSummaryCountsByGroup', 'compactCoverageText', 'showCoverageSummaries');
+            'countFor', 'rowSummaryCountsByGroup', 'rawRegularCountOverrides', 'dedupeBenchmarkingDsaAcrossTissues',
+            'compactCoverageText', 'showCoverageSummaries');
         const getContainerGroupStyle = function(columnKey = 'overall-summary') {
             const width = StackedBlockGroupedRow.getColumnWidthForKey(columnKey, props);
             return {


### PR DESCRIPTION
## Summary

This PR fixes several inconsistencies in the data matrix popover, especially in Tissue x Assay and summary-row/summary-column states.

## What changed

- added a shared helper to compute unique donor counts from grouped items
- made regular and summary popovers fall back to aggregate donor totals when grouped rows do not carry donor identifiers directly
- passed the rendered block value into the popover so summary totals use the displayed value instead of re-deriving it
- improved Tissue x Assay popover details:
  - show `Total Donors` for regular blocks
  - show `Total Assays` when the column grouping is tissue-based
  - format `Total Files` and `Total Coverage` consistently
  - show `Multiple` for germ layer when grouped rows span more than one layer
- updated column total aggregation so donor counts, file totals, and coverage totals are merged correctly across matching column entries
- preserved grouped row metadata when overriding collapsed DSA file totals, so popovers still have the right contextual information

## Why

Some matrix popovers were showing incorrect or incomplete summary information because:
- donor counts were derived only from row-level donor fields that are not always present in aggregated Tissue x Assay data
- summary popovers could re-compute values differently from what the cell actually rendered
- collapsed/derived DSA totals dropped metadata needed by the popover

These changes keep the popover aligned with the visible matrix values and make donor/tissue summary information more reliable.

### Bug Fix: Total Files
<img width="2348" height="898" alt="resim" src="https://github.com/user-attachments/assets/d65454a9-3379-437c-aafa-7c6f66736803" />

### Feature: Total Donors & Coverage Formatting
<img width="2328" height="938" alt="resim" src="https://github.com/user-attachments/assets/7c7b1501-85f4-427b-9086-4cbe8c1dd277" />

### Bug Fix: Germ Layer
<img width="2328" height="938" alt="resim" src="https://github.com/user-attachments/assets/ec21fdef-106e-4f61-9a02-acafffa9cacd" />

### Bug Fix: Incorrect Total Files
<img width="4484" height="1958" alt="resim" src="https://github.com/user-attachments/assets/c106f9e8-4ebe-429e-884a-b021b46f2e4e" />
