### PR TITLE
Fix label_overrides not applying to FacetCharts on Donor/Protected Donor browse pages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,10 +8,18 @@ Change Log
 ----------
 
 
+2.3.6
+=====
+
+`PR 711: Fix label_overrides not applying to FacetCharts on Donor/Protected Donor browse pages <https://github.com/smaht-dac/smaht-portal/pull/711>`_
+
+* Fixes a bug where label_overrides were not being applied to FacetCharts on Donor and Protected Donor browse pages
+
+
 2.3.5
 =====
 
-'PR 710: update annotated filename for SupplementaryFiles with category Annotation <https://github.com/smaht-dac/smaht-portal/pull/710>'_
+`PR 710: update annotated filename for SupplementaryFiles with category Annotation <https://github.com/smaht-dac/smaht-portal/pull/710>`_
 
 * added genome annotation data class for benchmarking cell lines - for supplementary files to annotated_file_name script
 
@@ -19,7 +27,7 @@ Change Log
 2.3.4
 =====
 
-`PR #713: refactor: load donor browse row data progressively with a concurrency-limited queue <https://github.com/smaht-dac/smaht-portal/pull/713>`_
+`PR 713: refactor: load donor browse row data progressively with a concurrency-limited queue <https://github.com/smaht-dac/smaht-portal/pull/713>`_
 
 * Donor browse: load per-donor file data (tissues, assays, file count, file size) via a
   concurrency-limited queue (``DonorDataProvider``) so rows populate in display order

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "2.3.5"
+version = "2.3.6"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/browse/components/FacetCharts.js
+++ b/src/encoded/static/components/browse/components/FacetCharts.js
@@ -10,38 +10,49 @@ import { ChartDataController } from './../../viz/chart-data-controller';
 import * as BarPlot from './../../viz/BarPlot';
 import { termTransformFxnWithOverrides } from './../SearchView';
 
-function termTransformFxnWithChartAliases(facets = null){
+function getCandidateFields(field, fieldList) {
+    if (typeof field !== 'string') return [];
+
+    // Bar plot aggregation fields do not always match the browse facet field exactly
+    // (e.g. `sequencing.*` in the chart vs `file_sets.sequencing.*` in facets). Match
+    // by equivalent trailing path so chart labels can still use facet label_overrides.
+    const matchingFields = fieldList
+        .filter((facetField) => {
+            if (typeof facetField !== 'string') return false;
+            return (
+                facetField === field ||
+                facetField.endsWith(`.${field}`) ||
+                field.endsWith(`.${facetField}`)
+            );
+        })
+        .sort((a, b) => {
+            if (a === field) return -1;
+            if (b === field) return 1;
+            return a.length - b.length;
+        });
+
+    return matchingFields.length > 0 ? matchingFields : [field];
+}
+
+function termTransformFxnWithChartAliases(facets = null, schemas = null){
     const baseTransform = termTransformFxnWithOverrides(facets);
 
-    const getCandidateFields = (field) => {
-        if (typeof field !== 'string') return [];
+    const contextFacetFields = facets
+        .map(({ field: facetField }) => facetField)
+        .filter((facetField) => typeof facetField === 'string');
 
-        // Bar plot aggregation fields do not always match the browse facet field exactly
-        // (e.g. `sequencing.*` in the chart vs `file_sets.sequencing.*` in facets). Match
-        // by equivalent trailing path so chart labels can still use facet label_overrides.
-        const matchingFields = facets
-            .map(({ field: facetField }) => facetField)
-            .filter((facetField) => {
-                if (typeof facetField !== 'string') return false;
-                return (
-                    facetField === field ||
-                    facetField.endsWith(`.${field}`) ||
-                    field.endsWith(`.${facetField}`)
-                );
-            })
-            .sort((a, b) => {
-                if (a === field) return -1;
-                if (b === field) return 1;
-                return a.length - b.length;
-            });
-
-        return matchingFields.length > 0 ? matchingFields : [field];
-    };
+    // The chart's aggregated fields (tissues, sequencers, assays, etc.) are always
+    // File-related, even on Donor/ProtectedDonor browse pages where `context.facets`
+    // is the Donor/ProtectedDonor search context and has no such fields at all. Fall
+    // back to the File schema's own facets (which is where these label_overrides are
+    // actually authored) so charts on those pages can resolve them too.
+    const fileSchemaFacets = (schemas && schemas.File && schemas.File.facets) || {};
+    const fileSchemaFacetFields = Object.keys(fileSchemaFacets);
 
     return function(field, key){
-        const candidateFields = getCandidateFields(field);
-        for (let i = 0; i < candidateFields.length; i++) {
-            const candidateField = candidateFields[i];
+        const contextCandidates = getCandidateFields(field, contextFacetFields);
+        for (let i = 0; i < contextCandidates.length; i++) {
+            const candidateField = contextCandidates[i];
             // Read label overrides directly here so this stays scoped to facet charts and
             // does not broaden behavior of the shared browse/search term transformer.
             const override = facets.find(
@@ -51,6 +62,15 @@ function termTransformFxnWithChartAliases(facets = null){
                 return override;
             }
         }
+
+        const schemaCandidates = getCandidateFields(field, fileSchemaFacetFields);
+        for (let i = 0; i < schemaCandidates.length; i++) {
+            const override = fileSchemaFacets[schemaCandidates[i]]?.label_overrides?.[key];
+            if (typeof override !== 'undefined') {
+                return override;
+            }
+        }
+
         return baseTransform(field, key);
     };
 }
@@ -288,7 +308,7 @@ export class FacetCharts extends React.PureComponent {
         const donorFilters = searchFilters.contextFiltersToExpSetFilters(context && context.filters, browseBaseParams);
         // Use a chart-local term resolver so facet label_overrides are applied in chart bars,
         // popovers, and legend even when chart aggregation fields use an alias of the facet field.
-        const termLabelTransform = termTransformFxnWithChartAliases((context && context.facets) || []);
+        const termLabelTransform = termTransformFxnWithChartAliases((context && context.facets) || [], schemas);
         let height = show === 'small' ? (mapping === 'all' ? 330 : 370) : 370;
         let width;
 


### PR DESCRIPTION
- `FacetCharts` resolved `label_overrides` (e.g. `sequencers.display_title` → "Multiple Platforms", `assays.display_title` → "Multiple Assays") only from `context.facets`. This worked on `BrowseView.js` (File browse), where `context` is the File search-results context, but failed on `BrowseDonorVizWrapper.js` (Donor/Protected Donor browse pages), where `context` is the Donor/ProtectedDonor search-results context and never contains those File-specific facet fields at all — even though the chart itself always aggregates File-related fields regardless of which page hosts it.
- `termTransformFxnWithChartAliases` now also accepts `schemas` and falls back to `schemas.File.facets` (the raw File JSON schema facets dict) when the current `context.facets` has no matching entry, so the override resolves correctly on Donor/Protected Donor pages too, with no change to existing File-browse behavior.