### PR TITLE
fix: decrease select-all file limit to 3000

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Change Log
 2.3.4
 =====
 
-`PR 714: Decrease select-all file limit to 3000 <https://github.com/smaht-dac/smaht-portal/pull/714>`_
+`PR 714: fix: decrease select-all file limit to 3000 <https://github.com/smaht-dac/smaht-portal/pull/714>`_
 
 * Decrease the "Select All" upper limit from 8000 to 3000 files
 * Update the disabled-state tooltip to reflect the new limit

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,15 @@ Change Log
 ----------
 
 
+2.3.4
+=====
+
+`PR 714: Decrease select-all file limit to 3000 <https://github.com/smaht-dac/smaht-portal/pull/714>`_
+
+* Decrease the "Select All" upper limit from 8000 to 3000 files
+* Update the disabled-state tooltip to reflect the new limit
+
+
 2.3.3
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "2.3.3"
+version = "2.3.4"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
+++ b/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
 import _ from 'underscore';
-import { Modal, Tabs, Tab, OverlayTrigger } from 'react-bootstrap';
+import { Modal, Tabs, Tab, OverlayTrigger, Popover } from 'react-bootstrap';
 import ReactTooltip from 'react-tooltip';
 
 import {
@@ -455,16 +455,29 @@ export class SelectAllFilesButton extends React.PureComponent {
         const cls =
             'btn btn-sm me-05 align-items-center ' +
             (isAllSelected ? 'btn-secondary' : 'btn-outline-secondary');
-        const tooltip =
-            !isAllSelected && !isEnabled
-                ? `The maximum number of files that can be downloaded at a time is 3,000 for an optimal download speed and portal performance. If >3,000 files need to be downloaded, please download them in multiple smaller batches of files.: ${SELECT_ALL_LIMIT}`
-                : null;
+        const showMaxDownloadLimitPopover =
+            !selecting && !isAllSelected && !isEnabled;
+        const maxDownloadLimitPopover = (
+            <Popover className="download-popover protected selection-limit">
+                <Popover.Header as="h3">
+                    Maximum Download Limit: {SELECT_ALL_LIMIT}
+                </Popover.Header>
+                <Popover.Body>
+                    For optimal download speed and portal performance, files can
+                    only be downloaded {SELECT_ALL_LIMIT.toLocaleString()} at a
+                    time. <br />
+                    <br />
+                    If more files need to be downloaded, please download them in
+                    multiple smaller batches.
+                </Popover.Body>
+            </Popover>
+        );
 
         if (type === 'checkbox') {
             const checkboxTooltip = selecting
                 ? `Selecting ${selectingProgress}%`
-                : tooltip;
-            return (
+                : null;
+            const checkboxContent = (
                 <span
                     ref={this.selectAllButtonRef}
                     className="d-inline-flex flex-column align-items-center"
@@ -502,29 +515,59 @@ export class SelectAllFilesButton extends React.PureComponent {
                     </div>
                 </span>
             );
+            if (showMaxDownloadLimitPopover) {
+                return (
+                    <OverlayTrigger
+                        trigger={['hover', 'focus']}
+                        placement="top"
+                        overlay={maxDownloadLimitPopover}>
+                        {checkboxContent}
+                    </OverlayTrigger>
+                );
+            }
+            return checkboxContent;
         }
+
+        const selectAllButton = (
+            <button
+                ref={this.selectAllButtonRef}
+                type="button"
+                id="select-all-files-button"
+                disabled={selecting || (!isAllSelected && !isEnabled)}
+                className={cls}
+                onClick={this.handleSelectAll}>
+                <i className={iconClassName} />
+                <span className="d-none d-md-inline text-400">
+                    {selecting
+                        ? `Selecting ${selectingProgress}%`
+                        : isAllSelected
+                        ? 'Deselect'
+                        : 'Select'}{' '}
+                </span>
+                <span className="text-600">All</span>
+            </button>
+        );
+
+        const selectAllButtonWrapper = (
+            <span
+                className="d-inline-block"
+                data-tip={selecting ? `Selecting ${selectingProgress}%` : null}>
+                {selectAllButton}
+            </span>
+        );
 
         return (
             <div className="d-inline-flex flex-column">
-                <span className="d-inline-block" data-tip={tooltip}>
-                    <button
-                        ref={this.selectAllButtonRef}
-                        type="button"
-                        id="select-all-files-button"
-                        disabled={selecting || (!isAllSelected && !isEnabled)}
-                        className={cls}
-                        onClick={this.handleSelectAll}>
-                        <i className={iconClassName} />
-                        <span className="d-none d-md-inline text-400">
-                            {selecting
-                                ? `Selecting ${selectingProgress}%`
-                                : isAllSelected
-                                ? 'Deselect'
-                                : 'Select'}{' '}
-                        </span>
-                        <span className="text-600">All</span>
-                    </button>
-                </span>
+                {showMaxDownloadLimitPopover ? (
+                    <OverlayTrigger
+                        trigger={['hover', 'focus']}
+                        placement="top"
+                        overlay={maxDownloadLimitPopover}>
+                        {selectAllButtonWrapper}
+                    </OverlayTrigger>
+                ) : (
+                    selectAllButtonWrapper
+                )}
                 {selecting ? (
                     <div
                         className="progress mt-03 select-all-progress select-all-progress-button"

--- a/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
+++ b/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
@@ -58,7 +58,10 @@ export const SelectAllAboveTableComponent = (props) => {
                 Results
             </div>
             <div className="ms-auto col-auto me-0 d-flex pe-0">
-                <SelectAllFilesButton {...selectedFileProps} {...{ context, searchHref }} />
+                <SelectAllFilesButton
+                    {...selectedFileProps}
+                    {...{ context, searchHref }}
+                />
                 {/* Show popover if user has the access needed for this table */}
                 {canDownloadFiles ? (
                     <SelectedItemsDownloadButton
@@ -115,7 +118,7 @@ export class SelectAllFilesButton extends React.PureComponent {
         'display_title',
         '@id',
         '@type',
-        'file_sets.@id'
+        'file_sets.@id',
     ];
     static isLocalhost =
         typeof window !== 'undefined' &&
@@ -141,13 +144,17 @@ export class SelectAllFilesButton extends React.PureComponent {
         super(props);
         this.isAllSelected = this.isAllSelected.bind(this);
         this.handleSelectAll = this.handleSelectAll.bind(this);
-        this.fetchAllPagesForSelection = this.fetchAllPagesForSelection.bind(
-            this
-        );
-        this.updateProgressTrackWidth = this.updateProgressTrackWidth.bind(this);
+        this.fetchAllPagesForSelection =
+            this.fetchAllPagesForSelection.bind(this);
+        this.updateProgressTrackWidth =
+            this.updateProgressTrackWidth.bind(this);
         this.selectAllButtonRef = React.createRef();
         this.selectAllButtonResizeObserver = null;
-        this.state = { selecting: false, selectingProgress: 0, progressTrackWidth: null };
+        this.state = {
+            selecting: false,
+            selectingProgress: 0,
+            progressTrackWidth: null,
+        };
     }
 
     componentDidMount() {
@@ -157,10 +164,14 @@ export class SelectAllFilesButton extends React.PureComponent {
             typeof window.ResizeObserver === 'function' &&
             this.selectAllButtonRef.current
         ) {
-            this.selectAllButtonResizeObserver = new window.ResizeObserver(() => {
-                this.updateProgressTrackWidth();
-            });
-            this.selectAllButtonResizeObserver.observe(this.selectAllButtonRef.current);
+            this.selectAllButtonResizeObserver = new window.ResizeObserver(
+                () => {
+                    this.updateProgressTrackWidth();
+                }
+            );
+            this.selectAllButtonResizeObserver.observe(
+                this.selectAllButtonRef.current
+            );
         } else if (typeof window !== 'undefined') {
             // Fallback for environments lacking ResizeObserver support.
             window.addEventListener('resize', this.updateProgressTrackWidth);
@@ -227,10 +238,13 @@ export class SelectAllFilesButton extends React.PureComponent {
     async fetchAllPagesForSelection(searchHref) {
         const currentHrefParts = memoizedUrlParse(searchHref);
         const currentHrefQuery = _.extend({}, currentHrefParts.query);
-        const { total, pageSize, concurrentRequests } = this.getSelectAllConfig();
+        const { total, pageSize, concurrentRequests } =
+            this.getSelectAllConfig();
         const requestPathname = (() => {
             const parsedPathname =
-                currentHrefParts?.pathname || String(searchHref || '').split('?')[0] || '/search/';
+                currentHrefParts?.pathname ||
+                String(searchHref || '').split('?')[0] ||
+                '/search/';
             if (parsedPathname === '/browse/' || parsedPathname === '/browse') {
                 return '/search/';
             }
@@ -270,7 +284,8 @@ export class SelectAllFilesButton extends React.PureComponent {
             const batchResponses = await Promise.all(
                 batchStarts.map((from) => {
                     const query = { ...currentHrefQuery, from };
-                    const reqHref = requestPathname + '?' + queryString.stringify(query);
+                    const reqHref =
+                        requestPathname + '?' + queryString.stringify(query);
                     return ajax.promise(reqHref);
                 })
             );
@@ -349,7 +364,7 @@ export class SelectAllFilesButton extends React.PureComponent {
             );
         }
         if (!searchHref) {
-            logger.error("No search href available for Select All.");
+            logger.error('No search href available for Select All.');
             Alerts.queue({
                 title: 'Select All Failed',
                 message:
@@ -435,14 +450,14 @@ export class SelectAllFilesButton extends React.PureComponent {
             (selecting
                 ? 'circle-notch icon-spin fas'
                 : isAllSelected
-                    ? 'square far'
-                    : 'check-square far');
+                ? 'square far'
+                : 'check-square far');
         const cls =
             'btn btn-sm me-05 align-items-center ' +
             (isAllSelected ? 'btn-secondary' : 'btn-outline-secondary');
         const tooltip =
             !isAllSelected && !isEnabled
-                ? `"Select All" is disabled since the total file count exceeds the upper limit: ${SELECT_ALL_LIMIT}`
+                ? `The maximum number of files that can be downloaded at a time is 3,000 for an optimal download speed and portal performance. If >3,000 files need to be downloaded, please download them in multiple smaller batches of files.: ${SELECT_ALL_LIMIT}`
                 : null;
 
         if (type === 'checkbox') {
@@ -471,7 +486,8 @@ export class SelectAllFilesButton extends React.PureComponent {
                         }
                         style={{
                             width:
-                                progressTrackWidth && Number.isFinite(progressTrackWidth)
+                                progressTrackWidth &&
+                                Number.isFinite(progressTrackWidth)
                                     ? `${progressTrackWidth}px`
                                     : '100%',
                         }}>
@@ -503,8 +519,8 @@ export class SelectAllFilesButton extends React.PureComponent {
                             {selecting
                                 ? `Selecting ${selectingProgress}%`
                                 : isAllSelected
-                                    ? 'Deselect'
-                                    : 'Select'}{' '}
+                                ? 'Deselect'
+                                : 'Select'}{' '}
                         </span>
                         <span className="text-600">All</span>
                     </button>
@@ -514,7 +530,8 @@ export class SelectAllFilesButton extends React.PureComponent {
                         className="progress mt-03 select-all-progress select-all-progress-button"
                         style={{
                             width:
-                                progressTrackWidth && Number.isFinite(progressTrackWidth)
+                                progressTrackWidth &&
+                                Number.isFinite(progressTrackWidth)
                                     ? `${progressTrackWidth}px`
                                     : '100%',
                         }}>
@@ -1359,7 +1376,10 @@ const SelectedItemsDownloadStartButton = React.memo(
                         className="btn btn-primary mt-0 me-1 btn-block-xs-only"
                         data-tip="Details for each individual selected file delivered via a TSV spreadsheet.">
                         <i className="icon icon-fw icon-download fas me-1" />
-                        Download <b>{isAWSDownload ? 'AWS CLI ' : 'cURL'}</b> File Manifest
+                        Download <b>
+                            {isAWSDownload ? 'AWS CLI ' : 'cURL'}
+                        </b>{' '}
+                        File Manifest
                     </button>
                 </form>
             </>

--- a/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
+++ b/src/encoded/static/components/static-pages/components/SelectAllAboveTableComponent.js
@@ -97,7 +97,7 @@ export const SelectAllAboveTableComponent = (props) => {
     );
 };
 
-const SELECT_ALL_LIMIT = 8000;
+const SELECT_ALL_LIMIT = 3000;
 
 const manifest_enum_map = [
     'file',

--- a/src/encoded/static/scss/encoded/modules/_tooltip.scss
+++ b/src/encoded/static/scss/encoded/modules/_tooltip.scss
@@ -1,36 +1,40 @@
-
 /*** Override ReactTooltip styles ***/
 
 /**************** React Tooltips (NPM: react-tooltip) overwrite of styling *********************/
 
 body .__react_component_tooltip {
-
     padding: 7px 15px;
-	z-index: 9999 !important;
+    z-index: 9999 !important;
 
     max-width: 630px;
     @include media-breakpoint-down(sm) {
-        max-width : 400px;
+        max-width: 400px;
     }
     @include media-breakpoint-down(md) {
-        max-width : 500px;
+        max-width: 500px;
     }
     @include media-breakpoint-down(lg) {
-        max-width : 600px;
+        max-width: 600px;
     }
 
-    h1,h2,h3,h4,h5,h6 {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
         color: #fff;
         margin-top: 5px;
         margin-bottom: 5px;
     }
 
-    small + h2, small + h3,
-    small + h4, small + h5,
+    small + h2,
+    small + h3,
+    small + h4,
+    small + h5,
     small + h6 {
         margin-top: 0;
     }
-
 }
 
 /* Probably doesn't do anything useful -- */
@@ -42,58 +46,64 @@ body .__react_component_tooltip {
     }
 }
 
-
 // Styles for Popovers shared across the portal
 
 /*************
 Popover Styles
 **************/
 .popover {
-	&.description-definitions-popover {
-		max-width: 600px;
+    &.description-definitions-popover {
+        max-width: 600px;
 
-		thead > tr > th {
-			background-color: #F1F9FF;
-		}
+        thead > tr > th {
+            background-color: #f1f9ff;
+        }
 
-		.popover-header {
-			font-weight: 600;
-			background-color: #F1F9FF;
-		}
-	}
+        .popover-header {
+            font-weight: 600;
+            background-color: #f1f9ff;
+        }
+    }
 
-	&.download-popover {
-		width: 300px;
-		max-width: 400px;
-		color: #343741;
+    &.download-popover {
+        width: 300px;
+        max-width: 400px;
+        color: #343741;
 
-		.popover-header {
-			margin: 0px;
-			background-color: #F1F9FF;
-			font-weight: 500;
+        .popover-header {
+            margin: 0px;
+            background-color: #f1f9ff;
+            font-weight: 500;
             padding: 8px 12px;
-		}
+        }
 
-		.popover-body {
-			padding: 12px 12px;
-		}
+        .popover-body {
+            padding: 12px 12px;
+        }
 
         // Styles for login popover
         &.login {
             .popover-header {
-                background-color: #DCFCEA;
+                background-color: #dcfcea;
             }
         }
         // Styles for protected popover
         &.protected {
             .popover-header {
-                background-color: #FDDCDC;
+                background-color: #fddcdc;
             }
         }
         &.coming-soon {
             .popover-header {
-                background-color: #F1F9FF;
+                background-color: #f1f9ff;
             }
         }
-	}
+        &.selection-limit {
+            width: 400px;
+
+            .popover-body {
+                padding-right: 20px;
+            }
+        }
+    }
 }


### PR DESCRIPTION
* Decrease the "Select All" upper limit from 8000 to 3000 files
* Update the disabled-state tooltip to reflect the new limit