### PR TITLE
fix: preserve Donor/Cohort toggle state across href changes (facet selection, "Explore Donors", etc.)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,11 +8,20 @@ Change Log
 ----------
 
 
+2.3.9
+=====
+
+`PR 720: fix: preserve Donor/Cohort toggle state across href changes (facet selection, "Explore Donors", etc.) <https://github.com/smaht-dac/smaht-portal/pull/720>`_
+
+* Fixes a bug where the Donor/Cohort toggle state was lost when navigating to a new URL (e.g. selecting a facet, clicking "Explore Donors", etc.) by preserving the toggle state in the URL query string and restoring it on page load.
+
+
 2.3.8
 =====
 
 * Preserve the Donor and Protected Donor browse ``/peek-metadata/`` optimization while using the progressive, concurrency-limited row-data queue: both callers share an explicit URL contract with ``skip_default_facets=true`` and request only ``sample_summary.tissues``, ``assays.display_title``, and ``file_size``.
 * Avoid the HTTP 400 caused by combining ``skip_default_facets=true`` with ``additional_facet=type``. The File count now comes from the GET ``/peek-metadata/`` response's ``total`` alongside its ``facets``.
+
 
 2.3.7  
 =====

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "2.3.8"
+version = "2.3.9"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/browse/browse-view/BrowseDonor.js
+++ b/src/encoded/static/components/browse/browse-view/BrowseDonor.js
@@ -131,24 +131,26 @@ export const BrowseDonorBody = (props) => {
     );
 
     return (
-        <DonorDataProvider
-            key={href}
-            buildHref={buildDonorPeekMetadataHref}>
+        <React.Fragment>
             {showRedirectBanner && <RedirectBanner href={href} />}
             <BrowseDonorVizWrapper {...props} mapping="donor" />
             <hr />
-            <BrowseViewControllerWithSelections {...props}>
-                <BrowseDonorSearchTable />
-            </BrowseViewControllerWithSelections>
-            {context?.total === 0 && (
-                <NoResultsBrowseModal
-                    type="donor"
-                    context={context}
-                    href={href}
-                    userDownloadAccess={userDownloadAccess}
-                    isAccessResolved={isAccessResolved}
-                />
-            )}
-        </DonorDataProvider>
+            <DonorDataProvider
+                key={href}
+                buildHref={buildDonorPeekMetadataHref}>
+                <BrowseViewControllerWithSelections {...props}>
+                    <BrowseDonorSearchTable />
+                </BrowseViewControllerWithSelections>
+                {context?.total === 0 && (
+                    <NoResultsBrowseModal
+                        type="donor"
+                        context={context}
+                        href={href}
+                        userDownloadAccess={userDownloadAccess}
+                        isAccessResolved={isAccessResolved}
+                    />
+                )}
+            </DonorDataProvider>
+        </React.Fragment>
     );
 };

--- a/src/encoded/static/components/browse/browse-view/BrowseProtectedDonor.js
+++ b/src/encoded/static/components/browse/browse-view/BrowseProtectedDonor.js
@@ -157,24 +157,26 @@ export const BrowseProtectedDonorBody = (props) => {
     const { context, alerts, href, userDownloadAccess, isAccessResolved } =
         props;
     return (
-        <DonorDataProvider
-            key={href}
-            buildHref={buildDonorPeekMetadataHref}>
+        <React.Fragment>
             <Alerts alerts={alerts} className="mt-2" />
             <BrowseDonorVizWrapper {...props} mapping="protected-donor" />
             <hr />
-            <BrowseViewControllerWithSelections {...props}>
-                <BrowseProtectedDonorSearchTable />
-            </BrowseViewControllerWithSelections>
-            {context?.total === 0 && (
-                <NoResultsBrowseModal
-                    type="protected_donor"
-                    context={context}
-                    href={href}
-                    userDownloadAccess={userDownloadAccess}
-                    isAccessResolved={isAccessResolved}
-                />
-            )}
-        </DonorDataProvider>
+            <DonorDataProvider
+                key={href}
+                buildHref={buildDonorPeekMetadataHref}>
+                <BrowseViewControllerWithSelections {...props}>
+                    <BrowseProtectedDonorSearchTable />
+                </BrowseViewControllerWithSelections>
+                {context?.total === 0 && (
+                    <NoResultsBrowseModal
+                        type="protected_donor"
+                        context={context}
+                        href={href}
+                        userDownloadAccess={userDownloadAccess}
+                        isAccessResolved={isAccessResolved}
+                    />
+                )}
+            </DonorDataProvider>
+        </React.Fragment>
     );
 };


### PR DESCRIPTION
### Summary
- Browse by Donor page reset the Donor/Cohort view toggle back to its default on *any* interaction that changes the page's `href` — not just clicking "Explore Donors", but also things like selecting/clearing a facet, paginating, or sorting.
- Root cause: `DonorDataProvider` is keyed on `href` (added in #713 to support progressive row-data loading), so React fully unmounts and remounts its entire subtree every time `href` changes. `BrowseDonorVizWrapper` — which owns the toggle's local `toggleViewIndex` state — was nested inside that keyed subtree, so every href change wiped its state, regardless of what caused it.
- `BrowseDonorVizWrapper` never reads from `DonorDataContext`, so it doesn't need the per-href remount; only the search table/facets do. Moved it (and the redirect banner/alerts) outside the keyed `DonorDataProvider` in both `BrowseDonor.js` and `BrowseProtectedDonor.js`, so its state now survives any href change.

### Test plan
- [ ] On `/browse/?type=Donor`, switch to Cohort View, click "Explore Donors" on a chart bar, confirm the toggle stays on Cohort View.
- [ ] On the same page, switch to Cohort View, then select/clear a facet in Donor View... actually: set the toggle, then change a facet filter, and confirm the toggle is unaffected.
- [ ] Repeat toggle-persistence checks after paginating/sorting the donor table.
- [ ] Repeat all of the above on the Protected Donor variant.
- [ ] Confirm donor row peek-metadata (via `DonorDataProvider`) still refreshes correctly when filters/href change.
