### PR TITLE
docs: add durable repository agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,80 +1,129 @@
 # Project agent memory
 
-This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+This is the committed guide to durable, project-intrinsic knowledge. Prefer pointers to
+authoritative files over copied details; use `README.rst` for the longer macOS setup walkthrough.
 
-- Add durable project-specific notes here as they are discovered through real work.
+## Repository map
 
-## Building the production Docker image locally
+- `src/encoded/` is the Python `encoded` package (the `src/` layout is declared in
+  `pyproject.toml`). `src/encoded/__init__.py` is the Pyramid application factory and the best
+  overview of registered backend subsystems.
+- `src/encoded/types/` contains item classes, calculated properties, collections, and ACL behavior.
+  Their JSON Schemas live in `src/encoded/schemas/`; versioned schema migrations live in
+  `src/encoded/upgrade/`. Changes to an item model commonly require coordinated edits and tests
+  across all three.
+- `src/encoded/item_utils/` holds reusable domain calculations and predicates. HTTP views and
+  feature endpoints are mostly top-level modules such as `browse.py`, `metadata.py`, and
+  `visualization.py`, plus `src/encoded/endpoints/`. Submission processing is under
+  `src/encoded/ingestion/`; administrative CLIs are under `src/encoded/commands/` and registered in
+  `[tool.poetry.scripts]` in `pyproject.toml`.
+- `src/encoded/static/` is the React frontend. `browser.js` and `server.js` are the client and
+  server-rendering entries; `components/` is organized around browse, item pages, static pages,
+  navigation, forms, shared UI, and visualizations. SCSS sources are in `static/scss/`. Webpack and
+  Gulp configuration is in `webpack.config.js` and `gulpfile.js`; generated bundles/CSS go under
+  `static/build/` and `static/css/`.
+- `docs/public/` supplies portal-managed static page content; `docs/source/` contains user-facing
+  documentation sources. `deploy/` contains container/runtime assets and Cypress post-deploy tests.
+  `scripts/` and `bin/` contain developer and operational helpers.
+- Core persistence, indexing, search, CRUD, and ingestion machinery comes from `dcicsnovault`;
+  shared data models and views come from `encoded-core`. Their resolved versions are authoritative
+  in `poetry.lock`, not just the compatible ranges in `pyproject.toml`.
 
-- `Dockerfile` is a BuildKit multi-stage build (`builder` -> `runtime`); it needs
-  BuildKit (`DOCKER_BUILDKIT=1`, or Docker >= 23 default) because of the `# syntax=`
-  directive and the `RUN --mount=type=cache` mounts. `buildspec.yml` sets
-  `DOCKER_BUILDKIT: "1"` for CodeBuild.
-- `docker build .` will fail at `COPY deploy/docker/local/docker_development.ini` with
-  `"... not found"` unless that file exists in the build context. It is `.gitignore`d;
-  CI creates it in `buildspec.yml` pre_build (`touch deploy/docker/local/docker_development.ini`).
-  To build locally, `touch deploy/docker/local/docker_development.ini` first.
-- nginx is NOT Debian's stock package: `deploy/docker/production/install_nginx_bullseye.sh`
-  installs a pinned nginx.org build (1.21.6) and creates the non-root `nginx` user at
-  uid/gid 121. The container runs everything as `nginx` under `supervisord` (which now also
-  runs nginx via `[program:nginx]`; the entrypoints no longer `service nginx start`).
+## Architecture and data flow
 
-## Running the Python test suite
+- Pyramid starts through the `encoded:main` Paste factory. `include_snovault()` in
+  `src/encoded/__init__.py` selectively registers the framework services, while `include_encoded()`
+  registers portal-specific modules. `encoded.project_defs` and `src/encoded/project/` provide the
+  project-specific hooks expected by the shared libraries.
+- JSON Schema defines stored item shape and validation; Python type modules add collection metadata,
+  calculated properties, permissions, and relationships. Writes persist in PostgreSQL, then the
+  Snovault indexer materializes embedded documents in OpenSearch. Browse/search reads normally use
+  OpenSearch; item CRUD and indexing behavior therefore spans schemas, types, embeds, and invalidation.
+- `src/encoded/browse.py` delegates `/browse` to Snovault search. Frame and indexing/search behavior
+  should be checked in the resolved Snovault source before adding portal-side workarounds.
+- Pyramid supplies initial page data and the server-rendered React bundle; the browser bundle then
+  hydrates and calls JSON endpoints. Follow `webpack.config.js` aliases and bundle entries when
+  tracing frontend imports. Shared UI dependencies include `@hms-dbmi-bgm/shared-portal-components`
+  and `@hms-dbmi-bgm/react-workflow-viz` (see `package.json` and their Gulp build steps).
+- Ingestion submissions flow through `src/encoded/ingestion/` into Snovault's listener/message
+  infrastructure. Production runs portal, indexer, ingester, and deployment entrypoint roles from
+  `deploy/docker/production/`; do not assume every role executes the same startup path.
 
-- The project uses a `src/` layout package named `encoded` (see `pyproject.toml`,
-  `packages = [{ include="encoded", from="src" }]`). Tests live under
-  `src/encoded/tests/` and use relative imports (e.g. `from ..item_utils.utils import ...`).
-- `pytest.ini` sets `testpaths = src/encoded deploy` and pulls in datafixtures/serverfixtures
-  plugins, so most tests are integration-style and require Postgres + Elasticsearch (and some
-  require AWS/moto). Pure unit tests that only import functions can be run standalone, e.g.:
-  `pytest src/encoded/tests/test_item_utils.py`.
-- Test markers of note (`pytest.ini`): `-m "not workbook"` selects the non-workbook set,
-  `-m unit` the proper unit tests, `-m static` the static-analysis tests. The Makefile
-  `test-unit` / `test-npm` targets wrap these.
-- Coverage tooling is available (`pytest-cov`, `coverage` are dev deps); add `--cov=encoded.<module>
-  --cov-report=term-missing`. Note: modules imported before coverage starts (via conftest) can
-  show import-time lines as "missed" — judge coverage by whether the function bodies are exercised,
-  not the raw percentage.
+## Configuration and deployment
 
-## S3 upload/download credentials need `S3_UPLOAD_ROLE_ARN` once `encoded-core` >= 1.0.0
+- `base.ini` is the shared Paste/Pyramid base. Local `development.ini` and `test.ini` are generated
+  from ignored `*.template` files by `prepare-local-dev` during `make build`; do not commit generated
+  files or secrets. The generation logic is in `src/encoded/commands/prepare_template.py`.
+- Runtime environment and secret translation happens in `src/encoded/__init__.py` and
+  `deploy/docker/production/assume_identity.py`. Production builds `production.ini` from the AWS
+  Secrets Manager identity named by `IDENTITY`, using `deploy/docker/production/smaht_any_alpha.ini`
+  as the settings convention. Treat identities, Auth0 values, database/search endpoints, and AWS
+  credentials as external configuration.
+- `Dockerfile` is a BuildKit multi-stage build (`builder` then non-root `runtime`). A local production
+  image build needs `touch deploy/docker/local/docker_development.ini` first because the ignored file
+  is copied into the image; `.github/workflows/main.yml` and `buildspec.yml` do the same. Build with
+  `DOCKER_BUILDKIT=1 docker build .` when BuildKit is not already the default.
+- The production image installs the pinned nginx.org build via
+  `deploy/docker/production/install_nginx_bullseye.sh`, rather than Debian nginx. `supervisord.conf`
+  runs nginx and multiple non-root Pyramid processes; role entrypoints build runtime configuration
+  before serving, indexing, ingesting, or deploying.
+- `buildspec.yml` builds and pushes the ECR image. GitHub Actions in `.github/workflows/main.yml`
+  runs the Python test suite and a production Docker build; separate Cypress workflows exercise
+  deployed environments. Deployment configuration is operationally sensitive—document it, but do
+  not casually change it alongside application work.
 
-`encoded_core.types.file.external_creds()` generates the temporary S3 credentials returned by
-`upload_credentials`/`extra_files_creds`/download redirects. As of `encoded-core` 1.0.0 it calls
-`sts:assume_role` (previously `sts:get_federation_token`, changed because `GetFederationToken`
-cannot be called with temporary credentials — which is exactly what OIDC-based
-`aws-actions/configure-aws-credentials` produces in CI).
+## Local development
 
-`assume_role` requires an explicit `RoleArn`. That value comes *only* from:
-- `identity.get('S3_UPLOAD_ROLE_ARN')` when the `IDENTITY` env var is set (production path, value
-  lives in the app's Secrets Manager `GLOBAL_APPLICATION_CONFIGURATION` secret), or
-- `os.environ.get('S3_UPLOAD_ROLE_ARN')` otherwise — the path taken by unit tests, since
-  `conftest.py` sets `USE_SAMPLE_ENVUTILS = True` and never sets `IDENTITY`.
+- Supported Python is declared in `pyproject.toml` (currently 3.11/3.12); CI uses Python 3.11 and
+  Node 20. Use the lockfiles and repository commands rather than ad hoc dependency upgrades.
+- `make build` installs frontend dependencies with `npm ci`, builds assets, installs Poetry 1.8.5
+  and Python dependencies, and generates local INI files. It also downloads AWS IP ranges and
+  restricted-domain data, so it requires network access.
+- Start PostgreSQL/OpenSearch/nginx and load local data with `make deploy1`, then serve Pyramid in a
+  second terminal with `make deploy2`; the portal is proxied at `http://localhost:8000`. Variants
+  `deploy1a`/`deploy1b` separate the ingestion listener for debugging. These commands clear the local
+  `/tmp/encoded` data area; `make kill` uses broad process-name kills and must be used carefully.
+- Useful frontend loops are `npm run dev-quick`, `npm run watch-scss`, `npm run lint`, and
+  `npm run build`. The Makefile remains the authoritative command catalog (`make help`).
 
-There is no `S3_UPLOAD_ROLE_ARN` wired into this repo's CI (`.github/workflows/main.yml`),
-`Makefile`, or `conftest.py`, so any test that exercises file upload/download credentials
-(`test_permissions.py`, `test_types_file.py`, `test_schema_meta_workflow.py`, etc.) fails with
-`ParamValidationError: Invalid type for parameter RoleArn, value: None` until that env var is set
-to a real IAM role ARN. That role must (a) have S3 `GetObject`/`PutObject`/`ListBucket` on the
-unit-test buckets (e.g. `smaht-unit-testing-wfout`), and (b) trust whatever identity the CI job
-authenticates as (the role behind `AWS_OIDC_ROLE_ARN`) for `sts:AssumeRole`. This is an AWS IAM
-change plus a new GitHub Actions secret — not fixable from application code alone. See PR #646 for
-the full investigation.
+## Tests and checks
 
-## `dcicsnovault` currently resolves to 11.32.1 and includes upstream ES-efficiency fixes
+- `pytest.ini` sets test roots to `src/encoded` and `deploy` and loads custom fixtures from
+  `src/encoded/tests/datafixtures.py` and `snovault.tests.serverfixtures`. Most backend tests are integration-like
+  and start PostgreSQL/OpenSearch; fixtures and shared settings are in `src/encoded/tests/conftest.py`
+  and `conftest_settings.py`.
+- Focus first: `pytest -vv src/encoded/tests/test_<area>.py` or add `-k <name>`. Pure utility tests can
+  run alone, but schema/type/view tests usually need the fixture stack. Add
+  `--cov=encoded.<module> --cov-report=term-missing` for focused coverage; conftest imports before
+  coverage starts can make import-time lines appear missed.
+- `make test` runs both marker groups. Despite legacy target names, `make test-unit` means
+  `-m "not workbook"` and `make test-npm` means `-m workbook`; trust the recipes in `Makefile`.
+  `make test-static` runs static pytest checks plus frontend lint. `make remote-test` uses the shared
+  AWS-authenticated OpenSearch test service and is the CI path, not a credential-free local check.
+- React/Jest tests live in `src/encoded/static/components/__tests__/`; Cypress specifications and
+  configuration live under `deploy/post_deploy_testing/`. Use the `cypress:*` scripts in
+  `package.json`; they require Auth0 credentials and an explicit/local or deployed target.
 
-`pyproject.toml` declares `dcicsnovault = "^11.30.0"` (a caret range, not an exact pin), and
-`poetry.lock` currently resolves that dependency to `dcicsnovault` `11.32.1`. The lock file header
-says it was generated by `Poetry 1.8.5`, matching the `Makefile`'s `pip install poetry==1.8.5`.
+## Integration and operational sharp edges
 
-As of the PR #705 investigation, the resolved `dcicsnovault 11.32.1` source distribution includes
-the snovault search-efficiency fixes previously referenced from
-https://github.com/4dn-dcic/snovault/pull/318: `compound_search` restricts `_source` to
-`embedded.*`, default facets are skipped for non-embedded frames, `frame=object`/`raw` only fetch
-their corresponding ES source frame, and `limit=all` pagination drops repeated `aggs` and
-`track_total_hits` from subsequent page queries. It also includes `snovault/tests/test_search_efficiency.py`
-covering those behaviors.
+- AWS-backed tests generally need usable AWS credentials and `GLOBAL_ENV_BUCKET`. Temporary S3
+  upload/download credentials also require `S3_UPLOAD_ROLE_ARN`: production reads it through the
+  configured identity, while tests without `IDENTITY` read the environment variable. CI supplies it
+  from `AWS_OIDC_ROLE_ARN`; local runs must supply an assumable role with the required bucket access.
+- Test indices are shared remote infrastructure when `--aws-auth --es ...` is used. Preserve the
+  unique `TEST_JOB_ID` convention and cleanup behavior in `.github/workflows/main.yml` to avoid
+  collisions or leaked indices.
+- Search behavior can change through compatible dependency resolution. The current lockfile resolves
+  Snovault with source-frame filtering, facet avoidance for non-embedded frames, and efficient
+  `limit=all` pagination. Recheck `poetry.lock` and resolved package code before claiming a dependency
+  bump or portal patch is needed.
+- Schema changes are migrations, not only JSON edits: update `src/encoded/upgrade/` when existing
+  stored data must transform, bump schema versions according to neighboring types, and cover both
+  schema validation and upgrader behavior.
 
-Because `/browse` delegates directly to snovault's shared `search()` in `src/encoded/browse.py`,
-`/browse` already gets those upstream search-efficiency fixes through the current caret-resolved
-lockfile. Do not leave stale "waiting on a dependency bump" language for these fixes unless
-`pyproject.toml` or `poetry.lock` changes again and you have rechecked the resolved package code.
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.


### PR DESCRIPTION
## Summary
- expand the root AGENTS.md into a pointer-heavy repository and architecture guide
- document configuration, deployment, local development, CI, tests, and operational sharp edges
- preserve the tracked relative CLAUDE.md -> AGENTS.md symlink
- correct stale S3 role guidance to match the current CI workflow

## Validation
- fm-ensure-agents-md.sh .
- git diff --check
- verified CLAUDE.md is a tracked relative symlink
- verified documented repository paths exist

Documentation only; no application behavior or configuration changed.