### PR TITLE
build: multi-stage production Dockerfile (keep current base, exclude dhi.io/Splunk/CrowdStrike)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,21 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 
 - Add durable project-specific notes here as they are discovered through real work.
 
+## Building the production Docker image locally
+
+- `Dockerfile` is a BuildKit multi-stage build (`builder` -> `runtime`); it needs
+  BuildKit (`DOCKER_BUILDKIT=1`, or Docker >= 23 default) because of the `# syntax=`
+  directive and the `RUN --mount=type=cache` mounts. `buildspec.yml` sets
+  `DOCKER_BUILDKIT: "1"` for CodeBuild.
+- `docker build .` will fail at `COPY deploy/docker/local/docker_development.ini` with
+  `"... not found"` unless that file exists in the build context. It is `.gitignore`d;
+  CI creates it in `buildspec.yml` pre_build (`touch deploy/docker/local/docker_development.ini`).
+  To build locally, `touch deploy/docker/local/docker_development.ini` first.
+- nginx is NOT Debian's stock package: `deploy/docker/production/install_nginx_bullseye.sh`
+  installs a pinned nginx.org build (1.21.6) and creates the non-root `nginx` user at
+  uid/gid 121. The container runs everything as `nginx` under `supervisord` (which now also
+  runs nginx via `[program:nginx]`; the entrypoints no longer `service nginx start`).
+
 ## Running the Python test suite
 
 - The project uses a `src/` layout package named `encoded` (see `pyproject.toml`,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ smaht-portal
 Change Log
 ----------
 
+2.3.0
+=====
+
+* Convert Docker built to multi-stage to reduce image overhead
+
+
 2.2.3
 =====
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,32 @@
+# syntax=docker/dockerfile:1.7
 # SMaHT-Portal (Production) Dockerfile
 
 # Bullseye with Python 3.11.12
 # 2025-05-08: Update docker image to a newer Python 3.11 version;
 # this was previously: FROM python:3.9.16-slim-buster
-FROM python:3.11.12-slim-bullseye
+# BASE_IMAGE is overridable, but defaults to the standard Debian slim Python image
+# (NOT a hardened image) so plain `docker build .` works with no registry auth.
+ARG BASE_IMAGE=python:3.11.12-slim-bullseye
 
-MAINTAINER William Ronchetti "william_ronchetti@hms.harvard.edu"
+# ---------------------------------------------------------------------------
+# Builder stage: full toolchain (compilers, Node) used only to build the Python
+# venv and the front-end assets. None of this ships in the runtime image.
+# ---------------------------------------------------------------------------
+FROM ${BASE_IMAGE} AS builder
 
-# Build Arguments
-ARG INI_BASE
-ENV INI_BASE=${INI_BASE:-"smaht_any_alpha.ini"}
-
-# Configure (global) Env
-# Note that some important versions are pinned in this statement
-ENV NGINX_USER=nginx \
-    DEBIAN_FRONTEND=noninteractive \
+ENV DEBIAN_FRONTEND=noninteractive \
     CRYPTOGRAPHY_DONT_BUILD_RUST=1 \
-    PYTHONFAULTHANDLER=1 \
-    PYTHONUNBUFFERED=1 \
-    PYTHONHASHSEED=random \
-    PIP_NO_CACHE_DIR=off \
     PIP_DISABLE_PIP_VERSION_CHECK=on \
     PIP_DEFAULT_TIMEOUT=100 \
     NVM_VERSION=v0.39.1 \
     NODE_VERSION=21.7.3
 
-# Configure Python3.9 venv
+# Python venv (poetry + supervisor + app deps all install into here)
 ENV VIRTUAL_ENV=/opt/venv
 RUN python -m venv /opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Install system level dependencies (poetry, nvm)
-# Note that the ordering of these operations is intentional to minimize package footprint
+# Build toolchain + Node (via nvm). Editors/net-tools intentionally omitted.
 WORKDIR /home/nginx/.nvm
 ENV NVM_DIR=/home/nginx/.nvm
 
@@ -42,58 +37,99 @@ RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries && \
     echo 'Acquire::http::Pipeline-Depth "0";' >> /etc/apt/apt.conf.d/80-retries
 
 RUN apt-get update && apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends vim emacs net-tools ca-certificates build-essential \
-    gcc zlib1g-dev postgresql-client libpq-dev git make curl libmagic-dev && \
+    apt-get install -y --no-install-recommends ca-certificates build-essential \
+    gcc zlib1g-dev libpq-dev git make curl libmagic-dev && \
     pip install --upgrade pip && \
     pip install poetry==1.8.5 && \
     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash && \
     . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION} && \
     nvm use v${NODE_VERSION} && \
-    nvm alias default v${NODE_VERSION} && \
-    curl -o aws-ip-ranges.json https://ip-ranges.amazonaws.com/ip-ranges.json
-
-# Install nginx
-COPY deploy/docker/production/install_nginx_bullseye.sh /install_nginx.sh
-RUN bash /install_nginx.sh && \
-    chown -R nginx:nginx /opt/venv && \
-    mkdir -p /home/nginx/smaht-portal && \
-    mv aws-ip-ranges.json /home/nginx/smaht-portal/aws-ip-ranges.json && \
-    # uninstalled by nginx install, but needed later for npm install
-    apt-get update && apt-get install -y --no-install-recommends ca-certificates && \
-    apt-get clean
-
-# Link, verify installations
+    nvm alias default v${NODE_VERSION}
 ENV PATH="/home/nginx/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 
-# Build application
 WORKDIR /home/nginx/smaht-portal
 
-# Do the front-end dependency install first, since this is most intensive
-COPY package.json .
-COPY package-lock.json .
-RUN npm ci --no-fund --no-progress --no-optional --no-audit --python=/opt/venv/bin/python && npm cache clean --force
+# Back-end dependencies first, from the lockfiles only, so this expensive layer is
+# cached across code-only changes. BuildKit cache mounts persist the package caches.
+COPY pyproject.toml poetry.lock poetry.toml ./
+RUN --mount=type=cache,target=/root/.cache/pypoetry \
+    --mount=type=cache,target=/root/.cache/pip \
+    poetry install --no-root --no-dev
 
-# Copy over the rest of the code
+# Front-end dependencies next (also cache-friendly).
+COPY package.json package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --no-fund --no-progress --no-optional --no-audit --python=/opt/venv/bin/python
+
+# Now the full source, then install the project itself and build assets.
 COPY . .
-
-# Build remaining back-end
-RUN poetry install --no-dev -vvv && \
+RUN --mount=type=cache,target=/root/.cache/pypoetry \
+    poetry install --no-dev && \
     python setup_eb.py develop && \
     make fix-dist-info
-
-# Build front-end, remove node_modules when done
 ENV NODE_ENV=production
 RUN npm run build && \
     npm run build-scss && \
     rm -rf node_modules/
 
-# Copy config files in (down here for quick debugging)
-# Remove default configuration from Nginx
-RUN rm /etc/nginx/nginx.conf && \
-    rm /etc/nginx/conf.d/default.conf
+# Build-time data fetches (kept in the built tree, carried into runtime below).
+# NOTE: restricted_domains.txt is pulled from a third-party gist - consider vendoring
+# it into the repo with a checksum to remove this build-time supply-chain dependency.
+RUN curl -o aws-ip-ranges.json https://ip-ranges.amazonaws.com/ip-ranges.json && \
+    curl https://gist.githubusercontent.com/ammarshah/f5c2624d767f91a7cbdc4e54db8dd0bf/raw > restricted_domains.txt
+
+# ---------------------------------------------------------------------------
+# Runtime stage: slim image with only what's needed to serve the app - no
+# compilers, no Node toolchain, no editors.
+# ---------------------------------------------------------------------------
+FROM ${BASE_IMAGE} AS runtime
+
+# Build Arguments
+ARG INI_BASE
+ENV INI_BASE=${INI_BASE:-"smaht_any_alpha.ini"}
+
+ENV NGINX_USER=nginx \
+    DEBIAN_FRONTEND=noninteractive \
+    PYTHONFAULTHANDLER=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONHASHSEED=random \
+    VIRTUAL_ENV=/opt/venv \
+    GIT_PYTHON_GIT_EXECUTABLE=/usr/bin/git \
+    NODE_VERSION=21.7.3
+# Node is required at runtime for server-side rendering. We don't reinstall the Node
+# toolchain here - just copy the prebuilt runtime from the builder (below) onto PATH,
+# which keeps the build toolchain (gcc, headers, npm build deps) out of the final image.
+ENV NODE_DIR=/home/nginx/.nvm/versions/node/v${NODE_VERSION}
+ENV PATH="$VIRTUAL_ENV/bin:${NODE_DIR}/bin:$PATH"
+
+# deb.debian.org CDN reset mitigation (see builder stage).
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries && \
+    echo 'Acquire::http::Pipeline-Depth "0";' >> /etc/apt/apt.conf.d/80-retries
+
+# Runtime OS deps only. psycopg2-binary bundles libpq, so libpq-dev isn't needed
+# here; gcc/build tools aren't needed since wheels are built in the builder stage.
+# libmagic1 is for python-magic; make is for the local entrypoint; git is invoked
+# indirectly by dcicutils at runtime.
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends ca-certificates git make libmagic1 && \
+    apt-get clean
+
+# nginx: install the pinned nginx.org build (identical to the previous single-stage
+# image) via the bullseye install script. That script also creates the non-root
+# nginx user (uid/gid 121) and symlinks nginx's access/error logs to stdout/stderr.
+# On this standard Debian slim base the `adm` group (gid 4) and `www-data` user
+# (uid 33) already exist and uid/gid 121 are free, so - unlike the hardened base -
+# no extra account/tooling bootstrapping is required before installing nginx.
+COPY deploy/docker/production/install_nginx_bullseye.sh /install_nginx.sh
+RUN bash /install_nginx.sh && \
+    apt-get clean
+
+# nginx config: drop the packaged defaults and install ours.
+RUN rm -f /etc/nginx/nginx.conf /etc/nginx/conf.d/default.conf
 COPY deploy/docker/production/nginx.conf /etc/nginx/nginx.conf
 
-# nginx filesystem setup
+# nginx filesystem setup - everything runs as the non-root nginx user under
+# supervisord, so the paths nginx writes must be nginx-owned.
 RUN chown -R nginx:nginx /var/cache/nginx && \
     chown -R nginx:nginx /var/log/nginx && \
     chown -R nginx:nginx /etc/nginx/conf.d && \
@@ -107,46 +143,37 @@ RUN chown -R nginx:nginx /var/cache/nginx && \
     mkdir -p /data/nginx/cache && \
     chown -R nginx:nginx /data/nginx/cache
 
-# Pull all required files
-# Note that *.ini must match the env name in secrets manager!
-# Note that deploy/docker/production/entrypoint.sh resolves which entrypoint to run
-# based on env variable "application_type".
-# For now, this is mastertest. - Will 04/29/21
-COPY deploy/docker/local/docker_development.ini development.ini
-COPY deploy/docker/local/entrypoint.sh entrypoint_local.sh
-COPY deploy/docker/local/gitinfo.json .
-RUN chown nginx:nginx development.ini
-RUN chmod +x entrypoint_local.sh
+WORKDIR /home/nginx/smaht-portal
 
-# Production setup
-RUN chown nginx:nginx poetry.toml && \
-    touch production.ini && \
-    chown nginx:nginx production.ini && \
-    touch session-secret.b64 && \
-    chown nginx:nginx session-secret.b64 &&  \
-    touch supervisord.log && \
-    chown nginx:nginx supervisord.log && \
-    touch supervisord.sock && \
-    chown nginx:nginx supervisord.sock && \
-    touch supervisord.pid && \
-    chown nginx:nginx supervisord.pid
-COPY deploy/docker/production/$INI_BASE deploy/ini_files/.
-COPY deploy/docker/production/entrypoint.sh .
-COPY deploy/docker/production/entrypoint_portal.sh .
-COPY deploy/docker/production/entrypoint_deployment.sh .
-COPY deploy/docker/production/entrypoint_indexer.sh .
-COPY deploy/docker/production/entrypoint_ingester.sh .
-COPY deploy/docker/production/supervisord.conf .
-COPY deploy/docker/production/assume_identity.py .
-RUN chmod +x entrypoint.sh && \
-    chmod +x entrypoint_deployment.sh && \
-    chmod +x entrypoint_deployment.sh && \
-    chmod +x entrypoint_indexer.sh && \
-    chmod +x entrypoint_ingester.sh && \
-    chmod +x assume_identity.py
+# Bring in the built venv and the built application tree from the builder. --chown
+# avoids a second full-size layer that a later `chown -R` would create.
+COPY --chown=nginx:nginx --from=builder /opt/venv /opt/venv
+COPY --chown=nginx:nginx --from=builder /home/nginx/smaht-portal /home/nginx/smaht-portal
+# Node runtime (for server-side rendering) - just the prebuilt interpreter, no toolchain.
+COPY --chown=nginx:nginx --from=builder ${NODE_DIR} ${NODE_DIR}
 
-# grab restricted domain list
-RUN curl https://gist.githubusercontent.com/ammarshah/f5c2624d767f91a7cbdc4e54db8dd0bf/raw > restricted_domains.txt
+# App config + entrypoints. entrypoint.sh dispatches by $application_type; *.ini must
+# match the env name in Secrets Manager.
+COPY --chown=nginx:nginx deploy/docker/local/docker_development.ini development.ini
+COPY --chown=nginx:nginx deploy/docker/local/entrypoint.sh entrypoint_local.sh
+COPY --chown=nginx:nginx deploy/docker/local/gitinfo.json .
+COPY --chown=nginx:nginx deploy/docker/production/$INI_BASE deploy/ini_files/.
+COPY --chown=nginx:nginx deploy/docker/production/entrypoint.sh .
+COPY --chown=nginx:nginx deploy/docker/production/entrypoint_portal.sh .
+COPY --chown=nginx:nginx deploy/docker/production/entrypoint_deployment.sh .
+COPY --chown=nginx:nginx deploy/docker/production/entrypoint_indexer.sh .
+COPY --chown=nginx:nginx deploy/docker/production/entrypoint_ingester.sh .
+COPY --chown=nginx:nginx deploy/docker/production/supervisord.conf .
+COPY --chown=nginx:nginx deploy/docker/production/assume_identity.py .
+
+# Create the runtime-writable files (populated at startup) and make entrypoints
+# executable - all in one layer.
+RUN touch production.ini session-secret.b64 supervisord.log supervisord.sock supervisord.pid && \
+    chown nginx:nginx production.ini session-secret.b64 supervisord.log supervisord.sock supervisord.pid && \
+    chmod +x entrypoint.sh entrypoint_local.sh entrypoint_portal.sh \
+             entrypoint_deployment.sh entrypoint_indexer.sh entrypoint_ingester.sh \
+             assume_identity.py
+
 EXPOSE 8000
 
 # Container does not run as root

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,5 +1,19 @@
 version: 0.2
 
+# The Dockerfile is a multi-stage build that relies on BuildKit features
+# (the `# syntax=` directive and `RUN --mount=type=cache` mounts), so BuildKit
+# must be enabled for `docker build`.
+env:
+  variables:
+    DOCKER_BUILDKIT: "1"
+
+# Reuse the Docker layer cache across builds when CodeBuild reuses a build host.
+# Requires the CodeBuild project's cache type to be set to LOCAL (and privileged mode,
+# already required for docker builds).
+cache:
+  modes:
+    - LOCAL_DOCKER_LAYER_CACHE
+
 phases:
   pre_build:
     commands:

--- a/deploy/docker/local/entrypoint.sh
+++ b/deploy/docker/local/entrypoint.sh
@@ -15,8 +15,8 @@ if [  -z ${TEST+x} ]; then
 
     fi
 
-    # Start nginx proxy
-    service nginx start
+    # Start nginx proxy (daemonizes to the background; make deploy2 holds the foreground)
+    /usr/sbin/nginx
 
     # Start application
     make deploy2

--- a/deploy/docker/production/entrypoint_portal.sh
+++ b/deploy/docker/production/entrypoint_portal.sh
@@ -6,9 +6,6 @@ echo "Starting up SMAHT WSGI"
 # secrets manager - this builds production.ini
 poetry run python -m assume_identity
 
-# Start nginx proxy
-service nginx start
-
-# Start application workers
+# Start application workers and nginx (nginx runs in the foreground under supervisord)
 echo "Starting supervisor"
 supervisord -c supervisord.conf

--- a/deploy/docker/production/supervisord.conf
+++ b/deploy/docker/production/supervisord.conf
@@ -52,3 +52,14 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile_maxbytes=0
 redirect_stderr=true
+
+# nginx now runs in the foreground under supervisord (the entrypoints no longer
+# `service nginx start`), so its lifetime/restarts are managed alongside the workers.
+[program:nginx]
+autorestart=true
+startsecs=5
+command=/usr/sbin/nginx -g "daemon off;"
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0
+redirect_stderr=true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "2.2.3"
+version = "2.3.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Ports the **multi-stage Docker build restructuring** from the `crowdstrike` branch onto `main`, while **keeping the current base image** (`python:3.11.12-slim-bullseye`) and deliberately leaving behind that branch's hardened-image (`dhi.io`), CrowdStrike, and Splunk additions.

The `crowdstrike` branch bundled three separable things: (1) a genuinely useful Docker build restructuring, (2) a swap to a private hardened base image + registry auth, and (3) compliance agents (Splunk forwarder + a commented-out CrowdStrike Falcon mirror). This PR takes only (1).

## ✅ Included — the build restructuring

- **`builder` → `runtime` split.** The final image ships only the app, the venv, nginx, and the Node runtime — no compilers, headers, npm build deps, or editors (`vim`/`emacs`/`net-tools` are gone).
- **BuildKit cache mounts** (`RUN --mount=type=cache` for pip/poetry/npm) + the `# syntax=docker/dockerfile:1.7` directive.
- **Layer-ordering optimization:** back-end deps (`pyproject.toml`/`poetry.lock`/`poetry.toml`) and front-end deps (`package*.json`) install **before** `COPY . .`, so code-only changes don't bust the expensive dependency layers.
- **`COPY --chown=... --from=builder`** of `/opt/venv`, the built app tree, and the Node runtime into the runtime stage.
- **nginx now runs under supervisord** (`[program:nginx]`); `entrypoint_portal.sh` no longer calls `service nginx start`, and the local `entrypoint.sh` starts nginx directly (`/usr/sbin/nginx`). This is the one supervisord change that is structurally required by the entrypoint change and is kept regardless of Splunk.
- **`buildspec.yml`:** enable BuildKit (`DOCKER_BUILDKIT: "1"`) and `LOCAL_DOCKER_LAYER_CACHE`.

## ❌ Excluded — not part of the build restructuring

- **The `dhi.io/python:3.11-debian-sfw-dev` hardened base.** `ARG BASE_IMAGE` is kept but defaults to the current `python:3.11.12-slim-bullseye`, so plain `docker build .` needs no private-registry auth.
- **The `buildspec.yml` `dhi.io` login block** (`DHI_USERNAME`/`DHI_TOKEN` Secrets Manager wiring + `docker login dhi.io`) and the **commented-out CrowdStrike Falcon sensor mirroring block**.
- **The Splunk Universal Forwarder** — see below.

### Why Splunk was dropped (please read)

The task asked to include the Splunk UF *and its `deploy/docker/production/splunk/*` config files if they exist on that branch*. **They do not exist** — `crowdstrike`'s Dockerfile `COPY`s `deploymentclient.conf`, `inputs.conf`, and `run_splunk_forwarder.sh`, but none of those were ever committed (the branch is WIP: `stage temporarily`). As a result **`crowdstrike`'s own Dockerfile would not build as-is.**

Rather than fabricate a compliance agent's config (the `deploymentclient.conf` deployment-server address is HMS infra I don't have a source of truth for), I dropped Splunk. Because Splunk is coupled to several log-routing changes, those were also reverted to current behavior:

- app workers keep logging to `/dev/stdout` (no `/var/log/smaht/*.log` files),
- no `log-shipper` / `splunkforwarder` supervisord programs,
- nginx keeps `access_log off`.

**To add Splunk back later:** commit the three `deploy/docker/production/splunk/*` files (especially `deploymentclient.conf` with the real deployment-server address), then re-add the builder-stage `dpkg -i splunkforwarder.deb`, the runtime `COPY --from=builder /opt/splunkforwarder`, the config COPYs, the `[program:splunkforwarder]`/`[program:log-shipper]` supervisord blocks, and switch the workers to `/var/log/smaht/*.log` + nginx `access_log`.

## 🔧 Adapted for the (non-hardened) current base

- **nginx install:** kept the existing `deploy/docker/production/install_nginx_bullseye.sh` (pinned **nginx.org 1.21.6** + xslt/geoip/image-filter/njs modules, creates the non-root `nginx` user at **uid/gid 121**) instead of `crowdstrike`'s `apt-get install nginx`. On bullseye that stock package would be a **different, unpinned nginx without those modules** — the `crowdstrike` switch was a hardened-base adaptation. The script is retained, not deleted.
- **Dropped `crowdstrike`'s hardened-base compensation steps** — manual creation of the `adm` group and `www-data` user, and installing `adduser`/`passwd`/`init-system-helpers`. Verified on `python:3.11.12-slim-bullseye` that `adm` (gid 4) and `www-data` (uid 33) already exist and uid/gid 121 are free, so these are redundant here.

## 🧪 Validation

Docker **was** available, so this was validated with a real build, not just a syntax walk-through:

- `DOCKER_BUILDKIT=1 docker build .` **succeeds end-to-end** (builder + runtime, all stages).
- Smoke test of the built image confirms:
  - runs as non-root **`nginx` (uid/gid 121)**,
  - **nginx 1.21.6**, `nginx -t` passes against the shipped `nginx.conf`,
  - **Node v21.7.3** present, **venv Python 3.11.12** + `supervisord` 4.3.0,
  - **`import encoded` works** (app installed correctly),
  - `aws-ip-ranges.json`, `restricted_domains.txt`, entrypoints, and configs present and `nginx`-owned.

**One caveat worth knowing** (pre-existing, not introduced here): a local `docker build .` fails at `COPY deploy/docker/local/docker_development.ini` unless that gitignored file exists — CI's `buildspec.yml` pre_build `touch`es it. `touch deploy/docker/local/docker_development.ini` first when building locally. This is now documented in `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
