### PR TITLE
fix: dedupe homepage ES searches and harden stat error handling (F1-F6)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,27 @@ smaht-portal
 Change Log
 ----------
 
+2.3.2
+=====
+
+* Homepage (``/home``) efficiency and correctness fixes:
+
+  * Dedupe redundant ES searches: run one ``limit=0`` search per distinct param dict
+    (6 instead of 14) and derive every stat (total + facet counts) from that single
+    captured response.
+  * Stop mutating shared state from concurrent worker threads: build each search's
+    param dict as a copy, and set the admin ``remote_user`` / strip the auth header on
+    the subrequest rather than the shared parent request.
+  * Never render the internal ``-1`` error sentinel to clients: failed sub-searches now
+    coerce to ``0``.
+  * ``generate_unique_facet_count`` no longer raises ``KeyError`` when a facet is absent
+    from the response; a missing facet degrades to a count of ``0``.
+  * Remove the unused ``pytz`` import and drop the always-hardcoded ``" EST"`` suffix
+    from the ``date`` field (now a plain ``YYYY-MM-DD`` string).
+  * Guard the release-date parse against the ``-1`` sentinel / non-ISO input so a single
+    failed sub-search degrades ``date`` to ``None`` instead of 500ing the homepage.
+
+
 2.3.1
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,13 @@ Change Log
     from the ``date`` field (now a plain ``YYYY-MM-DD`` string).
   * Guard the release-date parse against the ``-1`` sentinel / non-ISO input so a single
     failed sub-search degrades ``date`` to ``None`` instead of 500ing the homepage.
+  * Skip the full File default facet set on the homepage sub-searches: each search now
+    passes ``skip_default_facets`` and requests (via ``additional_facet``) only the
+    specific facets its stats read, instead of computing all ~21 File facets per search
+    and discarding all but one. The ``PRODUCTION`` search's ``additional_facet`` was
+    reconciled to declare ``donors.display_title`` and ``sample_summary.tissues`` (which
+    its donor / tissue-type counts read but previously got only as default facets) and to
+    drop the never-read ``...uberon_id`` facet. Stat values are unchanged.
 
 * Chart-endpoint (``visualization.py``) efficiency fixes:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,17 @@ Change Log
   * Guard the release-date parse against the ``-1`` sentinel / non-ISO input so a single
     failed sub-search degrades ``date`` to ``None`` instead of 500ing the homepage.
 
+* Chart-endpoint (``visualization.py``) efficiency fixes:
+
+  * ``date_histogram_aggregations`` and ``bar_plot_chart`` now pass
+    ``skip_default_facets`` so Elasticsearch no longer computes the full File default
+    facet set that both endpoints immediately discard (custom aggregations are
+    unaffected; ``data_matrix_aggregations`` still computes facets because it uses them).
+  * ``bar_plot_chart`` no longer computes the per-bucket
+    ``total_tissues``/``total_assays``/``total_file_size`` sub-aggregations that are only
+    read at the top-level total; per-bucket aggregations are trimmed to the fields
+    actually consumed. Response shape is unchanged.
+
 
 2.3.1
 =====

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "2.3.1"
+version = "2.3.2"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/homepage.py
+++ b/src/encoded/homepage.py
@@ -22,12 +22,20 @@ def includeme(config):
 
 
 class SearchBase:
-    """ Contains search params for getting various bits of information from the ES """
+    """ Contains search params for getting various bits of information from the ES
+
+        Each dict passes ``skip_default_facets=true`` so ES does not compute the full
+        File default facet set (~21 aggregations) that the homepage never reads. Under
+        ``skip_default_facets`` ONLY the facets named in ``additional_facet`` are computed,
+        so every facet a search's stats read MUST be declared there (see the extractors in
+        ``home``). Keep ``additional_facet`` in sync with the facets each search reads.
+    """
     LATEST_RELEASE_DATE_SEARCH_PARAMS = {
         'type': 'File',
         'status': ['open', 'open-early', 'open-network', 'protected-network', 'protected', 'protected-early',],
         'sort': '-file_status_tracking.release_dates.initial_release_date',
         'limit': 1,
+        'skip_default_facets': ['true'],  # reads @graph only, no facets needed
     }
     ALL_RELEASED_FILES_SEARCH_PARAMS = {
         'type': 'File',
@@ -41,24 +49,27 @@ class SearchBase:
         'status': ['open', 'open-early', 'open-network', 'protected-network', 'protected', 'protected-early',],
         'dataset': ['colo829blt_50to1', 'colo829t', 'colo829bl'],
         'additional_facet': [
-            'assays.display_title'
-        ]
+            'assays.display_title'  # assay count
+        ],
+        'skip_default_facets': ['true'],
     }
     HAPMAP_RELEASED_FILES_SEARCH_PARAMS = {
         'type': 'File',
         'status': ['open', 'open-early', 'open-network', 'protected-network', 'protected', 'protected-early',],
         'dataset': ['hapmap'],
         'additional_facet': [
-            'assays.display_title'
-        ]
+            'assays.display_title'  # assay count
+        ],
+        'skip_default_facets': ['true'],
     }
     IPSC_RELEASED_FILES_SEARCH_PARAMS = {
         'type': 'File',
         'status': ['open', 'open-early', 'open-network', 'protected-network', 'protected', 'protected-early',],
         'dataset': ['lb_fibroblast', 'lb_ipsc_1', 'lb_ipsc_2', 'lb_ipsc_4', 'lb_ipsc_52', 'lb_ipsc_60'],
         'additional_facet': [
-            'assays.display_title'
-        ]
+            'assays.display_title'  # assay count
+        ],
+        'skip_default_facets': ['true'],
     }
     TISSUES_RELEASED_FILES_SEARCH_PARAMS = {
         'type': 'File',
@@ -73,8 +84,10 @@ class SearchBase:
             'ST004-1Q'
         ],
         'additional_facet': [
-            'donors.display_title', 'assays.display_title'
-        ]  # required since this is default_hidden for now
+            'donors.display_title',  # donor count
+            'assays.display_title'   # assay count
+        ],
+        'skip_default_facets': ['true'],
     }
     PRODUCTION_TISSUES_FILES_SEARCH_PARAMS = {
         'type': 'File',
@@ -82,9 +95,11 @@ class SearchBase:
         'sample_summary.studies': ['Production'],
         'dataset!': ['No value'],
         'additional_facet': [
-            'assays.display_title',
-            'file_sets.libraries.analytes.samples.sample_sources.uberon_id'
-        ]
+            'assays.display_title',      # assay count
+            'donors.display_title',      # donor count
+            'sample_summary.tissues'     # tissue-type count
+        ],
+        'skip_default_facets': ['true'],
     }
 
 

--- a/src/encoded/homepage.py
+++ b/src/encoded/homepage.py
@@ -1,14 +1,19 @@
 import traceback
 from datetime import datetime
-from pytz import timezone
 from pyramid.view import view_config
 from snovault.util import debug_log
 from concurrent.futures import ThreadPoolExecutor
 from structlog import getLogger
-from .utils import generate_admin_search_given_params, generate_search_total
+from .utils import generate_admin_search_given_params
 
 
 log = getLogger(__name__)
+
+# Sentinel value used to seed concurrent search results; any slot still holding this
+# after execution indicates the corresponding search raised (see
+# make_concurrent_search_requests). It must never be rendered to a client - the
+# response-assembly extractors below coerce it to 0 / None.
+SEARCH_ERROR_SENTINEL = -1
 
 
 def includeme(config):
@@ -93,7 +98,7 @@ def make_concurrent_search_requests(search_helpers):
         If you use this to make database requests, you will leak connections and start generating server
         side errors!
     """
-    results = [-1] * len(search_helpers)  # watch out for -1 counts as indicative of an error
+    results = [SEARCH_ERROR_SENTINEL] * len(search_helpers)  # watch out for -1 counts as indicative of an error
     with ThreadPoolExecutor() as executor:
         futures = []
         for i, (func, kwargs) in enumerate(search_helpers):
@@ -121,23 +126,43 @@ def extract_desired_facet_from_search(facets, desired_facet_name):
     return {}
 
 
-def generate_unique_facet_count(context, request, search_param, desired_facet):
-    """ Helper function that extracts the number of unique facet terms """
-    search_param['limit'] = 0  # we do not care about search results, just facet counts
-    result = generate_admin_search_given_params(context, request, search_param)
-    facet = extract_desired_facet_from_search(result['facets'], desired_facet)
+def generate_search_result(context, request, search_param):
+    """ Runs a single admin ``limit=0`` search for the given params and returns the whole
+        result. A ``limit=0`` response already contains BOTH the ``total`` and the full
+        ``facets`` block, so one search per distinct param dict is enough to derive every
+        stat (total + each facet count) - see the extractors below. This avoids firing a
+        separate ES round-trip per stat.
+
+        Builds a copy of ``search_param`` with ``limit`` set rather than mutating the
+        (shared, class-level) param dict.
+    """
+    search_param = {**search_param, 'limit': 0}  # we only care about total + facet counts
+    return generate_admin_search_given_params(context, request, search_param)
+
+
+def extract_total_from_search(result):
+    """ Pure extractor: total hit count from a search result. Coerces the error sentinel
+        (or any non-dict result) to 0 so a failed sub-search never renders as -1. """
+    if not isinstance(result, dict):
+        return 0
+    return result.get('total', 0)
+
+
+def extract_unique_facet_count_from_search(result, desired_facet):
+    """ Pure extractor: number of unique terms for ``desired_facet`` in a search result.
+        Degrades gracefully to 0 when the search failed (sentinel/non-dict) or the facet
+        is absent from the response, rather than crashing. """
+    if not isinstance(result, dict):
+        return 0
+    facet = extract_desired_facet_from_search(result.get('facets', []), desired_facet)
     # correct for no value, worst case we check the whole list of facet terms
     # but this is usually a manageable sized list - Will 28 March 2024
-    for term in facet['terms']:
+    terms = facet.get('terms', [])  # missing facet -> 0 rather than KeyError
+    for term in terms:
         if term['key'] == 'No value':
-            return len(facet['terms']) - 1
-    return len(facet['terms'])
+            return len(terms) - 1
+    return len(terms)
 
-
-def generate_colo829_cell_line_file_count(context, request):
-    """ Makes a search subrequest for released + public + restricted files for colo829 """
-    search_param = SearchBase.COLO829_RELEASED_FILES_SEARCH_PARAMS
-    return generate_search_total(context, request, search_param)
 
 def generate_latest_release_date(context, request):
     """ Makes a search subrequest for the latest release date """
@@ -148,76 +173,17 @@ def generate_latest_release_date(context, request):
         return None
     return graph[0].get('file_status_tracking', {}).get('release_dates', {}).get('initial_release_date')
 
-def generate_colo829_assay_count(context, request):
-    """ Makes a search subrequest the same as the above to extract the assay counts for colo829 """
-    search_param = SearchBase.COLO829_RELEASED_FILES_SEARCH_PARAMS
-    return generate_unique_facet_count(context, request, search_param, 'assays.display_title')
 
-
-def generate_hapmap_cell_line_file_count(context, request):
-    """ Makes a search subrequest for released + public + restricted files for hapmap """
-    search_param = SearchBase.HAPMAP_RELEASED_FILES_SEARCH_PARAMS
-    return generate_search_total(context, request, search_param)
-
-
-def generate_hapmap_assay_count(context, request):
-    """ Makes a search subrequest the same as the above to extract the assay counts for hapmap """
-    search_param = SearchBase.HAPMAP_RELEASED_FILES_SEARCH_PARAMS
-    return generate_unique_facet_count(context, request, search_param, 'assays.display_title')
-
-
-def generate_ipsc_cell_line_file_count(context, request):
-    """ Makes a search subrequest for released + public + restricted files for ipsc """
-    search_param = SearchBase.IPSC_RELEASED_FILES_SEARCH_PARAMS
-    return generate_search_total(context, request, search_param)
-
-
-def generate_ipsc_assay_count(context, request):
-    """ Makes a search subrequest the same as the above to extract the assay counts for ipsc """
-    search_param = SearchBase.IPSC_RELEASED_FILES_SEARCH_PARAMS
-    return generate_unique_facet_count(context, request, search_param, 'assays.display_title')
-
-
-def generate_tissue_file_count(context, request):
-    """ Get total file count for benchmarking tissues """
-    search_param = SearchBase.TISSUES_RELEASED_FILES_SEARCH_PARAMS
-    return generate_search_total(context, request, search_param)
-
-
-def generate_tissue_donor_count(context, request):
-    """ Get benchmarking tissue donor count by aggregating on donor """
-    search_param = SearchBase.TISSUES_RELEASED_FILES_SEARCH_PARAMS
-    return generate_unique_facet_count(context, request, search_param, 'donors.display_title')
-
-
-def generate_tissue_assay_count(context, request):
-    """ Get total assay count for benchmarking tissues """
-    search_param = SearchBase.TISSUES_RELEASED_FILES_SEARCH_PARAMS
-    return generate_unique_facet_count(context, request, search_param, 'assays.display_title')
-
-
-def generate_production_file_count(context, request):
-    """ Get total file count for production tissues """
-    search_param = SearchBase.PRODUCTION_TISSUES_FILES_SEARCH_PARAMS
-    return generate_search_total(context, request, search_param)
-
-
-def generate_production_tissue_donor_count(context, request):
-    """ Get production tissue donor count """
-    search_param = SearchBase.PRODUCTION_TISSUES_FILES_SEARCH_PARAMS
-    return generate_unique_facet_count(context, request, search_param, 'donors.display_title')
-
-
-def generate_production_tissue_assay_count(context, request):
-    """ Get production tissue assay counts """
-    search_param = SearchBase.PRODUCTION_TISSUES_FILES_SEARCH_PARAMS
-    return generate_unique_facet_count(context, request, search_param, 'assays.display_title')
-
-
-def generate_production_tissue_type_count(context, request):
-    """ Get production tissue type counts """
-    search_param = SearchBase.PRODUCTION_TISSUES_FILES_SEARCH_PARAMS
-    return generate_unique_facet_count(context, request, search_param, 'sample_summary.tissues')
+def format_release_date(release_date):
+    """ Formats the stored ISO release date as YYYY-MM-DD, or None when it is missing,
+        the error sentinel, or otherwise unparseable (guards against a single failed
+        release-date sub-search 500ing the whole homepage). """
+    if not isinstance(release_date, str):
+        return None
+    try:
+        return datetime.fromisoformat(release_date).strftime("%Y-%m-%d")
+    except ValueError:
+        return None
 
 
 @view_config(route_name='home', request_method=['GET'])
@@ -227,36 +193,34 @@ def home(context, request):
         Uses a threadpool to make several async requests to the ES to extract data for
         homepage statistics
     """
+    # One search per distinct param dict. A single limit=0 response carries both the
+    # 'total' and the full 'facets' block, so every stat below is derived from these six
+    # results via pure extractors rather than a fresh ES round-trip per stat.
     search_results = make_concurrent_search_requests([
         # latest release date
         (generate_latest_release_date, {'context': context, 'request': request}),  # 0
-        # colo829 stats
-        (generate_colo829_assay_count, {'context': context, 'request': request}),  # 1
-        (generate_colo829_cell_line_file_count, {'context': context, 'request': request}),  # 2
-
-        # HapMap stats
-        (generate_hapmap_assay_count, {'context': context, 'request': request}),  # 3
-        (generate_hapmap_cell_line_file_count, {'context': context, 'request': request}),  # 4
-
-        # iPSC & Fibroblast stats
-        (generate_ipsc_assay_count, {'context': context, 'request': request}),  # 5
-        (generate_ipsc_cell_line_file_count, {'context': context, 'request': request}),  # 6
-
-        # Tissue stats
-        (generate_tissue_file_count, {'context': context, 'request': request}),  # 7
-        (generate_tissue_donor_count, {'context': context, 'request': request}),  # 8
-        (generate_tissue_assay_count, {'context': context, 'request': request}),  # 9
-
-        # Production stats
-        (generate_production_file_count, {'context': context, 'request': request}),  # 10
-        (generate_production_tissue_donor_count, {'context': context, 'request': request}),  # 11
-        (generate_production_tissue_assay_count, {'context': context, 'request': request}),  # 12
-        (generate_production_tissue_type_count, {'context': context, 'request': request}),  # 13
+        # per cell-line / tissue-set searches (each yields total + facets)
+        (generate_search_result,
+         {'context': context, 'request': request,
+          'search_param': SearchBase.COLO829_RELEASED_FILES_SEARCH_PARAMS}),  # 1
+        (generate_search_result,
+         {'context': context, 'request': request,
+          'search_param': SearchBase.HAPMAP_RELEASED_FILES_SEARCH_PARAMS}),  # 2
+        (generate_search_result,
+         {'context': context, 'request': request,
+          'search_param': SearchBase.IPSC_RELEASED_FILES_SEARCH_PARAMS}),  # 3
+        (generate_search_result,
+         {'context': context, 'request': request,
+          'search_param': SearchBase.TISSUES_RELEASED_FILES_SEARCH_PARAMS}),  # 4
+        (generate_search_result,
+         {'context': context, 'request': request,
+          'search_param': SearchBase.PRODUCTION_TISSUES_FILES_SEARCH_PARAMS}),  # 5
     ])
+    release_date, colo829, hapmap, ipsc, tissues, production = search_results
     response = {
         '@context': '/home',
         '@id': '/home',
-        'date': datetime.fromisoformat(search_results[0]).strftime("%Y-%m-%d") + ' EST' if search_results[0] else None,
+        'date': format_release_date(release_date),
         '@graph': [
             {
                 "title": "Benchmarking",
@@ -267,10 +231,10 @@ def home(context, request):
                         "link": "/data/benchmarking/COLO829",
                         "figures": [
                             { "value": 2, "unit": "Cell Lines" },
-                            { "value": search_results[1],
+                            { "value": extract_unique_facet_count_from_search(colo829, 'assays.display_title'),
                               "unit": "Assays" },
                             { "value": 0, "unit": "Mutations" },
-                            { "value": search_results[2],
+                            { "value": extract_total_from_search(colo829),
                               "unit": "Files Generated" }
                         ]
                     },
@@ -279,9 +243,9 @@ def home(context, request):
                         "link": "/data/benchmarking/HapMap",
                         "figures": [
                             { "value": 6, "unit": "Cell Lines" },
-                            { "value": search_results[3], "unit": "Assays" },
+                            { "value": extract_unique_facet_count_from_search(hapmap, 'assays.display_title'), "unit": "Assays" },
                             { "value": 0, "unit": "Mutations" },
-                            { "value": search_results[4], "unit": "Files Generated" }
+                            { "value": extract_total_from_search(hapmap), "unit": "Files Generated" }
                         ]
                     },
                     {
@@ -289,19 +253,19 @@ def home(context, request):
                         "link": "/data/benchmarking/iPSC-fibroblasts",
                         "figures": [
                             { "value": 5, "unit": "Cell Lines" },
-                            { "value": search_results[5], "unit": "Assays" },
+                            { "value": extract_unique_facet_count_from_search(ipsc, 'assays.display_title'), "unit": "Assays" },
                             { "value": 0, "unit": "Mutations" },
-                            { "value": search_results[6], "unit": "Files Generated" }
+                            { "value": extract_total_from_search(ipsc), "unit": "Files Generated" }
                         ]
                     },
                     {
                         "title": "Benchmarking Tissues",
                         "link": "/data/benchmarking/donor-st001",
                         "figures": [
-                            { "value": search_results[8], "unit": "Donors" },
+                            { "value": extract_unique_facet_count_from_search(tissues, 'donors.display_title'), "unit": "Donors" },
                             { "value": 4, "unit": "Tissue Types" },
-                            { "value": search_results[9], "unit": "Assays" },
-                            { "value": search_results[7], "unit": "Files Generated" }
+                            { "value": extract_unique_facet_count_from_search(tissues, 'assays.display_title'), "unit": "Assays" },
+                            { "value": extract_total_from_search(tissues), "unit": "Files Generated" }
                         ]
                     }
                 ]
@@ -314,10 +278,10 @@ def home(context, request):
                         "title": "Primary Tissues",
                         "link": "/browse",
                         "figures": [
-                            { "value": search_results[11], "unit": "Donors" },
-                            { "value": search_results[13], "unit": "Tissue Types" },
-                            { "value": search_results[12], "unit": "Assays" },
-                            { "value": search_results[10], "unit": "Files Generated" }
+                            { "value": extract_unique_facet_count_from_search(production, 'donors.display_title'), "unit": "Donors" },
+                            { "value": extract_unique_facet_count_from_search(production, 'sample_summary.tissues'), "unit": "Tissue Types" },
+                            { "value": extract_unique_facet_count_from_search(production, 'assays.display_title'), "unit": "Assays" },
+                            { "value": extract_total_from_search(production), "unit": "Files Generated" }
                         ]
                     }
                 ]

--- a/src/encoded/tests/test_homepage.py
+++ b/src/encoded/tests/test_homepage.py
@@ -131,6 +131,65 @@ def test_home_dedupes_searches_and_never_returns_sentinel(monkeypatch):
     assert_no_sentinel(response)
 
 
+def test_home_stats_resolve_from_declared_additional_facets_only(monkeypatch):
+    """ Finding 1 (skip_default_facets) reconciliation guard: under skip_default_facets
+        ONLY the facets a search declares in `additional_facet` are computed. This mocks
+        each search to return a response containing ONLY that dict's declared facets (no
+        default facet set), and asserts every stat still resolves - in particular the
+        PRODUCTION donor / tissue-type counts, which previously leaned on default facets.
+        Term counts are chosen distinct so a facet resolving to the wrong/absent one is
+        detectable. """
+    # unique term counts per facet so each figure is individually verifiable
+    facet_terms = {
+        'assays.display_title': [{'key': 'a1'}, {'key': 'a2'}, {'key': 'a3'}],          # 3
+        'donors.display_title': [{'key': 'd1'}, {'key': 'd2'}],                          # 2
+        'sample_summary.tissues': [{'key': 't1'}, {'key': 't2'}, {'key': 't3'}, {'key': 't4'}],  # 4
+    }
+
+    def fake_search(context, request, search_param):
+        # Every homepage search must opt out of the default facet set.
+        assert search_param.get('skip_default_facets') == ['true'], search_param
+        if search_param.get('limit') == 1:  # release-date search: no facets needed
+            return {'@graph': [
+                {'file_status_tracking': {'release_dates': {'initial_release_date': '2024-03-28'}}}
+            ]}
+        # Simulate skip_default_facets: return ONLY the declared additional_facet facets.
+        declared = search_param.get('additional_facet', [])
+        for field in declared:
+            assert field in facet_terms, f'test needs term data for declared facet {field}'
+        return {
+            'total': 7,
+            'facets': [{'field': field, 'terms': facet_terms[field]} for field in declared],
+        }
+
+    monkeypatch.setattr(homepage, 'generate_admin_search_given_params', fake_search)
+    response = home(None, testing.DummyRequest())
+
+    benchmarking, production = response['@graph']
+    colo829, hapmap, ipsc, tissues = benchmarking['categories']
+
+    def figures(category):
+        return {f['unit']: f['value'] for f in category['figures']}
+
+    # cell-line blocks read only the assays facet + total
+    for block in (colo829, hapmap, ipsc):
+        assert figures(block)['Assays'] == 3
+        assert figures(block)['Files Generated'] == 7
+
+    # tissues reads donors + assays + total
+    assert figures(tissues)['Donors'] == 2
+    assert figures(tissues)['Assays'] == 3
+    assert figures(tissues)['Files Generated'] == 7
+
+    # PRODUCTION is the reconciliation-critical one: donor + tissue-type + assay must all
+    # resolve from the declared additional_facet (they'd be 0 if the facet weren't declared)
+    prod = figures(production['categories'][0])
+    assert prod['Donors'] == 2
+    assert prod['Tissue Types'] == 4
+    assert prod['Assays'] == 3
+    assert prod['Files Generated'] == 7
+
+
 @pytest.mark.workbook
 def test_home_page_workbook(es_testapp, workbook):
     """ Tests that we get appropriate counts based on workbook inserts """

--- a/src/encoded/tests/test_homepage.py
+++ b/src/encoded/tests/test_homepage.py
@@ -1,6 +1,15 @@
 import re
 import pytest
-from ..homepage import extract_desired_facet_from_search
+from pyramid import testing
+from .. import homepage
+from ..homepage import (
+    extract_desired_facet_from_search,
+    extract_total_from_search,
+    extract_unique_facet_count_from_search,
+    format_release_date,
+    home,
+    SEARCH_ERROR_SENTINEL,
+)
 
 
 def test_extract_desired_facet():
@@ -9,8 +18,117 @@ def test_extract_desired_facet():
         {'field': 'type', 'title': 'Data Type', 'total': 0, 'hide_from_view': True, 'aggregation_type': 'terms',
          'terms': [{'key': 'File', 'doc_count': 7}, {'key': 'Item', 'doc_count': 7}]}
     ]
-    assert extract_desired_facet_from_search(example_facets, 'type') is not {}
+    assert extract_desired_facet_from_search(example_facets, 'type') == example_facets[0]
+    # not-found returns an empty dict (falsy)
     assert not extract_desired_facet_from_search(example_facets, 'not-found')
+
+
+def test_extract_desired_facet_original_terms():
+    """ When a facet carries a group_by_field, original_terms is promoted to terms """
+    example_facets = [
+        {'field': 'assays.display_title', 'title': 'Assay',
+         'terms': [{'key': 'grouped', 'doc_count': 1}],
+         'original_terms': [
+             {'key': 'bulk_wgs', 'doc_count': 3},
+             {'key': 'bulk_rna_seq', 'doc_count': 2},
+         ]}
+    ]
+    facet = extract_desired_facet_from_search(example_facets, 'assays.display_title')
+    assert facet['terms'] == example_facets[0]['original_terms']
+
+
+def test_extract_total_from_search():
+    """ total is read from a dict result, sentinel/non-dict coerces to 0 """
+    assert extract_total_from_search({'total': 42}) == 42
+    assert extract_total_from_search({}) == 0
+    # F3: the error sentinel never renders as -1
+    assert extract_total_from_search(SEARCH_ERROR_SENTINEL) == 0
+    assert extract_total_from_search(None) == 0
+
+
+def _facet_result(field, term_keys):
+    return {'total': 0, 'facets': [
+        {'field': field, 'terms': [{'key': k, 'doc_count': 1} for k in term_keys]}
+    ]}
+
+
+def test_extract_unique_facet_count_basic():
+    """ Counts unique facet terms """
+    result = _facet_result('assays.display_title', ['bulk_wgs', 'bulk_rna_seq', 'bulk_mas_iso_seq'])
+    assert extract_unique_facet_count_from_search(result, 'assays.display_title') == 3
+
+
+def test_extract_unique_facet_count_excludes_no_value():
+    """ 'No value' is not counted as a real term """
+    result = _facet_result('donors.display_title', ['ST001', 'ST002', 'No value'])
+    assert extract_unique_facet_count_from_search(result, 'donors.display_title') == 2
+
+
+def test_extract_unique_facet_count_missing_facet():
+    """ F4: a facet absent from the response degrades to 0, not a KeyError """
+    result = _facet_result('assays.display_title', ['bulk_wgs'])
+    assert extract_unique_facet_count_from_search(result, 'donors.display_title') == 0
+
+
+def test_extract_unique_facet_count_sentinel():
+    """ F3: sentinel/non-dict result yields 0 rather than crashing """
+    assert extract_unique_facet_count_from_search(SEARCH_ERROR_SENTINEL, 'assays.display_title') == 0
+    assert extract_unique_facet_count_from_search(None, 'assays.display_title') == 0
+
+
+def test_format_release_date():
+    """ F5/F6: plain YYYY-MM-DD (no ' EST'), and safe on bad/missing/sentinel input """
+    assert format_release_date('2024-03-28') == '2024-03-28'
+    assert format_release_date('2024-03-28T12:00:00') == '2024-03-28'
+    # F5: no timezone suffix appended
+    assert ' EST' not in format_release_date('2024-03-28')
+    # F6: sentinel / non-str / unparseable degrade to None instead of raising
+    assert format_release_date(SEARCH_ERROR_SENTINEL) is None
+    assert format_release_date(None) is None
+    assert format_release_date('not-a-date') is None
+
+
+def test_home_dedupes_searches_and_never_returns_sentinel(monkeypatch):
+    """ F1/F3: home() runs exactly one search per distinct param dict (6 total: 1 date +
+        5 result dicts, down from 14), and no figure value is ever the -1 sentinel. """
+    calls = []
+    canned = {
+        'total': 7,
+        'facets': [
+            {'field': 'assays.display_title', 'terms': [{'key': 'a'}, {'key': 'b'}]},
+            {'field': 'donors.display_title', 'terms': [{'key': 'd1'}]},
+            {'field': 'sample_summary.tissues', 'terms': [{'key': 't1'}, {'key': 'No value'}]},
+        ],
+        '@graph': [
+            {'file_status_tracking': {'release_dates': {'initial_release_date': '2024-03-28'}}}
+        ],
+    }
+
+    def fake_search(context, request, search_param):
+        calls.append(dict(search_param))
+        return canned
+
+    monkeypatch.setattr(homepage, 'generate_admin_search_given_params', fake_search)
+    response = home(None, testing.DummyRequest())
+
+    # exactly 6 ES searches (1 release date + 5 per-dict result searches)
+    assert len(calls) == 6
+    # every result search is a limit=0 search (the date search uses the dict's own limit=1)
+    assert sum(1 for c in calls if c.get('limit') == 0) == 5
+    # F5: date is a bare YYYY-MM-DD with no timezone suffix
+    assert response['date'] == '2024-03-28'
+
+    def assert_no_sentinel(node):
+        if isinstance(node, dict):
+            for value in node.values():
+                assert_no_sentinel(value)
+        elif isinstance(node, list):
+            for value in node:
+                assert_no_sentinel(value)
+        else:
+            assert node != SEARCH_ERROR_SENTINEL
+
+    assert_no_sentinel(response)
 
 
 @pytest.mark.workbook
@@ -19,7 +137,7 @@ def test_home_page_workbook(es_testapp, workbook):
     home = es_testapp.get('/home').json
     # Validate some basic structure
     assert home['@context'] == '/home'
-    assert home['date'] is None or re.match(r'^\d{4}-\d{2}-\d{2}( \w+)?$', home['date'])
+    assert home['date'] is None or re.match(r'^\d{4}-\d{2}-\d{2}$', home['date'])
     assert '@graph' in home
     assert 'categories' in home['@graph'][0]
     assert 'figures' in home['@graph'][0]['categories'][0]
@@ -31,3 +149,8 @@ def test_home_page_workbook(es_testapp, workbook):
     # check assay count for colo829 (bulk_wgs, bulk_mas_iso_seq, bulk_rna_seq)
     assert home['@graph'][0]['categories'][0]['figures'][1]['value'] == 3
     assert home['@graph'][0]['categories'][0]['figures'][1]['unit'] == 'Assays'
+    # no figure value should ever be the error sentinel (F3)
+    for section in home['@graph']:
+        for category in section['categories']:
+            for figure in category['figures']:
+                assert figure['value'] != SEARCH_ERROR_SENTINEL

--- a/src/encoded/tests/test_visualization.py
+++ b/src/encoded/tests/test_visualization.py
@@ -738,3 +738,130 @@ def test_data_matrix_aggregations_flatten_composite_keys():
         "donor": "D1",
         "counts": {"files": 6, "total_coverage": 1.0, "donors": 1},
     }]
+
+
+# ---------------------------------------------------------------------------
+# Efficiency-fix guardrails (chart endpoints)
+# ---------------------------------------------------------------------------
+
+def _run_view_capturing(view, search_result, request):
+    """Invoke a view, capturing the subreq path and custom_aggregations passed to ES."""
+    captured = {}
+
+    def fake_make_subreq(req, path):
+        captured["path"] = path
+        return None
+
+    def fake_search(context, subreq, custom_aggregations=None):
+        captured["custom_aggregations"] = custom_aggregations
+        return search_result
+
+    with patch.object(visualization, "make_search_subreq", fake_make_subreq), \
+            patch.object(visualization, "perform_search_request", fake_search):
+        result = view(None, request)
+    return result, captured
+
+
+def test_date_histogram_skips_default_facets():
+    """Fix A: date_histogram_aggregations tells ES to skip the (discarded) default facets."""
+    search_result = {
+        "aggregations": {
+            "weekly_interval_file_status_tracking.status_tracking.uploading": {"buckets": []}
+        },
+        "total": 0,
+    }
+    request = FakeRequest(json_body={"search_query_params": {"type": ["File"]}})
+    result, captured = _run_view_capturing(
+        visualization.date_histogram_aggregations, search_result, request
+    )
+    assert "skip_default_facets=true" in captured["path"]
+    # custom aggregations still flow through and the response keeps its aggregations
+    assert captured["custom_aggregations"]  # non-empty date-histogram agg
+    assert "aggregations" in result
+
+
+def test_bar_plot_skips_default_facets():
+    """Fix A: bar_plot_chart tells ES to skip the (discarded) default facets."""
+    request = FakeRequest(json_body={
+        "search_query_params": {"type": ["File"]},
+        "fields_to_aggregate_for": ["data_type", "file_format"],
+    })
+    result, captured = _run_view_capturing(
+        visualization.bar_plot_chart, _bar_plot_search_result(), request
+    )
+    assert "skip_default_facets=true" in captured["path"]
+    assert "terms" in result and "total" in result
+
+
+def test_bar_plot_per_bucket_aggs_are_slim():
+    """Fix B: per-bucket aggs request only total_donors + all_donors_ids; the top-level
+    total keeps the full sum definition (total_tissues/assays/file_size)."""
+    request = FakeRequest(json_body={
+        "search_query_params": {"type": ["File"]},
+        "fields_to_aggregate_for": ["data_type", "file_format"],
+    })
+    _, captured = _run_view_capturing(
+        visualization.bar_plot_chart, _bar_plot_search_result(), request
+    )
+    aggs = captured["custom_aggregations"]
+
+    # Top-level total keeps every sub-aggregation (read at the top level only).
+    for key in ("total_donors", "total_tissues", "total_assays", "total_file_size", "all_donors_ids"):
+        assert key in aggs
+
+    trimmed = {"total_tissues", "total_assays", "total_file_size"}
+    # Per-bucket (field_0) aggs carry the two consumed fields plus the nested field_1,
+    # but NOT the trimmed sub-aggregations.
+    field_0_aggs = aggs["field_0"]["aggs"]
+    assert {"total_donors", "all_donors_ids"} <= set(field_0_aggs)
+    assert trimmed.isdisjoint(field_0_aggs)
+    # The terminal (deepest) level carries ONLY the two consumed fields.
+    field_1_aggs = field_0_aggs["field_1"]["aggs"]
+    assert set(field_1_aggs) == {"total_donors", "all_donors_ids"}
+
+
+def test_bar_plot_response_unchanged_after_slim_aggs():
+    """Fix B snapshot: the multi-field response is identical to the pre-refactor shape
+    (the trimmed per-bucket fields never entered the response)."""
+    request = FakeRequest(json_body={
+        "search_query_params": {"type": ["File"]},
+        "fields_to_aggregate_for": ["data_type", "file_format"],
+    })
+    result = _run_view(visualization.bar_plot_chart, _bar_plot_search_result(), request)
+    _strip_volatile(result)
+
+    assert result == {
+        "field": "data_type",
+        "terms": {
+            "Aligned Reads": {
+                "term": "Aligned Reads",
+                "field": "file_format",
+                "total": {"doc_count": 60, "files": 60, "donors": 7, "all_donors_ids": ["D1", "D2"]},
+                "terms": {
+                    "bam": {"doc_count": 40, "files": 40, "donors": 5, "all_donors_ids": ["D1"]},
+                    "cram": {"doc_count": 20, "files": 20, "donors": 3, "all_donors_ids": ["D2"]},
+                },
+                "other_doc_count": 1,
+            },
+            "Unaligned Reads": {
+                "term": "Unaligned Reads",
+                "field": "file_format",
+                "total": {"doc_count": 40, "files": 40, "donors": 4, "all_donors_ids": ["D3"]},
+                "terms": {
+                    "fastq": {"doc_count": 40, "files": 40, "donors": 4, "all_donors_ids": ["D3"]},
+                },
+                "other_doc_count": 0,
+            },
+        },
+        "total": {
+            "doc_count": 100,
+            "files": 100,
+            "donors": 10,
+            "assays": 4,
+            "tissues": 3,
+            "file_size": 5000,
+            "all_donors_ids": ["D1", "D2", "D3"],
+        },
+        "other_doc_count": 2,
+        "meta": {},
+    }

--- a/src/encoded/utils.py
+++ b/src/encoded/utils.py
@@ -34,19 +34,23 @@ def generate_admin_search_given_params(context, request, search_param):
     """ Helper function for below that generates/executes a search given params AS ADMIN
         BE EXTREMELY CAREFUL WITH THIS - do NOT use to return results directly
     """
+    subreq = make_search_subreq(request, f'/search?{urlencode(search_param, True)}')
     # VERY IMPORTANT - the below lines eliminate database calls, which is necessary
     # as making calls (as explained above) leaks connections - Will March 29 2024
-    request.remote_user = 'IMPORT'
-    if 'HTTP_AUTHORIZATION' in request.environ:
-        del request.environ['HTTP_AUTHORIZATION']
-    subreq = make_search_subreq(request, f'/search?{urlencode(search_param, True)}')
+    # These are set on the *subrequest* (not the shared parent request) so that
+    # concurrent worker threads never mutate/copy the parent request.environ at the
+    # same time - see homepage.make_concurrent_search_requests - Will 8 July 2026
+    subreq.remote_user = 'IMPORT'
+    if 'HTTP_AUTHORIZATION' in subreq.environ:
+        del subreq.environ['HTTP_AUTHORIZATION']
     subreq.cookies = {}
     return search(context, subreq)
 
 
 def generate_search_total(context, request, search_param):
     """ Helper function that executes a search and extracts the total """
-    search_param['limit'] = 0  # we do not care about search results, just total
+    # Build a copy with limit=0 rather than mutating the (possibly shared) param dict
+    search_param = {**search_param, 'limit': 0}  # we do not care about search results, just total
     return generate_admin_search_given_params(context, request, search_param)['total']
 
 

--- a/src/encoded/visualization.py
+++ b/src/encoded/visualization.py
@@ -198,6 +198,10 @@ def date_histogram_aggregations(context, request):
                 outer_date_histogram_agg[interval + '_interval_' + dh_field]['aggs'] = histogram_sub_aggs
 
     search_param_lists['limit'] = search_param_lists['from'] = [0]
+    # We discard the default File facets from this response (see FIELDS_TO_DELETE), so skip
+    # computing them entirely. The custom date-histogram aggregations still run because
+    # snovault gates them on size==0 (which limit=0 gives us), not on facets being present.
+    search_param_lists['skip_default_facets'] = ['true']
     subreq = make_search_subreq(request, '{}?{}'.format('/search/', urlencode(search_param_lists, True)))
     search_result = perform_search_request(None, subreq, custom_aggregations=outer_date_histogram_agg)
 
@@ -292,6 +296,14 @@ def bar_plot_chart(context, request):
             }
         }
     }
+    # Per-bucket aggregations only ever read `total_donors` and `all_donors_ids`
+    # (see format_bucket_result); `total_tissues`/`total_assays`/`total_file_size`
+    # are consumed only at the top-level total. Computing the full definition at
+    # every bucket at every nesting depth wastes ES work, so nest this slim subset.
+    PER_BUCKET_AGGREGATION_DEFINITION = {
+        "total_donors": SUM_AGGREGATION_DEFINITION["total_donors"],
+        "all_donors_ids": SUM_AGGREGATION_DEFINITION["all_donors_ids"],
+    }
 
     isFileTypeSearch = False
     try:
@@ -319,7 +331,7 @@ def bar_plot_chart(context, request):
                 "missing": TERM_NAME_FOR_NO_VALUE,
                 "size": MAX_BUCKET_COUNT
             },
-            "aggs": deepcopy(SUM_AGGREGATION_DEFINITION)
+            "aggs": deepcopy(PER_BUCKET_AGGREGATION_DEFINITION)
         }
     }
 
@@ -346,11 +358,15 @@ def bar_plot_chart(context, request):
                 "missing": TERM_NAME_FOR_NO_VALUE,
                 "size": MAX_BUCKET_COUNT
             },
-            "aggs": deepcopy(SUM_AGGREGATION_DEFINITION)
+            "aggs": deepcopy(PER_BUCKET_AGGREGATION_DEFINITION)
         }
         curr_field_aggs = curr_field_aggs['field_' + str(field_index)]['aggs']
 
     search_param_lists['limit'] = search_param_lists['from'] = [0]
+    # We discard the default File facets from this response (see FIELDS_TO_DELETE), so skip
+    # computing them entirely. The custom bar-plot aggregations still run because snovault
+    # gates them on size==0 (which limit=0 gives us), not on facets being present.
+    search_param_lists['skip_default_facets'] = ['true']
     subreq = make_search_subreq(request, '{}?{}'.format('/search/', urlencode(search_param_lists, True)))
     search_result = perform_search_request(None, subreq, custom_aggregations=primary_agg)
 


### PR DESCRIPTION
## Summary

Efficiency and correctness fixes to backend endpoints, in three workstreams. All changes are behavior-preserving except the one F5 date-format change explicitly flagged below.

### 1. Homepage `/home` findings F1–F6 (`homepage.py`, `utils.py`)

The endpoint previously fired **14** ES subrequests even though the six `SearchBase` param dicts only need one query each (a single `limit=0` response carries both `total` and `facets`). It now fires **6** and derives every stat via pure extractors.

- **F1** — dedupe redundant ES searches (14 → 6); one search per distinct param dict.
- **F2** — stop mutating shared state from worker threads: param dicts copied (`{**dict, 'limit': 0}`); `remote_user`/auth-header stripping moved onto the subrequest instead of the shared parent `request`.
- **F3** — the `-1` error sentinel is coerced to `0` in response assembly (value-only, same keys/shape).
- **F4** — missing-facet loop guarded with `facet.get('terms', [])` → `0` instead of `KeyError`.
- **F5** — removed dead `pytz` import + dropped the hardcoded `" EST"` suffix. ⚠️ **Observable change:** `date` is now a bare `YYYY-MM-DD` string (was `YYYY-MM-DD EST`). **Please check front-end consumers of `/home`'s `date` field before merging.**
- **F6** — release-date parse guarded (`isinstance(str)` + `try/except`) → degrades to `None` instead of 500ing.

(F7 broader test backlog and F8 caching are out of scope / deferred.)

### 2. Homepage default-facet reduction (perf review Finding 1, `homepage.py`)

Each `type=File` sub-search computed the full File default facet set (~21 aggregations) but the homepage reads at most three facets. Each `SearchBase.*` dict now passes `skip_default_facets=true` and declares (via `additional_facet`) only the facets its stats read.

- **Correctness-critical reconciliation:** `PRODUCTION_TISSUES` previously declared only `['assays.display_title', ...uberon_id]`, but its donor and tissue-type stats read `donors.display_title` and `sample_summary.tissues` (which worked only because they were *default* facets). Both are now declared in `additional_facet`, and the never-read `...uberon_id` facet is dropped. COLO829/HAPMAP/IPSC (assays) and TISSUES (donors+assays) were already complete.
- **Behavior-preserving**, verified by source analysis (snovault 11.32.1 `_initialize_additional_facets` appends the identical schema facet config for an in-schema `additional_facet` field as the default loop does) + a mocked reconciliation unit test (each search returns ONLY its declared facets, proving every stat still resolves). CI's workbook COLO829 assay assertion exercises the `group_by_field` → `original_terms` facet path under `skip_default_facets`.

### 3. Chart-endpoint efficiency fixes (perf review Findings 2 & 3, `visualization.py`)

- **Finding 2** — `date_histogram_aggregations` and `bar_plot_chart` issue a `limit=0` `/search` whose default facet set is immediately discarded (`FIELDS_TO_DELETE`). Both now pass `skip_default_facets=true`; the custom aggregations survive because snovault gates them on `size==0`, not on facets. `data_matrix_aggregations` is deliberately untouched (it uses facets).
- **Finding 3** — `bar_plot_chart` deep-copied the full 5-sub-agg `SUM_AGGREGATION_DEFINITION` into every bucket at every nesting depth, but per bucket only `total_donors`/`all_donors_ids` are read (`total_tissues`/`total_assays`/`total_file_size` are read only at the top-level total). A slim `PER_BUCKET_AGGREGATION_DEFINITION` is now nested at the per-bucket levels; the top-level total keeps the full definition. Response shape unchanged.

## Tests

- `test_homepage.py`: unit tests for the pure extractors (sentinel/missing-facet/`original_terms`/date paths), a test asserting `home()` fires exactly 6 searches and never returns `-1`, and a reconciliation test proving every stat resolves from declared `additional_facet` facets only (incl. PRODUCTION donor/tissue-type). Fixed the pre-existing no-op `is not {}` assertion.
- `test_visualization.py`: guardrails asserting both chart endpoints set `skip_default_facets`, that per-bucket aggs are slim while the top-level total keeps all sub-aggs, and a snapshot that the multi-field `bar_plot` response is unchanged.

**Local test execution note:** the full pytest suite could not be run in this worktree (the repo's autouse `conn`/Postgres fixture is unavailable and the local Poetry toolchain is broken). The pure-function, `home()`, and chart-endpoint logic were verified standalone against this branch's code using a working interpreter; the integration/workbook paths are validated by CI.

## Versioning

Bumps `pyproject.toml` to `2.3.2` with a combined `CHANGELOG.rst` entry covering all three workstreams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
