### PR TITLE
refactor: load donor browse row data progressively with a concurrency-limited queue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,17 @@ Change Log
 ----------
 
 
+2.3.4
+=====
+
+`PR #713: refactor: load donor browse row data progressively with a concurrency-limited queue <https://github.com/smaht-dac/smaht-portal/pull/713>`_
+
+* Donor browse: load per-donor file data (tissues, assays, file count, file size) via a
+  concurrency-limited queue (``DonorDataProvider``) so rows populate in display order
+* Each donor issues one ``/peek-metadata/`` request with ``skip_default_facets=true``, cutting
+  Elasticsearch aggregation work from 21 default File facets to 3
+
+
 2.3.3
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "2.3.3"
+version = "2.3.4"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/metadata.py
+++ b/src/encoded/metadata.py
@@ -1360,9 +1360,8 @@ def peek_metadata(context, request):
 
     # GET path — forward URL params verbatim to /search. Type-agnostic; the
     # caller gets the same facets `/search?<their-params>` would return,
-    # which is what the legacy fallback did. This preserves callers like
-    # ProtectedDonorViewDataCards.js that read default facets (e.g. `type`)
-    # from the response.
+    # which is what the legacy fallback did. Callers that use
+    # `skip_default_facets=true` must explicitly request every facet they read.
     if isinstance(args, Response):
         return _facets_via_search(request, request.params)
 

--- a/src/encoded/metadata.py
+++ b/src/encoded/metadata.py
@@ -1045,7 +1045,7 @@ def _facets_via_search(request, params):
     aggregation coordination timeout). Everything else goes through here.
     """
     forwarded = MultiDict()
-    for key in params.keys():
+    for key in dict.fromkeys(params.keys()):
         if key in ('limit', 'from'):
             continue
         for value in params.getall(key):

--- a/src/encoded/static/components/browse/browse-view/BrowseDonor.js
+++ b/src/encoded/static/components/browse/browse-view/BrowseDonor.js
@@ -5,10 +5,7 @@ import { Schemas } from '../../util';
 import { BrowseViewControllerWithSelections } from '../../static-pages/components/TableControllerWithSelections';
 import { BrowseViewAboveFacetListComponent } from './BrowseViewAboveFacetListComponent';
 import { BrowseViewAboveSearchTableControls } from './BrowseViewAboveSearchTableControls';
-import {
-    BROWSE_LINKS,
-    NoResultsBrowseModal,
-} from '../BrowseView';
+import { BROWSE_LINKS, NoResultsBrowseModal } from '../BrowseView';
 import { transformedFacets } from '../SearchView';
 import { BrowseDonorVizWrapper } from './BrowseDonorVizWrapper';
 import { DonorMetadataDownloadButton } from '../../shared/DonorMetadataDownloadButton';
@@ -38,7 +35,6 @@ const BrowseDonorSearchTable = (props) => {
         selectedItems,
         onSelectItem,
         onResetSelectedItems,
-        userDownloadAccess,
     } = props;
 
     const facets = transformedFacets(context, currentAction, schemas);
@@ -75,9 +71,7 @@ const BrowseDonorSearchTable = (props) => {
         createBrowseDonorColumnExtensionMap(selectedFileProps);
 
     const facetListSortFxns = {
-        hardy_scale: (a, b) => {
-            return a.key - b.key;
-        },
+        hardy_scale: (a, b) => a.key - b.key,
     };
 
     return (
@@ -106,8 +100,8 @@ const BrowseDonorSearchTable = (props) => {
 };
 
 // Banner Component to allow redirect to ProtectedDonor view after login
-const RedirectBanner = ({ href }) => {
-    return href ? (
+const RedirectBanner = ({ href }) =>
+    href ? (
         <div className="callout data-available">
             <span className="callout-text">
                 <i className="icon icon-users fas"></i> You are currently
@@ -120,7 +114,6 @@ const RedirectBanner = ({ href }) => {
             </span>
         </div>
     ) : null;
-};
 
 // Browse Donor Body Component
 export const BrowseDonorBody = (props) => {
@@ -128,11 +121,13 @@ export const BrowseDonorBody = (props) => {
     const { context, session, href, userDownloadAccess, isAccessResolved } =
         props;
 
-    useEffect(() => {
-        if (session && userDownloadAccess?.['protected']) {
-            setShowRedirectBanner(true);
-        }
-    }, [session, userDownloadAccess]);
+    useEffect(
+        () =>
+            session && userDownloadAccess?.['protected']
+                ? setShowRedirectBanner(true)
+                : undefined,
+        [session, userDownloadAccess]
+    );
 
     return (
         <DonorDataProvider>

--- a/src/encoded/static/components/browse/browse-view/BrowseDonor.js
+++ b/src/encoded/static/components/browse/browse-view/BrowseDonor.js
@@ -131,23 +131,21 @@ export const BrowseDonorBody = (props) => {
 
     return (
         <DonorDataProvider>
-            <>
-                {showRedirectBanner && <RedirectBanner href={props?.href} />}
-                <BrowseDonorVizWrapper {...props} mapping="donor" />
-                <hr />
-                <BrowseViewControllerWithSelections {...props}>
-                    <BrowseDonorSearchTable />
-                </BrowseViewControllerWithSelections>
-                {context?.total === 0 && (
-                    <NoResultsBrowseModal
-                        type="donor"
-                        context={context}
-                        href={href}
-                        userDownloadAccess={userDownloadAccess}
-                        isAccessResolved={isAccessResolved}
-                    />
-                )}
-            </>
+            {showRedirectBanner && <RedirectBanner href={props.href} />}
+            <BrowseDonorVizWrapper {...props} mapping="donor" />
+            <hr />
+            <BrowseViewControllerWithSelections {...props}>
+                <BrowseDonorSearchTable />
+            </BrowseViewControllerWithSelections>
+            {context?.total === 0 && (
+                <NoResultsBrowseModal
+                    type="donor"
+                    context={context}
+                    href={href}
+                    userDownloadAccess={userDownloadAccess}
+                    isAccessResolved={isAccessResolved}
+                />
+            )}
         </DonorDataProvider>
     );
 };

--- a/src/encoded/static/components/browse/browse-view/BrowseDonor.js
+++ b/src/encoded/static/components/browse/browse-view/BrowseDonor.js
@@ -6,7 +6,6 @@ import { BrowseViewControllerWithSelections } from '../../static-pages/component
 import { BrowseViewAboveFacetListComponent } from './BrowseViewAboveFacetListComponent';
 import { BrowseViewAboveSearchTableControls } from './BrowseViewAboveSearchTableControls';
 import {
-    BROWSE_STATUS_FILTERS,
     BROWSE_LINKS,
     NoResultsBrowseModal,
 } from '../BrowseView';
@@ -17,6 +16,7 @@ import {
     customRenderDetailPane,
     createBaseDonorColumnExtensionMap,
 } from './BrowseDonorBase';
+import { DonorDataProvider } from './BrowseDonorDataProvider';
 
 export function createBrowseDonorColumnExtensionMap(props) {
     const { columnExtensionMap, columns, hideFacets } =
@@ -57,9 +57,6 @@ const BrowseDonorSearchTable = (props) => {
             ...context,
             clear_filters: BROWSE_LINKS.donor,
         },
-        customColumnSearchHref: (result) =>
-            `/peek-metadata/?additional_facet=file_size&${BROWSE_STATUS_FILTERS}&dataset!=No+value&type=File&donors.display_title=` +
-            result?.display_title,
     };
 
     const aboveFacetListComponent = <BrowseViewAboveFacetListComponent />;
@@ -138,22 +135,24 @@ export const BrowseDonorBody = (props) => {
     }, [session, userDownloadAccess]);
 
     return (
-        <>
-            {showRedirectBanner && <RedirectBanner href={props?.href} />}
-            <BrowseDonorVizWrapper {...props} mapping="donor" />
-            <hr />
-            <BrowseViewControllerWithSelections {...props}>
-                <BrowseDonorSearchTable />
-            </BrowseViewControllerWithSelections>
-            {context?.total === 0 && (
-                <NoResultsBrowseModal
-                    type="donor"
-                    context={context}
-                    href={href}
-                    userDownloadAccess={userDownloadAccess}
-                    isAccessResolved={isAccessResolved}
-                />
-            )}
-        </>
+        <DonorDataProvider>
+            <>
+                {showRedirectBanner && <RedirectBanner href={props?.href} />}
+                <BrowseDonorVizWrapper {...props} mapping="donor" />
+                <hr />
+                <BrowseViewControllerWithSelections {...props}>
+                    <BrowseDonorSearchTable />
+                </BrowseViewControllerWithSelections>
+                {context?.total === 0 && (
+                    <NoResultsBrowseModal
+                        type="donor"
+                        context={context}
+                        href={href}
+                        userDownloadAccess={userDownloadAccess}
+                        isAccessResolved={isAccessResolved}
+                    />
+                )}
+            </>
+        </DonorDataProvider>
     );
 };

--- a/src/encoded/static/components/browse/browse-view/BrowseDonor.js
+++ b/src/encoded/static/components/browse/browse-view/BrowseDonor.js
@@ -130,7 +130,7 @@ export const BrowseDonorBody = (props) => {
     );
 
     return (
-        <DonorDataProvider>
+        <DonorDataProvider key={href}>
             {showRedirectBanner && <RedirectBanner href={props.href} />}
             <BrowseDonorVizWrapper {...props} mapping="donor" />
             <hr />

--- a/src/encoded/static/components/browse/browse-view/BrowseDonorBase.js
+++ b/src/encoded/static/components/browse/browse-view/BrowseDonorBase.js
@@ -584,7 +584,7 @@ export function createBaseDonorColumnExtensionMap({
                             return (
                                 <a
                                     className="value text-center"
-                                    href={`/browse/?type=File&${BROWSE_STATUS_FILTERS}&dataset!=No+value&donors.display_title=${result?.display_title}`}>
+                                    href={`/browse/?type=File&${BROWSE_STATUS_FILTERS}&dataset!=No+value&donors.display_title=${encodeURIComponent(result?.display_title)}`}>
                                     {fileCount} File{fileCount > 1 ? 's' : ''}
                                 </a>
                             );

--- a/src/encoded/static/components/browse/browse-view/BrowseDonorBase.js
+++ b/src/encoded/static/components/browse/browse-view/BrowseDonorBase.js
@@ -7,6 +7,7 @@ import { CustomTableRowToggleOpenButton } from '@hms-dbmi-bgm/shared-portal-comp
 import { LocalizedTime } from '@hms-dbmi-bgm/shared-portal-components/es/components/ui/LocalizedTime';
 import { valueTransforms } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
 import { getTissueCategoryFromFacetTerm } from '../../util/data';
+import { DonorDataCell } from './BrowseDonorDataProvider';
 
 export const formatTissueData = (data) => {
     const defaultTissueCategories = {
@@ -414,71 +415,73 @@ export function createBaseDonorColumnExtensionMap({
                     handleCellClick,
                 } = parentProps;
 
-                const { data, loading } = parentProps?.fetchedProps;
+                return (
+                    <DonorDataCell displayTitle={result.display_title}>
+                        {({ data, loading }) => {
+                            const tissueFacet = data?.find(
+                                (f) => f.field === 'sample_summary.tissues'
+                            );
+                            const tissueTerms = tissueFacet?.has_group_by
+                                ? tissueFacet?.original_terms || tissueFacet?.terms
+                                : tissueFacet?.terms;
+                            const tissueCount = tissueTerms?.length;
 
-                const tissueFacet = data?.find(
-                    (f) => f.field === 'sample_summary.tissues'
+                            if (loading) {
+                                return <span className="value text-center loading"></span>;
+                            }
+                            if (!tissueCount) {
+                                return <small className="value">-</small>;
+                            }
+                            return (
+                                <div
+                                    className={
+                                        'inner-value-container' +
+                                        (detailOpen ? ' detail-open' : ' detail-closed')
+                                    }>
+                                    <CustomTableRowToggleOpenButton
+                                        {...{
+                                            result,
+                                            href,
+                                            context,
+                                            rowNumber,
+                                            detailOpen,
+                                            toggleDetailOpen,
+                                            isActive: detailPaneType === 'tissue',
+                                            customToggleDetailClose: () => {
+                                                if (detailPaneType === 'assay') {
+                                                    handleCellClick('tissue');
+                                                } else {
+                                                    handleCellClick(null);
+                                                    toggleDetailOpen();
+                                                }
+                                            },
+                                            customToggleDetailOpen: () => {
+                                                handleCellClick('tissue');
+                                                toggleDetailOpen();
+                                            },
+                                            toggleOpenIcon: (
+                                                <>
+                                                    {tissueCount} Tissue
+                                                    {tissueCount > 1 ? 's' : ''}
+                                                    <i className="icon icon-circle-plus"></i>
+                                                </>
+                                            ),
+                                            toggleCloseIcon: (
+                                                <>
+                                                    {tissueCount} Tissue
+                                                    {tissueCount > 1 ? 's' : ''}
+                                                    <i className="icon icon-circle-minus"></i>
+                                                </>
+                                            ),
+                                        }}>
+                                        {tissueCount} Tissue
+                                        {tissueCount > 1 ? 's' : ''}
+                                    </CustomTableRowToggleOpenButton>
+                                </div>
+                            );
+                        }}
+                    </DonorDataCell>
                 );
-                const tissueTerms = tissueFacet?.has_group_by
-                    ? tissueFacet?.original_terms || tissueFacet?.terms
-                    : tissueFacet?.terms;
-                const tissueCount = tissueTerms?.length;
-
-                if (loading) {
-                    return (
-                        <span className="value text-center loading">
-                            {/* <i className="icon icon-circle-notch icon-spin fas"></i> */}
-                        </span>
-                    );
-                } else {
-                    return tissueCount ? (
-                        <div
-                            className={
-                                'inner-value-container' +
-                                (detailOpen ? ' detail-open' : ' detail-closed')
-                            }>
-                            <CustomTableRowToggleOpenButton
-                                {...{
-                                    result,
-                                    href,
-                                    context,
-                                    rowNumber,
-                                    detailOpen,
-                                    toggleDetailOpen,
-                                    isActive: detailPaneType === 'tissue',
-                                    customToggleDetailClose: (props) => {
-                                        if (detailPaneType === 'assay') {
-                                            handleCellClick('tissue');
-                                        } else {
-                                            handleCellClick(null);
-                                            toggleDetailOpen();
-                                        }
-                                    },
-                                    customToggleDetailOpen: (props) => {
-                                        handleCellClick('tissue');
-                                        toggleDetailOpen();
-                                    },
-                                    toggleOpenIcon: (
-                                        <>
-                                            {tissueCount} Tissue
-                                            {tissueCount > 1 ? 's' : ''}
-                                            <i className="icon icon-circle-plus"></i>
-                                        </>
-                                    ),
-                                    toggleCloseIcon: (
-                                        <>
-                                            {tissueCount} Tissue
-                                            {tissueCount > 1 ? 's' : ''}
-                                            <i className="icon icon-circle-minus"></i>
-                                        </>
-                                    ),
-                                }}>
-                                {tissueCount} Tissue
-                                {tissueCount > 1 ? 's' : ''}
-                            </CustomTableRowToggleOpenButton>
-                        </div>
-                    ) : null;
-                }
             },
         },
         assays: {
@@ -496,128 +499,127 @@ export function createBaseDonorColumnExtensionMap({
                     handleCellClick,
                 } = parentProps;
 
-                const { data, loading } = parentProps?.fetchedProps;
+                return (
+                    <DonorDataCell displayTitle={result.display_title}>
+                        {({ data, loading }) => {
+                            const assayCount = data
+                                ?.find((f) => f.field === 'assays.display_title')
+                                ?.terms?.reduce(
+                                    (acc, curr) => acc + (curr?.terms?.length ?? 1),
+                                    0
+                                );
 
-                const assayCount = data
-                    ?.find((f) => f.field === 'assays.display_title')
-                    ?.terms?.reduce(
-                        (acc, curr) => acc + (curr?.terms?.length ?? 1),
-                        0
-                    );
-
-                if (loading) {
-                    return (
-                        <span className="value text-center loading">
-                            {/* <i className="icon icon-circle-notch icon-spin fas"></i> */}
-                        </span>
-                    );
-                } else {
-                    return assayCount ? (
-                        <div
-                            className={
-                                'inner-value-container' +
-                                (detailOpen ? ' detail-open' : ' detail-closed')
-                            }>
-                            <CustomTableRowToggleOpenButton
-                                {...{
-                                    result,
-                                    href,
-                                    context,
-                                    rowNumber,
-                                    detailOpen,
-                                    toggleDetailOpen,
-                                    isActive: detailPaneType === 'assay',
-                                    customToggleDetailClose: (props) => {
-                                        if (detailPaneType === 'tissue') {
-                                            handleCellClick('assay');
-                                        } else {
-                                            handleCellClick(null);
-                                            toggleDetailOpen();
-                                        }
-                                    },
-                                    customToggleDetailOpen: (props) => {
-                                        handleCellClick('assay');
-                                        toggleDetailOpen();
-                                    },
-                                    toggleOpenIcon: (
-                                        <>
-                                            {assayCount} Assay
-                                            {assayCount > 1 ? 's' : ''}
-                                            <i className="icon icon-circle-plus"></i>
-                                        </>
-                                    ),
-                                    toggleCloseIcon: (
-                                        <>
-                                            {assayCount} Assay
-                                            {assayCount > 1 ? 's' : ''}
-                                            <i className="icon icon-circle-minus"></i>
-                                        </>
-                                    ),
-                                }}></CustomTableRowToggleOpenButton>
-                        </div>
-                    ) : null;
-                }
+                            if (loading) {
+                                return <span className="value text-center loading"></span>;
+                            }
+                            if (!assayCount) {
+                                return <small className="value">-</small>;
+                            }
+                            return (
+                                <div
+                                    className={
+                                        'inner-value-container' +
+                                        (detailOpen ? ' detail-open' : ' detail-closed')
+                                    }>
+                                    <CustomTableRowToggleOpenButton
+                                        {...{
+                                            result,
+                                            href,
+                                            context,
+                                            rowNumber,
+                                            detailOpen,
+                                            toggleDetailOpen,
+                                            isActive: detailPaneType === 'assay',
+                                            customToggleDetailClose: () => {
+                                                if (detailPaneType === 'tissue') {
+                                                    handleCellClick('assay');
+                                                } else {
+                                                    handleCellClick(null);
+                                                    toggleDetailOpen();
+                                                }
+                                            },
+                                            customToggleDetailOpen: () => {
+                                                handleCellClick('assay');
+                                                toggleDetailOpen();
+                                            },
+                                            toggleOpenIcon: (
+                                                <>
+                                                    {assayCount} Assay
+                                                    {assayCount > 1 ? 's' : ''}
+                                                    <i className="icon icon-circle-plus"></i>
+                                                </>
+                                            ),
+                                            toggleCloseIcon: (
+                                                <>
+                                                    {assayCount} Assay
+                                                    {assayCount > 1 ? 's' : ''}
+                                                    <i className="icon icon-circle-minus"></i>
+                                                </>
+                                            ),
+                                        }}
+                                    />
+                                </div>
+                            );
+                        }}
+                    </DonorDataCell>
+                );
             },
         },
         files: {
             noSort: true,
             colAlignment: 'text-end',
             widthMap: { lg: 90, md: 90, sm: 90 },
-            render: function (result, parentProps) {
-                const { data, loading } = parentProps?.fetchedProps;
+            render: function (result) {
+                return (
+                    <DonorDataCell displayTitle={result.display_title}>
+                        {({ data, loading }) => {
+                            const fileCount = data?.find((f) => f.field === 'file_size')?.count;
 
-                const fileCount = data
-                    ?.find((f) => f.field === 'type')
-                    ?.terms?.find((term) => term.key === 'File')?.doc_count;
-
-                if (loading) {
-                    return <span className="value text-center loading"></span>;
-                } else {
-                    return fileCount ? (
-                        <a
-                            className="value text-center"
-                            href={`/browse/?type=File&${BROWSE_STATUS_FILTERS}&dataset!=No+value&donors.display_title=${result?.display_title}`}>
-                            {fileCount} File{fileCount > 1 ? 's' : ''}
-                        </a>
-                    ) : null;
-                }
+                            if (loading) {
+                                return <span className="value text-center loading"></span>;
+                            }
+                            if (!fileCount) {
+                                return <small className="value">-</small>;
+                            }
+                            return (
+                                <a
+                                    className="value text-center"
+                                    href={`/browse/?type=File&${BROWSE_STATUS_FILTERS}&dataset!=No+value&donors.display_title=${result?.display_title}`}>
+                                    {fileCount} File{fileCount > 1 ? 's' : ''}
+                                </a>
+                            );
+                        }}
+                    </DonorDataCell>
+                );
             },
         },
         file_size: {
             noSort: true,
             colAlignment: 'text-end',
             widthMap: { lg: 90, md: 90, sm: 90 },
-            render: function (result, parentProps) {
-                const { data, loading } = parentProps?.fetchedProps;
+            render: function (result) {
+                return (
+                    <DonorDataCell displayTitle={result.display_title}>
+                        {({ data, loading }) => {
+                            const fileSize = data?.find(
+                                (f) => f.field === 'file_size'
+                            )?.sum;
 
-                const fileSize = data?.find(
-                    (f) => f.field === 'file_size'
-                )?.sum;
-
-                if (loading) {
-                    return (
-                        <span className="value text-center loading">
-                            {/* <i className="icon icon-circle-notch icon-spin fas"></i> */}
-                        </span>
-                    );
-                } else {
-                    return fileSize ? (
-                        <span className="value text-center">
-                            {valueTransforms.bytesToLargerUnit(
-                                fileSize,
-                                0,
-                                false,
-                                true
-                            )}{' '}
-                            {valueTransforms.bytesToLargerUnit(
-                                fileSize,
-                                0,
-                                true,
-                                false
-                            )}
-                        </span>
-                    ) : null;
-                }
+                            if (loading) {
+                                return <span className="value text-center loading"></span>;
+                            }
+                            if (!fileSize) {
+                                return <small className="value">-</small>;
+                            }
+                            return (
+                                <span className="value text-center">
+                                    {valueTransforms.bytesToLargerUnit(fileSize, 0, false, true)}{' '}
+                                    {valueTransforms.bytesToLargerUnit(fileSize, 0, true, false)}
+                                </span>
+                            );
+                        }}
+                    </DonorDataCell>
+                );
             },
         },
         hardy_scale: {

--- a/src/encoded/static/components/browse/browse-view/BrowseDonorDataProvider.js
+++ b/src/encoded/static/components/browse/browse-view/BrowseDonorDataProvider.js
@@ -12,13 +12,21 @@ import React, {
 import { ajax } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
 import { BROWSE_STATUS_FILTERS } from '../BrowseView';
 
+const DONOR_PEEK_METADATA_ADDITIONAL_FACETS = [
+    'sample_summary.tissues',
+    'assays.display_title',
+    'file_size',
+];
+
+const buildDonorPeekMetadataUrl = (displayTitle) => {
+    const additionalFacetParams = DONOR_PEEK_METADATA_ADDITIONAL_FACETS.map(
+        (facet) => `additional_facet=${facet}`
+    ).join('&');
+    return `/peek-metadata/?skip_default_facets=true&${additionalFacetParams}&${BROWSE_STATUS_FILTERS}&dataset!=No+value&type=File&donors.display_title=${encodeURIComponent(displayTitle)}`;
+};
+
 // Set a limit on the number of concurrent requests to avoid overloading the server
 const CONCURRENCY_LIMIT = 4;
-
-const buildPeekMetadataUrl = (displayTitle) =>
-    `/peek-metadata/?skip_default_facets=true&additional_facet=sample_summary.tissues&additional_facet=assays.display_title&additional_facet=file_size&${BROWSE_STATUS_FILTERS}&dataset!=No+value&type=File&donors.display_title=${encodeURIComponent(
-        displayTitle
-    )}`;
 
 // Context for holding per-donor facet data fetched in display order
 export const DonorDataContext = createContext({
@@ -77,7 +85,7 @@ export const DonorDataProvider = ({ children }) => {
                 pendingRef.current.add(displayTitle);
                 queueRef.current.push({
                     displayTitle,
-                    url: buildPeekMetadataUrl(displayTitle),
+                    url: buildDonorPeekMetadataUrl(displayTitle),
                 });
                 dispatch();
             }

--- a/src/encoded/static/components/browse/browse-view/BrowseDonorDataProvider.js
+++ b/src/encoded/static/components/browse/browse-view/BrowseDonorDataProvider.js
@@ -23,9 +23,11 @@ const ADDITIONAL_FACET_PARAMS = DONOR_PEEK_METADATA_ADDITIONAL_FACETS.map(
 ).join('&');
 
 const buildDonorPeekMetadataUrl = (displayTitle) =>
-    `/peek-metadata/?skip_default_facets=true&${ADDITIONAL_FACET_PARAMS}&${BROWSE_STATUS_FILTERS}&dataset!=No+value&type=File&donors.display_title=${encodeURIComponent(displayTitle)}`;
+    `/peek-metadata/?skip_default_facets=true&${ADDITIONAL_FACET_PARAMS}&${BROWSE_STATUS_FILTERS}&dataset!=No+value&type=File&donors.display_title=${encodeURIComponent(
+        displayTitle
+    )}`;
 
-// Set a limit on the number of concurrent requests to avoid overloading the server
+// Limits simultaneous requests to avoid flooding the server while rows fill in quickly
 const CONCURRENCY_LIMIT = 4;
 
 // Context for holding per-donor facet data fetched in display order

--- a/src/encoded/static/components/browse/browse-view/BrowseDonorDataProvider.js
+++ b/src/encoded/static/components/browse/browse-view/BrowseDonorDataProvider.js
@@ -1,0 +1,119 @@
+'use strict';
+
+import React, {
+    createContext,
+    useCallback,
+    useContext,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
+import { ajax } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
+import { BROWSE_STATUS_FILTERS } from '../BrowseView';
+
+// Set a limit on the number of concurrent requests to avoid overloading the server
+const CONCURRENCY_LIMIT = 4;
+
+const buildPeekMetadataUrl = (displayTitle) =>
+    `/peek-metadata/?skip_default_facets=true&additional_facet=sample_summary.tissues&additional_facet=assays.display_title&additional_facet=file_size&${BROWSE_STATUS_FILTERS}&dataset!=No+value&type=File&donors.display_title=${encodeURIComponent(
+        displayTitle
+    )}`;
+
+// Context for holding per-donor facet data fetched in display order
+export const DonorDataContext = createContext({
+    getDonorData: () => ({ data: null, loading: true }),
+    enqueueDonor: () => {},
+    version: 0,
+});
+
+/**
+ * Provides per-donor facet data fetched in display order with a limited
+ * concurrency queue. Each cell registers itself via `enqueueDonor()` when
+ * it mounts. Rows loaded by infinite scroll are handled automatically.
+ */
+export const DonorDataProvider = ({ children }) => {
+    const cacheRef = useRef(new Map());
+    const pendingRef = useRef(new Set());
+    const queueRef = useRef([]);
+    const activeRef = useRef(0);
+    const [version, setVersion] = useState(0);
+
+    const dispatch = useCallback(() => {
+        if (
+            activeRef.current >= CONCURRENCY_LIMIT ||
+            queueRef.current.length === 0
+        )
+            return;
+
+        const { displayTitle, url } = queueRef.current.shift();
+        pendingRef.current.delete(displayTitle);
+        activeRef.current++;
+        cacheRef.current.set(displayTitle, { data: null, loading: true });
+
+        const onComplete = (cacheEntry) => {
+            cacheRef.current.set(displayTitle, cacheEntry);
+            activeRef.current--;
+            setVersion((v) => v + 1);
+            dispatch();
+        };
+
+        ajax.load(
+            url,
+            (resp) => onComplete({ data: resp ?? null, loading: false }),
+            'GET',
+            () => onComplete({ data: null, loading: false })
+        );
+
+        dispatch(); // fill any remaining available slots
+    }, []);
+
+    const enqueueDonor = useCallback(
+        (displayTitle) => {
+            if (
+                !cacheRef.current.has(displayTitle) &&
+                !pendingRef.current.has(displayTitle)
+            ) {
+                pendingRef.current.add(displayTitle);
+                queueRef.current.push({
+                    displayTitle,
+                    url: buildPeekMetadataUrl(displayTitle),
+                });
+                dispatch();
+            }
+        },
+        [dispatch]
+    );
+
+    const getDonorData = useCallback(
+        (displayTitle) =>
+            cacheRef.current.get(displayTitle) ?? { data: null, loading: true },
+        []
+    );
+
+    const contextValue = useMemo(
+        () => ({ getDonorData, enqueueDonor, version }),
+        [getDonorData, enqueueDonor, version]
+    );
+
+    return (
+        <DonorDataContext.Provider value={contextValue}>
+            {children}
+        </DonorDataContext.Provider>
+    );
+};
+
+/**
+ * Wrapper component for donor column cells. Registers the donor with the provider
+ * on mount so its data is fetched in queue order, then re-renders when data arrives.
+ */
+export const DonorDataCell = ({ displayTitle, children }) => {
+    const { getDonorData, enqueueDonor } = useContext(DonorDataContext);
+
+    useEffect(() => {
+        enqueueDonor(displayTitle);
+    }, [displayTitle, enqueueDonor]);
+
+    const { data, loading } = getDonorData(displayTitle);
+    return children({ data, loading });
+};

--- a/src/encoded/static/components/browse/browse-view/BrowseDonorDataProvider.js
+++ b/src/encoded/static/components/browse/browse-view/BrowseDonorDataProvider.js
@@ -18,12 +18,12 @@ const DONOR_PEEK_METADATA_ADDITIONAL_FACETS = [
     'file_size',
 ];
 
-const buildDonorPeekMetadataUrl = (displayTitle) => {
-    const additionalFacetParams = DONOR_PEEK_METADATA_ADDITIONAL_FACETS.map(
-        (facet) => `additional_facet=${facet}`
-    ).join('&');
-    return `/peek-metadata/?skip_default_facets=true&${additionalFacetParams}&${BROWSE_STATUS_FILTERS}&dataset!=No+value&type=File&donors.display_title=${encodeURIComponent(displayTitle)}`;
-};
+const ADDITIONAL_FACET_PARAMS = DONOR_PEEK_METADATA_ADDITIONAL_FACETS.map(
+    (f) => `additional_facet=${f}`
+).join('&');
+
+const buildDonorPeekMetadataUrl = (displayTitle) =>
+    `/peek-metadata/?skip_default_facets=true&${ADDITIONAL_FACET_PARAMS}&${BROWSE_STATUS_FILTERS}&dataset!=No+value&type=File&donors.display_title=${encodeURIComponent(displayTitle)}`;
 
 // Set a limit on the number of concurrent requests to avoid overloading the server
 const CONCURRENCY_LIMIT = 4;

--- a/src/encoded/static/components/browse/browse-view/BrowseProtectedDonor.js
+++ b/src/encoded/static/components/browse/browse-view/BrowseProtectedDonor.js
@@ -157,23 +157,21 @@ export const BrowseProtectedDonorBody = (props) => {
         props;
     return (
         <DonorDataProvider>
-            <>
-                <Alerts alerts={alerts} className="mt-2" />
-                <BrowseDonorVizWrapper {...props} mapping="protected-donor" />
-                <hr />
-                <BrowseViewControllerWithSelections {...props}>
-                    <BrowseProtectedDonorSearchTable />
-                </BrowseViewControllerWithSelections>
-                {context?.total === 0 && (
-                    <NoResultsBrowseModal
-                        type="protected_donor"
-                        context={context}
-                        href={href}
-                        userDownloadAccess={userDownloadAccess}
-                        isAccessResolved={isAccessResolved}
-                    />
-                )}
-            </>
+            <Alerts alerts={alerts} className="mt-2" />
+            <BrowseDonorVizWrapper {...props} mapping="protected-donor" />
+            <hr />
+            <BrowseViewControllerWithSelections {...props}>
+                <BrowseProtectedDonorSearchTable />
+            </BrowseViewControllerWithSelections>
+            {context?.total === 0 && (
+                <NoResultsBrowseModal
+                    type="protected_donor"
+                    context={context}
+                    href={href}
+                    userDownloadAccess={userDownloadAccess}
+                    isAccessResolved={isAccessResolved}
+                />
+            )}
         </DonorDataProvider>
     );
 };

--- a/src/encoded/static/components/browse/browse-view/BrowseProtectedDonor.js
+++ b/src/encoded/static/components/browse/browse-view/BrowseProtectedDonor.js
@@ -156,7 +156,7 @@ export const BrowseProtectedDonorBody = (props) => {
     const { context, alerts, href, userDownloadAccess, isAccessResolved } =
         props;
     return (
-        <DonorDataProvider>
+        <DonorDataProvider key={href}>
             <Alerts alerts={alerts} className="mt-2" />
             <BrowseDonorVizWrapper {...props} mapping="protected-donor" />
             <hr />

--- a/src/encoded/static/components/browse/browse-view/BrowseProtectedDonor.js
+++ b/src/encoded/static/components/browse/browse-view/BrowseProtectedDonor.js
@@ -123,9 +123,7 @@ const BrowseProtectedDonorSearchTable = (props) => {
         createBrowseProtectedDonorColumnExtensionMap(selectedFileProps);
 
     const facetListSortFxns = {
-        hardy_scale: (a, b) => {
-            return a.key - b.key;
-        },
+        hardy_scale: (a, b) => a.key - b.key,
     };
 
     return (

--- a/src/encoded/static/components/browse/browse-view/BrowseProtectedDonor.js
+++ b/src/encoded/static/components/browse/browse-view/BrowseProtectedDonor.js
@@ -7,7 +7,6 @@ import { BrowseViewControllerWithSelections } from '../../static-pages/component
 import { BrowseViewAboveFacetListComponent } from './BrowseViewAboveFacetListComponent';
 import { BrowseViewAboveSearchTableControls } from './BrowseViewAboveSearchTableControls';
 import {
-    BROWSE_STATUS_FILTERS,
     BROWSE_LINKS,
     NoResultsBrowseModal,
 } from '../BrowseView';
@@ -18,6 +17,7 @@ import {
     customRenderDetailPane,
     createBaseDonorColumnExtensionMap,
 } from './BrowseDonorBase';
+import { DonorDataProvider } from './BrowseDonorDataProvider';
 
 export { formatTissueData, formatAssayData } from './BrowseDonorBase';
 
@@ -104,9 +104,6 @@ const BrowseProtectedDonorSearchTable = (props) => {
             ...context,
             clear_filters: BROWSE_LINKS.protected_donor,
         },
-        customColumnSearchHref: (result) =>
-            `/peek-metadata/?additional_facet=file_size&${BROWSE_STATUS_FILTERS}&dataset!=No+value&type=File&donors.display_title=` +
-            result?.display_title,
         defaultColAlignment: 'text-left',
     };
 
@@ -161,22 +158,24 @@ export const BrowseProtectedDonorBody = (props) => {
     const { context, alerts, href, userDownloadAccess, isAccessResolved } =
         props;
     return (
-        <>
-            <Alerts alerts={alerts} className="mt-2" />
-            <BrowseDonorVizWrapper {...props} mapping="protected-donor" />
-            <hr />
-            <BrowseViewControllerWithSelections {...props}>
-                <BrowseProtectedDonorSearchTable />
-            </BrowseViewControllerWithSelections>
-            {context?.total === 0 && (
-                <NoResultsBrowseModal
-                    type="protected_donor"
-                    context={context}
-                    href={href}
-                    userDownloadAccess={userDownloadAccess}
-                    isAccessResolved={isAccessResolved}
-                />
-            )}
-        </>
+        <DonorDataProvider>
+            <>
+                <Alerts alerts={alerts} className="mt-2" />
+                <BrowseDonorVizWrapper {...props} mapping="protected-donor" />
+                <hr />
+                <BrowseViewControllerWithSelections {...props}>
+                    <BrowseProtectedDonorSearchTable />
+                </BrowseViewControllerWithSelections>
+                {context?.total === 0 && (
+                    <NoResultsBrowseModal
+                        type="protected_donor"
+                        context={context}
+                        href={href}
+                        userDownloadAccess={userDownloadAccess}
+                        isAccessResolved={isAccessResolved}
+                    />
+                )}
+            </>
+        </DonorDataProvider>
     );
 };


### PR DESCRIPTION
[Trello Ticket 912](https://trello.com/c/iK00056y/912-look-into-whether-it-is-possible-to-reorder-requests-on-browse-by-donor)

## Summary

- Add `DonorDataProvider` / `DonorDataCell` render-prop pattern so all four donor-row data columns (tissues, assays, file count, total file size) share a single `/peek-metadata/` fetch per donor rather than issuing separate per-column requests.
- A concurrency queue (max 4 in-flight) loads donors in display order so the first visible rows populate immediately; rows added by infinite scroll enqueue automatically.
- The request uses `skip_default_facets=true` + three explicit `additional_facet` params, reducing Elasticsearch aggregation work from the 21-facet File default set to exactly the 3 aggregations the columns read.