### PR TITLE
Submission Status: Add Auto-review QC

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,21 @@ Change Log
 ----------
 
 
+2.5.0
+=====
+
+`PR 718: Submission Status: Add Auto-review QC <https://github.com/smaht-dac/smaht-portal/pull/718>`_
+
+* Add automated file set QC review to the Submission Status page: evaluate Warn/Fail QC
+  metrics on submitted and processed files and group coverage against target, then tag
+  file sets ("reviewed", plus "ready_to_release" when they pass) and record an
+  auto-review comment for each QC problem. Existing manual tags and comments are kept.
+* Add an "Auto-review QC" action in the "QC status" column header (admin-only, with
+  confirmation) that reviews every file set in the current view at once.
+* Fix tissue filtering so benchmarking file sets (whose ``tissue_type`` omits the code
+  prefix) are no longer dropped, and add ``tissue_type`` to the file set embedded list.
+
+
 2.4.4
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "2.4.4"
+version = "2.5.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/static-pages/components/internal/SubmissionStatus.js
+++ b/src/encoded/static/components/static-pages/components/internal/SubmissionStatus.js
@@ -22,7 +22,7 @@ import {
     getCommentInputField,
     getPagination,
     isActiveFileStatus,
-    computeGroupCoverageNumeric,
+    computeGroupCoverage,
     collectProblematicQcValues,
     groupProblematicQcByMetric,
 } from './utils';
@@ -33,6 +33,7 @@ import {
     SUBMISSION_STATUS_DEFAULT_FILTER,
     AUTO_REVIEW_COMMENT_PREFIX,
     AUTO_REVIEW_COVERAGE_THRESHOLD,
+    COVERAGE_QC_METRIC,
     TAG_REVIEWED,
     TAG_READY_TO_RELEASE,
 } from './config';
@@ -347,21 +348,27 @@ class SubmissionStatusComponent extends React.PureComponent {
         });
     };
 
-    // Coverage is only checked when target_coverage is set and a calculated group
-    // coverage is available. Otherwise the check is skipped.
+    // Coverage is only checked when target_coverage is set. When no coverage
+    // metric is present at all there is nothing to verify and the check is
+    // skipped. When the metric is present but has no usable numeric value,
+    // coverage cannot be verified, so we fail the check rather than let the
+    // fileset pass silently.
     evaluateCoverage = (fs, processedFiles) => {
         const target = fs.sequencing?.target_coverage;
         if (!target) {
             return { checked: false };
         }
-        const calculated = computeGroupCoverageNumeric(processedFiles);
-        if (calculated === null) {
+        const { coverage, metricPresent } = computeGroupCoverage(processedFiles);
+        if (coverage === null) {
+            if (metricPresent) {
+                return { checked: true, ok: false, unavailable: true, target };
+            }
             return { checked: false };
         }
         return {
             checked: true,
-            ok: calculated >= AUTO_REVIEW_COVERAGE_THRESHOLD * target,
-            calculated,
+            ok: coverage >= AUTO_REVIEW_COVERAGE_THRESHOLD * target,
+            calculated: coverage,
             target,
         };
     };
@@ -409,6 +416,15 @@ class SubmissionStatusComponent extends React.PureComponent {
             `${AUTO_REVIEW_COMMENT_PREFIX} Coverage below threshold: calculated ` +
             `group coverage ${this.round1(coverage.calculated)}x is ${pct}% of ` +
             `target ${coverage.target}x.`
+        );
+    };
+
+    buildCoverageUnavailableComment = (coverage) => {
+        return (
+            `${AUTO_REVIEW_COMMENT_PREFIX} Coverage could not be verified: the ` +
+            `coverage metric (${COVERAGE_QC_METRIC}) is present but has no numeric ` +
+            `value, while a target coverage of ${coverage.target}x is set. ` +
+            `Review manually.`
         );
     };
 
@@ -524,7 +540,11 @@ class SubmissionStatusComponent extends React.PureComponent {
             auto.push(this.buildQcFallbackComment());
         }
         if (coverageFails) {
-            auto.push(this.buildCoverageComment(coverage));
+            auto.push(
+                coverage.unavailable
+                    ? this.buildCoverageUnavailableComment(coverage)
+                    : this.buildCoverageComment(coverage)
+            );
         }
 
         const comments = [...auto, ...manual];

--- a/src/encoded/static/components/static-pages/components/internal/SubmissionStatus.js
+++ b/src/encoded/static/components/static-pages/components/internal/SubmissionStatus.js
@@ -243,10 +243,17 @@ class SubmissionStatusComponent extends React.PureComponent {
                     return;
                 } else {
                     this.setState(
-                        (prevState) => ({
-                            fileSets: filesets,
-                            loading: false,
-                        }),
+                        (prevState) => {
+                            const updated = filesets.find(
+                                (f) => f.uuid === fs_uuid
+                            );
+                            const merged = updated
+                                ? prevState.fileSets.map((f) =>
+                                    f.uuid === fs_uuid ? updated : f
+                                )
+                                : filesets;
+                            return { fileSets: merged, loading: false };
+                        },
                         function () {
                             if (onDone) {
                                 onDone();
@@ -375,31 +382,26 @@ class SubmissionStatusComponent extends React.PureComponent {
 
     round1 = (num) => Math.round(num * 10) / 10;
 
-    buildSubmittedQcComment = (groups) => {
-        const parts = groups.map((g) => {
-            let part = `'${g.key}' (${g.flag}) in ${g.count} file(s)`;
-            if (g.numeric) {
-                part +=
-                    g.min === g.max
-                        ? ` with value ${formatQcValue(g.min)}`
-                        : ` with values between ${formatQcValue(
-                              g.min
-                          )} and ${formatQcValue(g.max)}`;
-            }
-            return part;
-        });
-        return `${AUTO_REVIEW_COMMENT_PREFIX} Submitted file QC issues: ${parts.join(
-            '; '
-        )}`;
+    // One comment per problematic submitted-file metric (group).
+    buildSubmittedQcComment = (g) => {
+        let part = `'${g.key}' (${g.flag}) in ${g.count} file(s)`;
+        if (g.numeric) {
+            const min = formatQcValue(g.min);
+            const max = formatQcValue(g.max);
+            part +=
+                g.min === g.max
+                    ? ` with value ${min}`
+                    : ` with values between ${min} and ${max}`;
+        }
+        return `${AUTO_REVIEW_COMMENT_PREFIX} Submitted file QC issue: ${part}`;
     };
 
-    buildOutputQcComment = (problems) => {
-        const parts = problems.map(
-            (p) => `${p.accession} ${p.key}=${formatQcValue(p.value)} (${p.flag})`
+    // One comment per problematic output-file QC value.
+    buildOutputQcComment = (p) => {
+        return (
+            `${AUTO_REVIEW_COMMENT_PREFIX} Output file QC issue: ` +
+            `${p.key}=${formatQcValue(p.value)} (${p.flag})`
         );
-        return `${AUTO_REVIEW_COMMENT_PREFIX} Output file QC issues: ${parts.join(
-            '; '
-        )}`;
     };
 
     buildQcFallbackComment = () => {
@@ -428,8 +430,9 @@ class SubmissionStatusComponent extends React.PureComponent {
         );
     };
 
-    // "Review" button handler. Fetches detailed QC for the file group, applies the
-    // review rules, and patches tags + comments in a single request.
+    // Fetches detailed QC for a single file group, applies the review rules, and
+    // patches tags + comments in a single request. Called per fileset by the
+    // "Auto-review QC" header action (autoReviewAllFilesets).
     autoReviewFileset = (fs) => {
         if (this.state.reviewingFilesets.includes(fs.uuid)) {
             return;
@@ -494,6 +497,29 @@ class SubmissionStatusComponent extends React.PureComponent {
         );
     };
 
+    // Review every fileset currently shown in the table. Reuses the per-fileset
+    // worker, firing all reviews concurrently. Each review patches tags/comments
+    // into local state as it completes (see patchFileset), so no reload is
+    // needed; the spinner clears once every fileset has finished.
+    autoReviewAllFilesets = () => {
+        if (this.state.reviewingFilesets.length > 0) {
+            return;
+        }
+        const filesets = [...this.state.fileSets];
+        if (filesets.length === 0) {
+            return;
+        }
+        if (
+            !window.confirm(
+                `Auto-review QC for ${filesets.length} file set(s) in the current view?`
+            )
+        ) {
+            return;
+        }
+
+        filesets.forEach((fs) => this.autoReviewFileset(fs));
+    };
+
     applyReviewResult = (
         fs,
         qcBlocks,
@@ -526,12 +552,12 @@ class SubmissionStatusComponent extends React.PureComponent {
             (c) => !c.startsWith(AUTO_REVIEW_COMMENT_PREFIX)
         );
         const auto = [];
-        if (submittedProblems.length > 0) {
-            auto.push(this.buildSubmittedQcComment(submittedProblems));
-        }
-        if (outputProblems.length > 0) {
-            auto.push(this.buildOutputQcComment(outputProblems));
-        }
+        submittedProblems.forEach((g) => {
+            auto.push(this.buildSubmittedQcComment(g));
+        });
+        outputProblems.forEach((p) => {
+            auto.push(this.buildOutputQcComment(p));
+        });
         if (
             qcBlocks &&
             submittedProblems.length === 0 &&
@@ -710,29 +736,6 @@ class SubmissionStatusComponent extends React.PureComponent {
                 }
             });
 
-            const isReviewing = this.state.reviewingFilesets.includes(fs.uuid);
-            const reviewButton = this.state.isUserAdmin ? (
-                <small className="d-block text-secondary ss-line-height-140 mt-1">
-                    <div
-                        className="ss-link"
-                        //data-tip="Automatically review QC and set tags/comments"
-                        onClick={() =>
-                            isReviewing ? null : this.autoReviewFileset(fs)
-                        }>
-                        <i
-                            className={
-                                'icon icon-fw fas ' +
-                                (isReviewing
-                                    ? 'icon-spinner icon-spin'
-                                    : 'icon-clipboard-check')
-                            }></i>
-                        Auto-review QC
-                    </div>
-                </small>
-            ) : (
-                ''
-            );
-
             const submittedFilesQc = getQcResults(fs.submitted_files.qc_infos);
             const submittedFilesQcSummary = getQcResultsSummary(
                 fs.submitted_files.qc_infos
@@ -840,7 +843,6 @@ class SubmissionStatusComponent extends React.PureComponent {
                                 Review File Group QC
                             </div>
                         </small>
-                        {reviewButton}
                     </td>
                     <td>
                         <div className="p-1">{mwfrs}</div>
@@ -872,6 +874,8 @@ class SubmissionStatusComponent extends React.PureComponent {
                 </div>
             );
         }
+
+        const reviewingAll = this.state.reviewingFilesets.length > 0;
 
         return (
             <React.Fragment>
@@ -960,6 +964,25 @@ class SubmissionStatusComponent extends React.PureComponent {
                                             marginLeft: 3,
                                         },
                                     }}></object.CopyWrapper>
+                                {this.state.isUserAdmin && (
+                                    <i
+                                        className={
+                                            'icon icon-fw fas ss-link ' +
+                                            (reviewingAll
+                                                ? 'icon-spinner icon-spin'
+                                                : 'icon-clipboard-check')
+                                        }
+                                        data-tip="Auto-review QC for all file sets in the current view"
+                                        onClick={() =>
+                                            reviewingAll
+                                                ? null
+                                                : this.autoReviewAllFilesets()
+                                        }
+                                        style={{
+                                            fontSize: '0.875rem',
+                                            marginLeft: 3,
+                                        }}></i>
+                                )}
                             </th>
                             <th className="text-start">MetaWorkflowRuns</th>
                             <th className="text-start">

--- a/src/encoded/static/components/static-pages/components/internal/SubmissionStatus.js
+++ b/src/encoded/static/components/static-pages/components/internal/SubmissionStatus.js
@@ -9,6 +9,7 @@ import {
 import {
     fallbackCallback,
     formatDate,
+    formatQcValue,
     getLink,
     createBadge,
     createWarningIcon,
@@ -20,12 +21,20 @@ import {
     isReleasedInternally,
     getCommentInputField,
     getPagination,
+    isActiveFileStatus,
+    computeGroupCoverageNumeric,
+    collectProblematicQcValues,
+    groupProblematicQcByMetric,
 } from './utils';
 
 import {
     PAGE_SIZE,
     SUBMISSION_STATUS_TAGS,
     SUBMISSION_STATUS_DEFAULT_FILTER,
+    AUTO_REVIEW_COMMENT_PREFIX,
+    AUTO_REVIEW_COVERAGE_THRESHOLD,
+    TAG_REVIEWED,
+    TAG_READY_TO_RELEASE,
 } from './config';
 
 import { SubmissionStatusFilter } from './SubmissionStatusFilter';
@@ -51,6 +60,7 @@ class SubmissionStatusComponent extends React.PureComponent {
             submittedFilesVisibility: [],
             comments: {},
             newComments: {},
+            reviewingFilesets: [],
             isUserAdmin: userDetails.details.groups?.includes('admin'),
             modal: null,
         };
@@ -220,12 +230,15 @@ class SubmissionStatusComponent extends React.PureComponent {
         });
     };
 
-    patchFileset = (fs_uuid, filesets, payload) => {
+    patchFileset = (fs_uuid, filesets, payload, onDone = null) => {
         ajax.load(
             fs_uuid,
             (resp) => {
                 if (resp.status !== 'success') {
                     console.error(resp);
+                    if (onDone) {
+                        onDone();
+                    }
                     return;
                 } else {
                     this.setState(
@@ -234,13 +247,21 @@ class SubmissionStatusComponent extends React.PureComponent {
                             loading: false,
                         }),
                         function () {
+                            if (onDone) {
+                                onDone();
+                            }
                             this.forceUpdate();
                         }
                     );
                 }
             },
             'PATCH',
-            fallbackCallback,
+            (errResp, xhr) => {
+                fallbackCallback(errResp, xhr);
+                if (onDone) {
+                    onDone();
+                }
+            },
             JSON.stringify(payload)
         );
     };
@@ -296,6 +317,226 @@ class SubmissionStatusComponent extends React.PureComponent {
                     isUserAdmin={this.state.isUserAdmin}></FileGroupQCModal>
             ),
         });
+    };
+
+    clearReviewing = (fsUuid) => {
+        this.setState((prevState) => ({
+            reviewingFilesets: prevState.reviewingFilesets.filter(
+                (uuid) => uuid !== fsUuid
+            ),
+        }));
+    };
+
+    // Whether any (active) submitted or output file has a Warn/Fail QC flag. Uses
+    // the row payload (overall_quality_status), which is authoritative and not
+    // subject to the /get_file_group_qc/ per-value cap. NA/missing does not block.
+    rowHasBlockingQc = (fs) => {
+        const qcInfos = [
+            ...(fs.submitted_files?.qc_infos ?? []),
+            ...(fs.output_files?.qc_infos ?? []),
+        ];
+        return qcInfos.some((info) => {
+            if (!isActiveFileStatus(info.status)) {
+                return false;
+            }
+            return (info.quality_metrics ?? []).some(
+                (qm) =>
+                    qm.overall_quality_status === 'Warn' ||
+                    qm.overall_quality_status === 'Fail'
+            );
+        });
+    };
+
+    // Coverage is only checked when target_coverage is set and a calculated group
+    // coverage is available. Otherwise the check is skipped.
+    evaluateCoverage = (fs, processedFiles) => {
+        const target = fs.sequencing?.target_coverage;
+        if (!target) {
+            return { checked: false };
+        }
+        const calculated = computeGroupCoverageNumeric(processedFiles);
+        if (calculated === null) {
+            return { checked: false };
+        }
+        return {
+            checked: true,
+            ok: calculated >= AUTO_REVIEW_COVERAGE_THRESHOLD * target,
+            calculated,
+            target,
+        };
+    };
+
+    round1 = (num) => Math.round(num * 10) / 10;
+
+    buildSubmittedQcComment = (groups) => {
+        const parts = groups.map((g) => {
+            let part = `'${g.key}' (${g.flag}) in ${g.count} file(s)`;
+            if (g.numeric) {
+                part +=
+                    g.min === g.max
+                        ? ` with value ${formatQcValue(g.min)}`
+                        : ` with values between ${formatQcValue(
+                              g.min
+                          )} and ${formatQcValue(g.max)}`;
+            }
+            return part;
+        });
+        return `${AUTO_REVIEW_COMMENT_PREFIX} Submitted file QC issues: ${parts.join(
+            '; '
+        )}`;
+    };
+
+    buildOutputQcComment = (problems) => {
+        const parts = problems.map(
+            (p) => `${p.accession} ${p.key}=${formatQcValue(p.value)} (${p.flag})`
+        );
+        return `${AUTO_REVIEW_COMMENT_PREFIX} Output file QC issues: ${parts.join(
+            '; '
+        )}`;
+    };
+
+    buildQcFallbackComment = () => {
+        return (
+            `${AUTO_REVIEW_COMMENT_PREFIX} QC issues blocking release: one or more ` +
+            `quality metrics have a Warn/Fail overall status; detailed values were ` +
+            `not available from the QC endpoint. Review manually.`
+        );
+    };
+
+    buildCoverageComment = (coverage) => {
+        const pct = this.round1((coverage.calculated / coverage.target) * 100);
+        return (
+            `${AUTO_REVIEW_COMMENT_PREFIX} Coverage below threshold: calculated ` +
+            `group coverage ${this.round1(coverage.calculated)}x is ${pct}% of ` +
+            `target ${coverage.target}x.`
+        );
+    };
+
+    // "Review" button handler. Fetches detailed QC for the file group, applies the
+    // review rules, and patches tags + comments in a single request.
+    autoReviewFileset = (fs) => {
+        if (this.state.reviewingFilesets.includes(fs.uuid)) {
+            return;
+        }
+        this.setState((prevState) => ({
+            reviewingFilesets: [...prevState.reviewingFilesets, fs.uuid],
+        }));
+
+        const payload = {
+            fileSetUuid: fs.uuid,
+            fileGroup: fs.file_group,
+        };
+
+        ajax.load(
+            '/get_file_group_qc/',
+            (resp) => {
+                if (resp.error) {
+                    console.error(resp.error);
+                    this.clearReviewing(fs.uuid);
+                    return;
+                }
+
+                const files = resp.files_with_qcs ?? [];
+                const submittedFiles = files.filter(
+                    (f) =>
+                        f.fileset_uuid === fs.uuid &&
+                        !f.is_output_file &&
+                        isActiveFileStatus(f.status)
+                );
+                const outputFiles = files.filter(
+                    (f) =>
+                        f.fileset_uuid === fs.uuid &&
+                        f.is_output_file &&
+                        isActiveFileStatus(f.status)
+                );
+                // Coverage is a group-level metric (across all filesets in the group)
+                const processedGroupFiles = files.filter(
+                    (f) => f.is_output_file && isActiveFileStatus(f.status)
+                );
+
+                const qcBlocks = this.rowHasBlockingQc(fs);
+                const submittedProblems = groupProblematicQcByMetric(
+                    collectProblematicQcValues(submittedFiles)
+                );
+                const outputProblems = collectProblematicQcValues(outputFiles);
+                const coverage = this.evaluateCoverage(fs, processedGroupFiles);
+
+                this.applyReviewResult(
+                    fs,
+                    qcBlocks,
+                    submittedProblems,
+                    outputProblems,
+                    coverage
+                );
+            },
+            'POST',
+            (errResp, xhr) => {
+                fallbackCallback(errResp, xhr);
+                this.clearReviewing(fs.uuid);
+            },
+            JSON.stringify(payload)
+        );
+    };
+
+    applyReviewResult = (
+        fs,
+        qcBlocks,
+        submittedProblems,
+        outputProblems,
+        coverage
+    ) => {
+        const filesets = JSON.parse(JSON.stringify(this.state.fileSets));
+        const target = filesets.find((x) => x.uuid === fs.uuid);
+        if (!target) {
+            this.clearReviewing(fs.uuid);
+            return;
+        }
+
+        const coverageFails = coverage.checked && !coverage.ok;
+        const passes = !qcBlocks && !coverageFails;
+
+        // Tags: only ever add tags, never remove. Always add "reviewed"; add
+        // "ready_to_release" when passing.
+        const tags = Array.isArray(target.tags) ? [...target.tags] : [];
+        if (!tags.includes(TAG_REVIEWED)) {
+            tags.push(TAG_REVIEWED);
+        }
+        if (passes && !tags.includes(TAG_READY_TO_RELEASE)) {
+            tags.push(TAG_READY_TO_RELEASE);
+        }
+
+        // Comments: strip previous auto-review comments, regenerate, keep manual ones
+        const manual = (target.comments ?? []).filter(
+            (c) => !c.startsWith(AUTO_REVIEW_COMMENT_PREFIX)
+        );
+        const auto = [];
+        if (submittedProblems.length > 0) {
+            auto.push(this.buildSubmittedQcComment(submittedProblems));
+        }
+        if (outputProblems.length > 0) {
+            auto.push(this.buildOutputQcComment(outputProblems));
+        }
+        if (
+            qcBlocks &&
+            submittedProblems.length === 0 &&
+            outputProblems.length === 0
+        ) {
+            auto.push(this.buildQcFallbackComment());
+        }
+        if (coverageFails) {
+            auto.push(this.buildCoverageComment(coverage));
+        }
+
+        const comments = [...auto, ...manual];
+        target.tags = tags.length ? tags : null;
+        target.comments = comments;
+
+        this.patchFileset(
+            fs.uuid,
+            filesets,
+            { tags: target.tags, comments },
+            () => this.clearReviewing(fs.uuid)
+        );
     };
 
     getSubmissionTableBody = () => {
@@ -449,6 +690,29 @@ class SubmissionStatusComponent extends React.PureComponent {
                 }
             });
 
+            const isReviewing = this.state.reviewingFilesets.includes(fs.uuid);
+            const reviewButton = this.state.isUserAdmin ? (
+                <small className="d-block text-secondary ss-line-height-140 mt-1">
+                    <div
+                        className="ss-link"
+                        //data-tip="Automatically review QC and set tags/comments"
+                        onClick={() =>
+                            isReviewing ? null : this.autoReviewFileset(fs)
+                        }>
+                        <i
+                            className={
+                                'icon icon-fw fas ' +
+                                (isReviewing
+                                    ? 'icon-spinner icon-spin'
+                                    : 'icon-clipboard-check')
+                            }></i>
+                        Auto-review QC
+                    </div>
+                </small>
+            ) : (
+                ''
+            );
+
             const submittedFilesQc = getQcResults(fs.submitted_files.qc_infos);
             const submittedFilesQcSummary = getQcResultsSummary(
                 fs.submitted_files.qc_infos
@@ -552,14 +816,18 @@ class SubmissionStatusComponent extends React.PureComponent {
                             <div
                                 className="ss-link"
                                 onClick={() => this.toggleFileGroupQc(fs)}>
+                                <i className="icon icon-fw fas icon-search"></i>
                                 Review File Group QC
                             </div>
                         </small>
+                        {reviewButton}
                     </td>
                     <td>
                         <div className="p-1">{mwfrs}</div>
                     </td>
-                    <td>{filesetStatusTags}</td>
+                    <td>
+                        {filesetStatusTags}
+                    </td>
                 </tr>
             );
         });

--- a/src/encoded/static/components/static-pages/components/internal/SubmissionStatusFileGroupQcModal.js
+++ b/src/encoded/static/components/static-pages/components/internal/SubmissionStatusFileGroupQcModal.js
@@ -17,6 +17,8 @@ import {
     shortenStringKeepBothEnds,
     getCommentsList,
     getTargetCoverage,
+    reformatQcValues,
+    computeGroupCoverageNumeric,
 } from './utils';
 
 class FileGroupQCModalComponent extends React.PureComponent {
@@ -62,7 +64,7 @@ class FileGroupQCModalComponent extends React.PureComponent {
                 // We need to reformat the QC values so that we have fast access to
                 // individual values
                 files.forEach((file) => {
-                    file['qc_values_dict'] = this.reformatQcValues(
+                    file['qc_values_dict'] = reformatQcValues(
                         file.quality_metric?.qc_values
                     );
                 });
@@ -90,35 +92,12 @@ class FileGroupQCModalComponent extends React.PureComponent {
         );
     };
 
-    // We need to index the qc values from the portal by derived_from for efficient access
-    reformatQcValues = (qcValues) => {
-        const result = {};
-        qcValues.forEach((qcValue) => {
-            result[qcValue.derived_from] = qcValue;
-        });
-        return result;
-    };
-
     getEstimatedCoverage = (processedFiles) => {
-        const coverage_metric = 'mosdepth:total';
-        const filesSeen = [];
-        let estimated_coverage = 0;
         if (processedFiles.length === 0) {
             return 'NA';
         }
-        for (const pf of processedFiles) {
-            const qcValues = pf['qc_values_dict'];
-            if (coverage_metric in qcValues) {
-                // If there are multiple QM items for the same file we don't want to count the coverage more than once
-                if (filesSeen.includes(pf.accession)) {
-                    continue;
-                }
-                const cov = qcValues[coverage_metric]['value'];
-                estimated_coverage += cov;
-                filesSeen.push(pf.accession);
-            }
-        }
-        return estimated_coverage > 0.0
+        const estimated_coverage = computeGroupCoverageNumeric(processedFiles);
+        return estimated_coverage && estimated_coverage > 0.0
             ? formatQcValue(estimated_coverage)
             : 'NA';
     };

--- a/src/encoded/static/components/static-pages/components/internal/SubmissionStatusFilter.js
+++ b/src/encoded/static/components/static-pages/components/internal/SubmissionStatusFilter.js
@@ -57,25 +57,22 @@ class SubmissionStatusFilterComponent extends React.PureComponent {
             (items) => {
                 const primaryTissues = [];
                 items.forEach((item) => {
-                    const tissue_type = item.display_title;
-
-                    const tissue_type_formatted = tissue_type.split(' - ')[1] || tissue_type;
-                    primaryTissues.push(tissue_type_formatted);
+                    primaryTissues.push(item.display_title);
                 });
+                primaryTissues.push("3AC - Fibroblast");
                 const tissuesAndMixtures = [
                     ...primaryTissues.sort((a, b) => a.localeCompare(b)),
                     ...CELL_CULTURE_MIXTURES,
                 ];
                 const selectItems = tissuesAndMixtures.map((tissue) => ({
                     title: tissue,
-                    code: tissue,
+                    code: tissue, // this is used in the search query. Here we need, e.g. "3AK - Brain, Frontal Lobe"
                 }));
                 this.setState({
                     cell_culture_mixtures_and_tissues: selectItems,
                 });
             }
         );
-        
     };
 
     componentDidMount() {
@@ -145,7 +142,9 @@ class SubmissionStatusFilterComponent extends React.PureComponent {
             <option value="in review">In Review</option>,
             <option value="open">Released to public</option>,
             <option value="released-network">Released to network</option>,
-            <option value="released-public-network">Released to public or network</option>,
+            <option value="released-public-network">
+                Released to public or network
+            </option>,
         ];
         const defaultValue = 'in review';
         const filterName = 'fileset_status';
@@ -159,7 +158,12 @@ class SubmissionStatusFilterComponent extends React.PureComponent {
 
         const options = [<option value="all">All</option>];
         this.state.assays.forEach((sc) => {
-            options.push(<option value={sc.title}>{sc.title}</option>);
+            // Escape special characters (e.g. "&" in "varCUT&Tag") so the value
+            // survives the backend's urlencode/unquote round-trip when building
+            // the search subrequest.
+            options.push(
+                <option value={encodeURIComponent(sc.title)}>{sc.title}</option>
+            );
         });
         const defaultValue = 'all';
         const filterName = 'assay';
@@ -173,7 +177,11 @@ class SubmissionStatusFilterComponent extends React.PureComponent {
 
         const options = [<option value="all">All</option>];
         this.state.sequencers.forEach((sc) => {
-            options.push(<option value={sc.title}>{sc.title}</option>);
+            // Escape special characters so the value survives the backend's
+            // urlencode/unquote round-trip when building the search subrequest.
+            options.push(
+                <option value={encodeURIComponent(sc.title)}>{sc.title}</option>
+            );
         });
         const defaultValue = 'all';
         const filterName = 'sequencer';
@@ -201,7 +209,7 @@ class SubmissionStatusFilterComponent extends React.PureComponent {
 
         const options = [<option value="all">All</option>];
         this.state.cell_culture_mixtures_and_tissues.forEach((sc) => {
-            options.push(<option value={sc.code}>{sc.code}</option>);
+            options.push(<option value={sc.code}>{sc.title}</option>);
         });
         const defaultValue = 'all';
         const filterName = 'cell_culture_mixtures_and_tissues';

--- a/src/encoded/static/components/static-pages/components/internal/config.js
+++ b/src/encoded/static/components/static-pages/components/internal/config.js
@@ -10,12 +10,19 @@ export const ANALYSIS_RUN_DEFAULT_FILTER = {
     exclude_tags: [],
 };
 
+export const TAG_REVIEWED = 'reviewed';
+export const TAG_READY_TO_RELEASE = 'ready_to_release';
+
 export const SUBMISSION_STATUS_TAGS = [
-    'ready_to_release',
-    'reviewed',
-    'submitted_files_copied',
-    'output_files_copied',
+    TAG_READY_TO_RELEASE,
+    TAG_REVIEWED,
 ];
+
+// Automated fileset QC review (the "Review" button on the submission status table)
+export const AUTO_REVIEW_COMMENT_PREFIX = '[auto-review]';
+export const AUTO_REVIEW_COVERAGE_THRESHOLD = 0.75;
+// Must match COVERAGE_DERIVED_FROM in src/encoded/types/quality_metric.py
+export const COVERAGE_QC_METRIC = 'mosdepth:total';
 
 export const SUBMISSION_STATUS_DEFAULT_FILTER = {
     submission_center: 'all_gcc',

--- a/src/encoded/static/components/static-pages/components/internal/utils.js
+++ b/src/encoded/static/components/static-pages/components/internal/utils.js
@@ -338,18 +338,26 @@ export const reformatQcValues = (qcValues) => {
 /**
  * Sum the group coverage (mosdepth:total) across the given processed files,
  * deduping by accession so a file with multiple QualityMetric items is not
- * counted more than once. Returns a Number, or null when no coverage metric is
- * present (distinct from a real 0). Accepts files that already carry a
- * `qc_values_dict` or raw files with `quality_metric.qc_values`.
+ * counted more than once. Accepts files that already carry a `qc_values_dict`
+ * or raw files with `quality_metric.qc_values`.
+ *
+ * Returns { coverage, metricPresent }:
+ *   - coverage: the summed Number, or null when no usable numeric value was
+ *     found (distinct from a real 0).
+ *   - metricPresent: whether the coverage metric appeared on any file at all,
+ *     regardless of whether its value was numeric. This lets callers tell
+ *     "no coverage data to check" apart from "coverage present but unusable".
  */
-export const computeGroupCoverageNumeric = (processedFiles) => {
+export const computeGroupCoverage = (processedFiles) => {
     const filesSeen = [];
     let coverage = 0;
-    let found = false;
+    let numericFound = false;
+    let metricPresent = false;
     for (const pf of processedFiles ?? []) {
         const qcValues =
             pf['qc_values_dict'] ?? reformatQcValues(pf.quality_metric?.qc_values);
         if (COVERAGE_QC_METRIC in qcValues) {
+            metricPresent = true;
             // If there are multiple QM items for the same file we don't want to
             // count the coverage more than once
             if (filesSeen.includes(pf.accession)) {
@@ -361,11 +369,19 @@ export const computeGroupCoverageNumeric = (processedFiles) => {
             }
             coverage += cov;
             filesSeen.push(pf.accession);
-            found = true;
+            numericFound = true;
         }
     }
-    return found ? coverage : null;
+    return { coverage: numericFound ? coverage : null, metricPresent };
 };
+
+/**
+ * Numeric-only accessor for the group coverage sum. Returns a Number, or null
+ * when no usable numeric coverage value is present. Used for display where the
+ * "metric present but unusable" distinction does not matter.
+ */
+export const computeGroupCoverageNumeric = (processedFiles) =>
+    computeGroupCoverage(processedFiles).coverage;
 
 /**
  * Collect the problematic (Warn/Fail) qc_values from the given files (already

--- a/src/encoded/static/components/static-pages/components/internal/utils.js
+++ b/src/encoded/static/components/static-pages/components/internal/utils.js
@@ -4,7 +4,12 @@ import { ajax } from '@hms-dbmi-bgm/shared-portal-components/es/components/util'
 import React from 'react';
 import * as d3 from 'd3';
 
-import { EXTERNAL_RELEASE_STATUSES, INTERNAL_RELEASE_STATUSES, PAGE_SIZE } from './config';
+import {
+    COVERAGE_QC_METRIC,
+    EXTERNAL_RELEASE_STATUSES,
+    INTERNAL_RELEASE_STATUSES,
+    PAGE_SIZE,
+} from './config';
 
 export const formatDate = (date_str) => {
     if (!date_str) {
@@ -304,6 +309,134 @@ export const getQcResultsSummary = (qc_results) => {
         } else {
             return <span>{badge} / </span>;
         }
+    });
+};
+
+// QC flag values that are considered problematic (matches FLAG_STATES in
+// src/encoded/types/quality_metric.py)
+const QC_FLAG_STATES = ['Warn', 'Fail'];
+
+/**
+ * Whether a file/QC-info is still relevant for review. Retracted and deleted
+ * files are ignored when deciding QC pass/fail and when building comments.
+ */
+export const isActiveFileStatus = (status) => {
+    return status !== 'retracted' && status !== 'deleted';
+};
+
+/**
+ * Index a QualityMetric's qc_values array by their derived_from id for fast lookup.
+ */
+export const reformatQcValues = (qcValues) => {
+    const result = {};
+    (qcValues ?? []).forEach((qcValue) => {
+        result[qcValue.derived_from] = qcValue;
+    });
+    return result;
+};
+
+/**
+ * Sum the group coverage (mosdepth:total) across the given processed files,
+ * deduping by accession so a file with multiple QualityMetric items is not
+ * counted more than once. Returns a Number, or null when no coverage metric is
+ * present (distinct from a real 0). Accepts files that already carry a
+ * `qc_values_dict` or raw files with `quality_metric.qc_values`.
+ */
+export const computeGroupCoverageNumeric = (processedFiles) => {
+    const filesSeen = [];
+    let coverage = 0;
+    let found = false;
+    for (const pf of processedFiles ?? []) {
+        const qcValues =
+            pf['qc_values_dict'] ?? reformatQcValues(pf.quality_metric?.qc_values);
+        if (COVERAGE_QC_METRIC in qcValues) {
+            // If there are multiple QM items for the same file we don't want to
+            // count the coverage more than once
+            if (filesSeen.includes(pf.accession)) {
+                continue;
+            }
+            const cov = Number(qcValues[COVERAGE_QC_METRIC]['value']);
+            if (Number.isNaN(cov)) {
+                continue;
+            }
+            coverage += cov;
+            filesSeen.push(pf.accession);
+            found = true;
+        }
+    }
+    return found ? coverage : null;
+};
+
+/**
+ * Collect the problematic (Warn/Fail) qc_values from the given files (already
+ * filtered to the relevant fileset and active statuses). Returns a flat list of
+ * { accession, key, value, flag }.
+ */
+export const collectProblematicQcValues = (files) => {
+    const problems = [];
+    (files ?? []).forEach((file) => {
+        (file.quality_metric?.qc_values ?? []).forEach((qv) => {
+            if (QC_FLAG_STATES.includes(qv.flag)) {
+                problems.push({
+                    accession: file.accession,
+                    key: qv.key,
+                    value: qv.value,
+                    flag: qv.flag,
+                });
+            }
+        });
+    });
+    return problems;
+};
+
+/**
+ * Coerce a qc_value value to a number, or return null when it is not numeric
+ * (e.g. empty string, null, boolean, non-numeric text).
+ */
+const toNumberOrNull = (v) => {
+    if (typeof v === 'number') {
+        return Number.isNaN(v) ? null : v;
+    }
+    if (typeof v === 'string' && v.trim() !== '' && !Number.isNaN(Number(v))) {
+        return Number(v);
+    }
+    return null;
+};
+
+/**
+ * Group problematic qc_values (from collectProblematicQcValues) by metric and
+ * flag, counting the number of distinct files affected. Used to collapse dozens
+ * of submitted files into one line per metric. When every value in a group is
+ * numeric, also returns the value range (min/max).
+ * Returns { key, flag, count, numeric, min, max }[].
+ */
+export const groupProblematicQcByMetric = (problems) => {
+    const groups = {};
+    (problems ?? []).forEach((p) => {
+        const groupKey = `${p.key}||${p.flag}`;
+        if (!groups[groupKey]) {
+            groups[groupKey] = {
+                key: p.key,
+                flag: p.flag,
+                accessions: new Set(),
+                values: [],
+            };
+        }
+        groups[groupKey].accessions.add(p.accession);
+        groups[groupKey].values.push(p.value);
+    });
+    return Object.values(groups).map((g) => {
+        const numericValues = g.values.map(toNumberOrNull);
+        const numeric =
+            numericValues.length > 0 && numericValues.every((v) => v !== null);
+        return {
+            key: g.key,
+            flag: g.flag,
+            count: g.accessions.size,
+            numeric,
+            min: numeric ? Math.min(...numericValues) : null,
+            max: numeric ? Math.max(...numericValues) : null,
+        };
     });
 };
 

--- a/src/encoded/submission_status.py
+++ b/src/encoded/submission_status.py
@@ -352,7 +352,16 @@ def add_submission_status_search_filters(
         if filter_value in CELL_CULTURE_MIXTURES:
             search_params["libraries.analytes.samples.sample_sources.code"] = filter_value
         else:
-            search_params["tissue_types"] = filter_value
+            # Benchmarking tissues index tissue_type without the leading code
+            # prefix (see item_utils.tissue.get_tissue_type), while production
+            # and fibroblast tissues keep it. Match both forms so benchmarking
+            # filesets are not dropped.
+            tissue_filter_values = [filter_value]
+            if " - " in filter_value:
+                tissue_filter_values.append(filter_value.split(" - ")[1])
+            search_params[
+                "libraries.analytes.samples.sample_sources.tissue_type"
+            ] = tissue_filter_values
     if filter.get("include_tags"):
         search_params["tags"] = filter["include_tags"]
     if filter.get("exclude_tags"):

--- a/src/encoded/types/file_set.py
+++ b/src/encoded/types/file_set.py
@@ -115,6 +115,7 @@ def _build_file_set_embedded_list():
         "libraries.analytes.samples.sample_sources.uberon_id",
         "libraries.analytes.samples.sample_sources.cell_line.code",
         "libraries.analytes.samples.sample_sources.uberon_id",
+        "libraries.analytes.samples.sample_sources.tissue_type",
         "libraries.analytes.samples.sample_sources.donor.display_title",
 
         # Sequencing/Sequencer LinkTo - used in file_merge_group


### PR DESCRIPTION
This pull request introduces a major enhancement to the submission status UI and backend logic, focusing on automating the QC review process for filesets. It adds an "Auto-review QC" button for admins, which evaluates file QC metrics and coverage, then updates tags and comments accordingly. Additionally, the PR improves QC value handling, filter UI robustness, and code maintainability.
