### PR TITLE
fix: harden nginx failover/observability (defer rss_limit raise)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,33 @@ Change Log
 ----------
 
 
+2.3.10
+======
+
+Production memory/reliability tuning for the per-worker RSS watchdog and nginx failover.
+
+* Raise the production per-worker ``rss_limit`` from ``450MB`` to ``600MB`` in ``base.ini``.
+  The in-process ``snovault.memlimit`` watchdog SIGKILLs a waitress worker when its RSS crosses
+  this cap; at 450MB workers were being killed at ~474 MiB while the 8 GiB ECS task ran only
+  ~60% typical / <90% peak, wasting most of the task budget. 5 workers x 600MB (~3 GiB) leaves
+  ample headroom. Byte-limit behavior is preserved; no percentage limit is added because
+  ``psutil.memory_percent`` reads the Fargate host, not the task. This is a conservative capacity
+  adjustment, not a memory-leak fix. Rollback: revert the value to ``450MB``.
+* ``deploy/docker/production/nginx.conf`` reliability/observability changes for worker
+  SIGKILL/restart churn:
+
+  * Make all 5 workers active in ``upstream app`` (port 6547 was ``backup``, concentrating normal
+    traffic on 4 workers); failover is preserved by ``proxy_next_upstream``.
+  * Reduce upstream ``fail_timeout`` from ``45`` to ``15s`` so a worker restarted by supervisord
+    (~6s) is not quarantined for 45s; ``max_fails`` left at its default.
+  * Bound retries with ``proxy_next_upstream_tries 2`` and ``proxy_next_upstream_timeout 30s`` to
+    prevent a correlated kill storm from stampeding all upstreams. Non-idempotent requests are
+    still not retried.
+  * Add a targeted ``upstream_debug`` access log (to ``/dev/stdout``) that fires only on failover
+    or upstream 5xx, exposing which internal worker failed/retried -- visibility the LB access log
+    cannot provide.
+
+
 2.3.9
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,24 +12,14 @@ Change Log
 =====
 
 nginx failover reliability and observability for worker SIGKILL/restart churn. The
-per-worker ``rss_limit`` increase originally proposed here is **deferred** pending
-capacity evidence (see below).
+per-worker ``rss_limit`` remains at ``450MB`` pending task-wide capacity evidence.
 
-* **Deferred (no change in this release):** the per-worker ``rss_limit`` in ``base.ini``
-  stays at ``450MB``. An earlier revision raised it to ``600MB``; that was reverted after
-  independent review found the "ample task headroom" justification unsound -- the
-  ``snovault.memlimit`` watchdog is a delayed, parent-only RSS check and does not bound
-  task memory: it excludes the up-to-80 thread-local Node SSR child processes, nginx's own
-  per-connection buffers, and watchdog overshoot, and a task near its 8 GiB hard limit has
-  little margin (raising all five caps by 150MB permits +750MB of parent RSS). Any future
-  raise requires a same-window process-tree/cgroup budget and canary alarms with a defined
-  rollback threshold, and must be staged after the routing change below.
 * ``deploy/docker/production/nginx.conf`` changes:
 
   * Make all 5 workers active in ``upstream app`` (port 6547 was ``backup``). This is a
     request-distribution change at the unchanged 450MB cap; failover is preserved by
     ``proxy_next_upstream``. (Note: warming the formerly-cold worker's lazy Node SSR
-    children can slightly raise task RSS -- covered by the deferred cap raise's canary watch.)
+    children can raise task RSS even though the parent-process cap is unchanged.)
   * Reduce upstream ``fail_timeout`` from ``45s`` to ``15s`` so a recovered peer becomes
     selectable again sooner; ``max_fails`` left at its default (1). (The real pserve
     socket-ready time after SIGKILL is unmeasured; 15s is revisited once measured.)
@@ -41,10 +31,11 @@ capacity evidence (see below).
     default: POST/LOCK/PATCH are not retried once sent to an upstream (after-send protection
     against duplicate side effects), while a pre-send connection failure and non-protected
     methods (GET/HEAD/PUT/DELETE/OPTIONS/...) may retry -- it is **not** "GET/HEAD only".
-  * Add a targeted ``upstream_debug`` access log (to ``/dev/stdout``) that fires only on
-    failover or upstream 5xx, exposing which internal worker failed/retried. Logs
-    ``$request_method`` and ``$uri`` (no query string) plus ``$request_id``; this is a
-    separate stream whose retention/access controls must match the LB log's.
+  * Add a targeted ``upstream_debug`` access log (to ``/dev/stdout``) for multiple-attempt
+    failover and upstream 502/504 gateway failures. It logs ``$request_method`` and ``$uri``
+    (no query string) plus ``$request_id``, but not the client address; ordinary application
+    5xx responses remain solely in the LB log. This separate stream's retention/access
+    controls must match the LB log's.
 * Add ``RUN nginx -t`` to the production ``Dockerfile`` so the config is validated against the
   pinned nginx 1.21.6 during the CI Docker build, and add an offline behavioral harness
   (``deploy/docker/production/test_nginx_failover.py``) for the retry/method/logging cases.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,28 +11,43 @@ Change Log
 2.3.10
 ======
 
-Production memory/reliability tuning for the per-worker RSS watchdog and nginx failover.
+nginx failover reliability and observability for worker SIGKILL/restart churn. The
+per-worker ``rss_limit`` increase originally proposed here is **deferred** pending
+capacity evidence (see below).
 
-* Raise the production per-worker ``rss_limit`` from ``450MB`` to ``600MB`` in ``base.ini``.
-  The in-process ``snovault.memlimit`` watchdog SIGKILLs a waitress worker when its RSS crosses
-  this cap; at 450MB workers were being killed at ~474 MiB while the 8 GiB ECS task ran only
-  ~60% typical / <90% peak, wasting most of the task budget. 5 workers x 600MB (~3 GiB) leaves
-  ample headroom. Byte-limit behavior is preserved; no percentage limit is added because
-  ``psutil.memory_percent`` reads the Fargate host, not the task. This is a conservative capacity
-  adjustment, not a memory-leak fix. Rollback: revert the value to ``450MB``.
-* ``deploy/docker/production/nginx.conf`` reliability/observability changes for worker
-  SIGKILL/restart churn:
+* **Deferred (no change in this release):** the per-worker ``rss_limit`` in ``base.ini``
+  stays at ``450MB``. An earlier revision raised it to ``600MB``; that was reverted after
+  independent review found the "ample task headroom" justification unsound -- the
+  ``snovault.memlimit`` watchdog is a delayed, parent-only RSS check and does not bound
+  task memory: it excludes the up-to-80 thread-local Node SSR child processes, nginx's own
+  per-connection buffers, and watchdog overshoot, and a task near its 8 GiB hard limit has
+  little margin (raising all five caps by 150MB permits +750MB of parent RSS). Any future
+  raise requires a same-window process-tree/cgroup budget and canary alarms with a defined
+  rollback threshold, and must be staged after the routing change below.
+* ``deploy/docker/production/nginx.conf`` changes:
 
-  * Make all 5 workers active in ``upstream app`` (port 6547 was ``backup``, concentrating normal
-    traffic on 4 workers); failover is preserved by ``proxy_next_upstream``.
-  * Reduce upstream ``fail_timeout`` from ``45`` to ``15s`` so a worker restarted by supervisord
-    (~6s) is not quarantined for 45s; ``max_fails`` left at its default.
-  * Bound retries with ``proxy_next_upstream_tries 2`` and ``proxy_next_upstream_timeout 30s`` to
-    prevent a correlated kill storm from stampeding all upstreams. Non-idempotent requests are
-    still not retried.
-  * Add a targeted ``upstream_debug`` access log (to ``/dev/stdout``) that fires only on failover
-    or upstream 5xx, exposing which internal worker failed/retried -- visibility the LB access log
-    cannot provide.
+  * Make all 5 workers active in ``upstream app`` (port 6547 was ``backup``). This is a
+    request-distribution change at the unchanged 450MB cap; failover is preserved by
+    ``proxy_next_upstream``. (Note: warming the formerly-cold worker's lazy Node SSR
+    children can slightly raise task RSS -- covered by the deferred cap raise's canary watch.)
+  * Reduce upstream ``fail_timeout`` from ``45s`` to ``15s`` so a recovered peer becomes
+    selectable again sooner; ``max_fails`` left at its default (1). (The real pserve
+    socket-ready time after SIGKILL is unmeasured; 15s is revisited once measured.)
+  * Bound retry fan-out with ``proxy_next_upstream_tries 2`` (at most **two total** upstream
+    attempts, not two retries) and ``proxy_next_upstream_timeout 30s`` (bounds only when a
+    handoff to another peer may be *initiated* -- **not** an end-to-end request deadline).
+    Deliberate availability trade: a request that hits two failed peers can error even if a
+    third is healthy, in exchange for bounded amplification. Retry method policy is nginx's
+    default: POST/LOCK/PATCH are not retried once sent to an upstream (after-send protection
+    against duplicate side effects), while a pre-send connection failure and non-protected
+    methods (GET/HEAD/PUT/DELETE/OPTIONS/...) may retry -- it is **not** "GET/HEAD only".
+  * Add a targeted ``upstream_debug`` access log (to ``/dev/stdout``) that fires only on
+    failover or upstream 5xx, exposing which internal worker failed/retried. Logs
+    ``$request_method`` and ``$uri`` (no query string) plus ``$request_id``; this is a
+    separate stream whose retention/access controls must match the LB log's.
+* Add ``RUN nginx -t`` to the production ``Dockerfile`` so the config is validated against the
+  pinned nginx 1.21.6 during the CI Docker build, and add an offline behavioral harness
+  (``deploy/docker/production/test_nginx_failover.py``) for the retry/method/logging cases.
 
 
 2.3.9

--- a/Dockerfile
+++ b/Dockerfile
@@ -143,6 +143,14 @@ RUN chown -R nginx:nginx /var/cache/nginx && \
     mkdir -p /data/nginx/cache && \
     chown -R nginx:nginx /data/nginx/cache
 
+# nginx config gate: validate the installed config against the EXACT pinned nginx
+# (1.21.6, from install_nginx_bullseye.sh) now that the config file and the log/cache
+# paths it references exist. This runs during `docker build` (the CI Docker job), so a
+# syntactically invalid or directive-incompatible nginx.conf fails the build instead of
+# only failing at container start. Local `nginx -t` on a different nginx version is not a
+# substitute for this. (Syntax/directive test only -- it does not prove runtime behavior.)
+RUN nginx -v && nginx -t
+
 WORKDIR /home/nginx/smaht-portal
 
 # Bring in the built venv and the built application tree from the builder. --chown

--- a/base.ini
+++ b/base.ini
@@ -79,14 +79,8 @@ use = egg:encoded#memlimit
 # Per-worker RSS soft cap enforced in-process by snovault.memlimit (byte limit only;
 # no percent limit, since psutil.memory_percent reads the Fargate *host*, not the task).
 #
-# DEFERRED: an earlier revision of this change raised this cap 450MB -> 600MB. That was
-# reverted after independent review (Sol F1): the "ample task headroom" justification
-# treated five delayed, parent-only RSS checks as a task-wide bound. It ignored the up-to-80
-# thread-local Node SSR child processes (excluded from the parent RSS check), nginx's own
-# per-connection buffers, watchdog overshoot, and the fact that a task near its 8 GiB hard
-# limit leaves little margin -- raising all five caps by 150MB permits +750MB of parent RSS.
-# Do NOT raise this value again until a same-window process-tree/cgroup budget (task memory
-# vs. every Python parent + all Node children + nginx) is measured and canary alarms with a
-# defined rollback threshold are in place. See report sections 11/14. Any future raise is a
-# capacity adjustment, not a leak fix. Rollback for a future raise: revert to 450MB.
+# Keep this at 450MB until a same-window process-tree/cgroup budget measures task memory
+# against all five Python parents, their thread-local Node SSR children, nginx, and watchdog
+# overshoot. Five parent limits do not form a task-wide bound. A future increase also needs
+# canary alarms and a defined rollback threshold; it is a capacity change, not a leak fix.
 rss_limit = 450MB

--- a/base.ini
+++ b/base.ini
@@ -76,4 +76,11 @@ timeout = 60
 
 [filter:memlimit]
 use = egg:encoded#memlimit
-rss_limit = 450MB
+# Per-worker RSS soft cap enforced in-process by snovault.memlimit (byte limit only;
+# no percent limit, since psutil.memory_percent reads the Fargate *host*, not the task).
+# Raised 450MB -> 600MB as a conservative first step: the ECS task is 8 GiB with 5
+# waitress workers, running ~60% typical / <90% peak, so 5 x 600MB = ~3 GiB of workers
+# leaves ample task headroom. This is a capacity adjustment, NOT a leak fix.
+# Rollback: revert this value to 450MB. Monitor after change: kill-event rate in worker
+# logs and ECS task memory %; only raise further (toward ~700MB) if headroom is confirmed.
+rss_limit = 600MB

--- a/base.ini
+++ b/base.ini
@@ -78,9 +78,15 @@ timeout = 60
 use = egg:encoded#memlimit
 # Per-worker RSS soft cap enforced in-process by snovault.memlimit (byte limit only;
 # no percent limit, since psutil.memory_percent reads the Fargate *host*, not the task).
-# Raised 450MB -> 600MB as a conservative first step: the ECS task is 8 GiB with 5
-# waitress workers, running ~60% typical / <90% peak, so 5 x 600MB = ~3 GiB of workers
-# leaves ample task headroom. This is a capacity adjustment, NOT a leak fix.
-# Rollback: revert this value to 450MB. Monitor after change: kill-event rate in worker
-# logs and ECS task memory %; only raise further (toward ~700MB) if headroom is confirmed.
-rss_limit = 600MB
+#
+# DEFERRED: an earlier revision of this change raised this cap 450MB -> 600MB. That was
+# reverted after independent review (Sol F1): the "ample task headroom" justification
+# treated five delayed, parent-only RSS checks as a task-wide bound. It ignored the up-to-80
+# thread-local Node SSR child processes (excluded from the parent RSS check), nginx's own
+# per-connection buffers, watchdog overshoot, and the fact that a task near its 8 GiB hard
+# limit leaves little margin -- raising all five caps by 150MB permits +750MB of parent RSS.
+# Do NOT raise this value again until a same-window process-tree/cgroup budget (task memory
+# vs. every Python parent + all Node children + nginx) is measured and canary alarms with a
+# defined rollback threshold are in place. See report sections 11/14. Any future raise is a
+# capacity adjustment, not a leak fix. Rollback for a future raise: revert to 450MB.
+rss_limit = 450MB

--- a/deploy/docker/production/nginx.conf
+++ b/deploy/docker/production/nginx.conf
@@ -24,14 +24,25 @@ http {
 
     # Full request access logging still comes from the LB. We additionally emit a
     # TARGETED nginx access log for upstream failure/failover events only -- the LB
-    # cannot see which of the 5 internal workers failed or retried, which is exactly
-    # what we need to observe worker SIGKILL/restart churn. Volume is low because the
-    # $ul_log condition only fires on a failover (multiple upstreams tried) or an
-    # upstream 5xx (e.g. an un-retried POST 502 hitting a killed worker).
+    # cannot see which of the 5 internal workers failed or retried, which is what we
+    # need to observe worker SIGKILL/restart churn.
+    #
+    # Fields deliberately log $request_method + $uri (the NORMALIZED path) and NOT
+    # $request, so query strings (which may carry tokens/OAuth codes/emails/search
+    # terms) are not copied into this stream. $request_id is nginx's per-request id
+    # (available since 1.11.0; present in the pinned 1.21.6) for correlation with the
+    # LB/app logs.
+    #
+    # This is a SEPARATE log stream from the LB's, so its access/retention controls
+    # must be confirmed to match. Volume is bounded to failover/5xx events but is NOT
+    # guaranteed small: $ul_5xx matches EVERY upstream 5xx, so a broad application-500
+    # incident logs one line per affected request (that is intended -- the spike is the
+    # signal). This failure-only log CANNOT measure normal worker load distribution;
+    # use per-port metrics or short-lived sampled success logging for that.
     log_format upstream_debug
-        '$remote_addr "$request" status=$status '
-        'req_time=$request_time ua="$upstream_addr" '
-        'us="$upstream_status" urt="$upstream_response_time" '
+        '$remote_addr method=$request_method uri=$uri status=$status '
+        'req_id=$request_id req_time=$request_time upstream_addr="$upstream_addr" '
+        'upstream_status="$upstream_status" urt="$upstream_response_time" '
         'uct="$upstream_connect_time"';
     map $upstream_addr   $ul_failover { "~,"     1; default 0; }
     map $upstream_status $ul_5xx      { "~5[0-9][0-9]" 1; default 0; }
@@ -49,14 +60,30 @@ http {
     types_hash_max_size 2048;
     types_hash_bucket_size 64;
 
-    # If 502 is encountered, we may have been killed for memory
-    # fall back to the next server, until one is back.
-    # NOTE: this deliberately does NOT include `non_idempotent`, so POST/PATCH/LOCK
-    # already sent to a killed worker are NOT retried (correct: they may have side
-    # effects). Only idempotent GET/HEAD are retried onto another worker.
+    # If a worker was killed for memory we may see a 502/error/timeout; hand the
+    # request to another upstream when that is safe.
+    #
+    # Retry method policy (nginx 1.21.6 semantics -- do not overstate this):
+    #  - `non_idempotent` is deliberately NOT set. Because of that, POST/LOCK/PATCH are
+    #    NOT retried ONCE THE REQUEST HAS BEEN SENT to an upstream (protects against
+    #    duplicated side effects) -- this after-send protection is the property that
+    #    matters and is preserved.
+    #  - A PRE-SEND failure (e.g. connection refused before any bytes were sent) may be
+    #    retried for ANY method, including POST -- nginx considers no side effect possible.
+    #  - Methods NOT in nginx's protected set (GET, HEAD, PUT, DELETE, OPTIONS, ...) may be
+    #    retried under the conditions below. It is NOT "GET/HEAD only".
+    #  - Once nginx has sent any response bytes to the client, no retry is possible; a
+    #    mid-response worker death is a truncated/failed response even for GET.
     proxy_next_upstream error timeout http_502;
-    # Bound retries so a correlated memory-kill storm cannot stampede all upstreams:
-    # at most 2 upstreams tried (original + 1 retry), within a 30s overall budget.
+    # Bound retry fan-out during a correlated memory-kill storm:
+    #  - `_tries 2` = at most TWO TOTAL upstream attempts (original + at most one more),
+    #    NOT two retries. Availability trade (deliberate): a request that happens to pick
+    #    two already-failed peers returns an error even if a third peer is healthy. This
+    #    caps amplification/latency; passive health (max_fails/fail_timeout, shared via the
+    #    upstream `zone`) steers subsequent requests away from peers already marked down.
+    #  - `_timeout 30s` bounds only WHEN a handoff to another peer may be INITIATED. It is
+    #    NOT an end-to-end request deadline: a second attempt begun before 30s may complete
+    #    well after it.
     proxy_next_upstream_tries 2;
     proxy_next_upstream_timeout 30s;
 
@@ -86,13 +113,19 @@ http {
 
     upstream app {
         zone app 32k;
-        # All 5 workers are active (6547 was previously `backup`, which concentrated
-        # normal traffic on only 4 workers and pushed them toward the per-worker RSS
-        # cap faster). Failover is preserved by proxy_next_upstream across the 5 members.
-        # fail_timeout reduced 45s -> 15s so a worker SIGKILLed by the memlimit watchdog
-        # and restarted by supervisord (~6s, startsecs=6) is not quarantined for 45s.
-        # max_fails is left at its default (1): a killed worker is genuinely down, so
-        # mark it down promptly rather than sending more requests to a dead process.
+        # All 5 workers are active (6547 was previously `backup`). This is a REQUEST-
+        # DISTRIBUTION change at the unchanged 450MB per-worker cap: normal traffic now
+        # round-robins across 5 members instead of 4. Note (Sol F1): the 5th worker's
+        # Node SSR children are created lazily per thread, so warming it can slightly
+        # RAISE task RSS -- this is exactly what the deferred cap raise's canary watch is
+        # for. Failover is preserved by proxy_next_upstream across the 5 members.
+        # fail_timeout reduced 45s -> 15s so a quarantined-but-recovered peer becomes
+        # selectable again sooner. Caveat: supervisord `startsecs` is the liveness window
+        # before a start is deemed successful -- it is NOT socket-ready time or a respawn
+        # delay, and the real pserve socket-ready time after SIGKILL is unmeasured. If
+        # readiness exceeds 15s the peer is simply re-probed and re-quarantined (harmless);
+        # revisit this value once readiness is measured (deferred). max_fails is left at
+        # its default (1): a killed worker is genuinely down, so mark it down promptly.
         server 0.0.0.0:6543 fail_timeout=15s;
         server 0.0.0.0:6544 fail_timeout=15s;
         server 0.0.0.0:6545 fail_timeout=15s;

--- a/deploy/docker/production/nginx.conf
+++ b/deploy/docker/production/nginx.conf
@@ -22,8 +22,21 @@ http {
     open_file_cache_min_uses 2;
     open_file_cache_errors on;
 
-    # We get access_log from the LB
-    access_log off;
+    # Full request access logging still comes from the LB. We additionally emit a
+    # TARGETED nginx access log for upstream failure/failover events only -- the LB
+    # cannot see which of the 5 internal workers failed or retried, which is exactly
+    # what we need to observe worker SIGKILL/restart churn. Volume is low because the
+    # $ul_log condition only fires on a failover (multiple upstreams tried) or an
+    # upstream 5xx (e.g. an un-retried POST 502 hitting a killed worker).
+    log_format upstream_debug
+        '$remote_addr "$request" status=$status '
+        'req_time=$request_time ua="$upstream_addr" '
+        'us="$upstream_status" urt="$upstream_response_time" '
+        'uct="$upstream_connect_time"';
+    map $upstream_addr   $ul_failover { "~,"     1; default 0; }
+    map $upstream_status $ul_5xx      { "~5[0-9][0-9]" 1; default 0; }
+    map "$ul_failover$ul_5xx" $ul_log { default 1; "00" 0; }
+    access_log /dev/stdout upstream_debug if=$ul_log;
 
     # Some additional optimizations
     charset utf-8;
@@ -37,8 +50,15 @@ http {
     types_hash_bucket_size 64;
 
     # If 502 is encountered, we may have been killed for memory
-    # fall back to the next server, until one is back
+    # fall back to the next server, until one is back.
+    # NOTE: this deliberately does NOT include `non_idempotent`, so POST/PATCH/LOCK
+    # already sent to a killed worker are NOT retried (correct: they may have side
+    # effects). Only idempotent GET/HEAD are retried onto another worker.
     proxy_next_upstream error timeout http_502;
+    # Bound retries so a correlated memory-kill storm cannot stampede all upstreams:
+    # at most 2 upstreams tried (original + 1 retry), within a 30s overall budget.
+    proxy_next_upstream_tries 2;
+    proxy_next_upstream_timeout 30s;
 
     # Allow large POST requests
     client_body_buffer_size 128K;
@@ -66,11 +86,18 @@ http {
 
     upstream app {
         zone app 32k;
-        server 0.0.0.0:6543 fail_timeout=45;
-        server 0.0.0.0:6544 fail_timeout=45;
-        server 0.0.0.0:6545 fail_timeout=45;
-        server 0.0.0.0:6546 fail_timeout=45;
-        server 0.0.0.0:6547 fail_timeout=45 backup;
+        # All 5 workers are active (6547 was previously `backup`, which concentrated
+        # normal traffic on only 4 workers and pushed them toward the per-worker RSS
+        # cap faster). Failover is preserved by proxy_next_upstream across the 5 members.
+        # fail_timeout reduced 45s -> 15s so a worker SIGKILLed by the memlimit watchdog
+        # and restarted by supervisord (~6s, startsecs=6) is not quarantined for 45s.
+        # max_fails is left at its default (1): a killed worker is genuinely down, so
+        # mark it down promptly rather than sending more requests to a dead process.
+        server 0.0.0.0:6543 fail_timeout=15s;
+        server 0.0.0.0:6544 fail_timeout=15s;
+        server 0.0.0.0:6545 fail_timeout=15s;
+        server 0.0.0.0:6546 fail_timeout=15s;
+        server 0.0.0.0:6547 fail_timeout=15s;
         keepalive 64;
     }
 

--- a/deploy/docker/production/nginx.conf
+++ b/deploy/docker/production/nginx.conf
@@ -23,30 +23,29 @@ http {
     open_file_cache_errors on;
 
     # Full request access logging still comes from the LB. We additionally emit a
-    # TARGETED nginx access log for upstream failure/failover events only -- the LB
+    # TARGETED nginx access log for upstream gateway failure/failover events only -- the LB
     # cannot see which of the 5 internal workers failed or retried, which is what we
     # need to observe worker SIGKILL/restart churn.
     #
     # Fields deliberately log $request_method + $uri (the NORMALIZED path) and NOT
     # $request, so query strings (which may carry tokens/OAuth codes/emails/search
-    # terms) are not copied into this stream. $request_id is nginx's per-request id
-    # (available since 1.11.0; present in the pinned 1.21.6) for correlation with the
-    # LB/app logs.
+    # terms) are not copied into this stream. We also omit $remote_addr because the LB
+    # already records it and $request_id provides correlation without duplicating client
+    # data. $request_id is available in the pinned nginx 1.21.6.
     #
     # This is a SEPARATE log stream from the LB's, so its access/retention controls
-    # must be confirmed to match. Volume is bounded to failover/5xx events but is NOT
-    # guaranteed small: $ul_5xx matches EVERY upstream 5xx, so a broad application-500
-    # incident logs one line per affected request (that is intended -- the spike is the
-    # signal). This failure-only log CANNOT measure normal worker load distribution;
-    # use per-port metrics or short-lived sampled success logging for that.
+    # must be confirmed to match. Log only multiple-attempt failover or upstream 502/504
+    # gateway failures; ordinary application 5xx responses remain in the LB log and must
+    # not amplify this worker-failover stream. This failure-only log CANNOT measure normal
+    # worker load distribution; use per-port metrics or sampled success logging for that.
     log_format upstream_debug
-        '$remote_addr method=$request_method uri=$uri status=$status '
+        'method=$request_method uri="$uri" status=$status '
         'req_id=$request_id req_time=$request_time upstream_addr="$upstream_addr" '
         'upstream_status="$upstream_status" urt="$upstream_response_time" '
         'uct="$upstream_connect_time"';
-    map $upstream_addr   $ul_failover { "~,"     1; default 0; }
-    map $upstream_status $ul_5xx      { "~5[0-9][0-9]" 1; default 0; }
-    map "$ul_failover$ul_5xx" $ul_log { default 1; "00" 0; }
+    map $upstream_addr   $ul_failover       { "~,"      1; default 0; }
+    map $upstream_status $ul_gateway_failure { "~50[24]" 1; default 0; }
+    map "$ul_failover$ul_gateway_failure" $ul_log { default 1; "00" 0; }
     access_log /dev/stdout upstream_debug if=$ul_log;
 
     # Some additional optimizations
@@ -115,10 +114,10 @@ http {
         zone app 32k;
         # All 5 workers are active (6547 was previously `backup`). This is a REQUEST-
         # DISTRIBUTION change at the unchanged 450MB per-worker cap: normal traffic now
-        # round-robins across 5 members instead of 4. Note (Sol F1): the 5th worker's
-        # Node SSR children are created lazily per thread, so warming it can slightly
-        # RAISE task RSS -- this is exactly what the deferred cap raise's canary watch is
-        # for. Failover is preserved by proxy_next_upstream across the 5 members.
+        # round-robins across 5 members instead of 4. The 5th worker's Node SSR children
+        # are created lazily per thread, so warming it can raise task RSS even though the
+        # parent-process cap remains unchanged. Failover is preserved by
+        # proxy_next_upstream across the 5 members.
         # fail_timeout reduced 45s -> 15s so a quarantined-but-recovered peer becomes
         # selectable again sooner. Caveat: supervisord `startsecs` is the liveness window
         # before a start is deemed successful -- it is NOT socket-ready time or a respawn

--- a/deploy/docker/production/test_nginx_failover.py
+++ b/deploy/docker/production/test_nginx_failover.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Offline behavioral harness for the nginx failover/retry policy in nginx.conf.
+
+Purpose
+-------
+Exercise the retry/method semantics that PR #721 documents, against a real nginx
+binary and loopback mock upstreams -- NO live services, no Docker, no AWS. This is
+an operational/behavioral check, deliberately NOT wired into pytest: it needs an
+nginx binary and spawns processes, which does not belong in the unit-test stack.
+
+What it asserts (deterministic, ordering forced with upstream `weight`):
+  1. GET, first peer 502, second 200                 -> final 200 (failover)
+  2. POST body sent, first peer 502                   -> final 502, NOT retried
+  3. POST, first peer connection-refused (pre-send)   -> retried -> final 200
+  4. PUT body sent, first peer 502                     -> retried -> final 200
+  5. GET, two peers 502, third healthy, tries=2        -> final 502 (third NOT tried)
+  6. Targeted log redaction: query string never logged; $request_id present
+
+Cases requiring wall-clock/quarantine timing and multi-nginx-worker shared health
+state (quarantine/recovery, handoff-timeout cutoff) are covered by the independent
+review's exact-version (nginx 1.21.6) validation; see data/smaht-721-review-sol-3n.
+
+Version note
+------------
+Run this against the PRODUCTION-pinned nginx (1.21.6) for authoritative results. The
+directives under test (proxy_next_upstream, _tries, _timeout, method policy) are core
+and version-stable; a smoke run on another local nginx confirms the harness itself.
+
+Usage
+-----
+  python3 deploy/docker/production/test_nginx_failover.py [--nginx /path/to/nginx]
+Exit code 0 = all asserted cases passed; 2 = a case failed; 77 = skipped (no nginx).
+"""
+import argparse
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+
+
+def free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+class MockUpstream(threading.Thread):
+    """Minimal loopback HTTP upstream with a fixed behavior.
+
+    mode: "200" | "502" -- reads the full request (incl. body via Content-Length),
+    then returns that status. A "refused" peer is modeled by simply NOT starting a
+    server on its port (connect() then fails pre-send).
+    """
+
+    def __init__(self, port, status):
+        super().__init__(daemon=True)
+        self.port = port
+        self.status = status
+        self._stop = False
+        self._srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._srv.bind(("127.0.0.1", port))
+        self._srv.listen(16)
+        self._srv.settimeout(0.3)
+
+    def run(self):
+        while not self._stop:
+            try:
+                conn, _ = self._srv.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            threading.Thread(target=self._handle, args=(conn,), daemon=True).start()
+
+    def _handle(self, conn):
+        conn.settimeout(2.0)
+        data = b""
+        try:
+            # Read headers.
+            while b"\r\n\r\n" not in data:
+                chunk = conn.recv(4096)
+                if not chunk:
+                    conn.close()
+                    return
+                data += chunk
+            head = data.split(b"\r\n\r\n", 1)[0]
+            m = re.search(rb"content-length:\s*(\d+)", head, re.I)
+            if m:
+                need = int(m.group(1))
+                have = len(data) - (len(head) + 4)
+                while have < need:
+                    chunk = conn.recv(4096)
+                    if not chunk:
+                        break
+                    have += len(chunk)
+            body = b"ok" if self.status == 200 else b"bad"
+            reason = "OK" if self.status == 200 else "Bad Gateway"
+            resp = (
+                f"HTTP/1.1 {self.status} {reason}\r\n"
+                f"Content-Length: {len(body)}\r\n"
+                f"Connection: close\r\n\r\n"
+            ).encode() + body
+            conn.sendall(resp)
+        except OSError:
+            pass
+        finally:
+            conn.close()
+
+    def stop(self):
+        self._stop = True
+        try:
+            self._srv.close()
+        except OSError:
+            pass
+
+
+def write_conf(workdir, listen_port, upstream_servers, access_log):
+    """Render a minimal nginx.conf mirroring the PR's retry directives.
+
+    upstream_servers: list of "server ...;" lines (weights force deterministic order).
+    No `use epoll;` -- let nginx pick the platform default so this runs on macOS too.
+    """
+    conf = f"""
+worker_processes 1;
+error_log stderr warn;
+pid {workdir}/nginx.pid;
+events {{ worker_connections 64; }}
+http {{
+    log_format upstream_debug
+        '$remote_addr method=$request_method uri=$uri status=$status '
+        'req_id=$request_id upstream_addr="$upstream_addr" '
+        'upstream_status="$upstream_status"';
+    map $upstream_addr   $ul_failover {{ "~,"     1; default 0; }}
+    map $upstream_status $ul_5xx      {{ "~5[0-9][0-9]" 1; default 0; }}
+    map "$ul_failover$ul_5xx" $ul_log {{ default 1; "00" 0; }}
+    access_log {access_log} upstream_debug if=$ul_log;
+
+    proxy_next_upstream error timeout http_502;
+    proxy_next_upstream_tries 2;
+    proxy_next_upstream_timeout 30s;
+
+    upstream app {{
+        {chr(10).join('        ' + s for s in upstream_servers)}
+    }}
+    server {{
+        listen 127.0.0.1:{listen_port};
+        location / {{
+            proxy_pass http://app;
+        }}
+    }}
+}}
+"""
+    path = os.path.join(workdir, "nginx.conf")
+    with open(path, "w") as f:
+        f.write(conf)
+    return path
+
+
+def http_request(port, method, path, body=None):
+    s = socket.socket()
+    s.settimeout(5.0)
+    s.connect(("127.0.0.1", port))
+    body_bytes = (body or "").encode()
+    req = f"{method} {path} HTTP/1.1\r\nHost: t\r\nConnection: close\r\n"
+    if method in ("POST", "PUT", "PATCH"):
+        req += f"Content-Length: {len(body_bytes)}\r\n"
+    req += "\r\n"
+    s.sendall(req.encode() + body_bytes)
+    data = b""
+    while True:
+        try:
+            chunk = s.recv(4096)
+        except socket.timeout:
+            break
+        if not chunk:
+            break
+        data += chunk
+    s.close()
+    status_line = data.split(b"\r\n", 1)[0].decode(errors="replace")
+    m = re.match(r"HTTP/1\.\d (\d+)", status_line)
+    return int(m.group(1)) if m else 0
+
+
+class Nginx:
+    def __init__(self, nginx_bin, conf, prefix):
+        self.p = subprocess.Popen([nginx_bin, "-c", conf, "-p", prefix, "-g", "daemon off;"],
+                                  stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+        time.sleep(0.6)
+
+    def stop(self):
+        self.p.terminate()
+        try:
+            self.p.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            self.p.kill()
+
+
+def run_case(nginx_bin, name, upstream_specs, method, expect_status, extra_check=None):
+    """upstream_specs: list of (behavior, weight). behavior: 200|502|refuse."""
+    workdir = tempfile.mkdtemp(prefix="nginx_failover_")
+    mocks = []
+    servers = []
+    try:
+        for behavior, weight in upstream_specs:
+            port = free_port()
+            if behavior in (200, 502):
+                mk = MockUpstream(port, behavior)
+                mk.start()
+                mocks.append(mk)
+            # behavior "refuse": no listener bound to `port` -> connection refused
+            w = f" weight={weight}" if weight else ""
+            servers.append(f"server 127.0.0.1:{port}{w} fail_timeout=15s;")
+        listen = free_port()
+        access_log = os.path.join(workdir, "access.log")
+        conf = write_conf(workdir, listen, servers, access_log)
+        ng = Nginx(nginx_bin, conf, workdir)
+        try:
+            status = http_request(listen, method, "/probe?token=SECRET123", body="x" * 32)
+        finally:
+            ng.stop()
+        log_txt = ""
+        if os.path.exists(access_log):
+            with open(access_log) as f:
+                log_txt = f.read()
+        ok = status == expect_status
+        detail = f"status={status} expect={expect_status}"
+        if ok and extra_check:
+            ex_ok, ex_detail = extra_check(log_txt)
+            ok = ok and ex_ok
+            detail += f"; {ex_detail}"
+        print(f"[{'PASS' if ok else 'FAIL'}] {name}: {detail}")
+        return ok
+    finally:
+        for mk in mocks:
+            mk.stop()
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--nginx", default=shutil.which("nginx"))
+    args = ap.parse_args()
+    if not args.nginx:
+        print("SKIP: no nginx binary found (pass --nginx). Exit 77.")
+        return 77
+    ver = subprocess.run([args.nginx, "-v"], capture_output=True, text=True)
+    print(f"nginx: {ver.stderr.strip() or ver.stdout.strip()}")
+    print("(Run against pinned 1.21.6 for authoritative results; see report §14.)\n")
+
+    results = []
+    # 1. GET failover: first peer 502 (heavy weight -> first hop), second 200.
+    results.append(run_case(args.nginx, "GET 502->200 failover",
+                            [(502, 100), (200, 1)], "GET", 200))
+    # 2. POST after-send 502 -> NOT retried.
+    results.append(run_case(args.nginx, "POST after-send 502 (no retry)",
+                            [(502, 100), (200, 1)], "POST", 502))
+    # 3. POST pre-send connection refused -> retried -> 200.
+    results.append(run_case(args.nginx, "POST pre-send refuse -> retry 200",
+                            [("refuse", 100), (200, 1)], "POST", 200))
+    # 4. PUT after-send 502 -> retried (PUT not protected) -> 200.
+    results.append(run_case(args.nginx, "PUT after-send 502 -> retry 200",
+                            [(502, 100), (200, 1)], "PUT", 200))
+    # 5. tries=2: two 502 peers, third healthy -> 502 (third not tried).
+    results.append(run_case(args.nginx, "tries=2: 502,502,(healthy 3rd) -> 502",
+                            [(502, 100), (502, 50), (200, 1)], "GET", 502))
+
+    # 6. Log redaction + correlation id (reuse case 1's failover log).
+    def check_log(log_txt):
+        no_qs = "SECRET123" not in log_txt and "token=" not in log_txt
+        has_id = "req_id=" in log_txt and not re.search(r"req_id=(\s|$)", log_txt)
+        has_uri = "uri=/probe" in log_txt
+        return (no_qs and has_id and has_uri,
+                f"query_string_redacted={no_qs} req_id_present={has_id} uri_logged={has_uri}")
+    results.append(run_case(args.nginx, "targeted log: no query string, has req_id",
+                            [(502, 100), (200, 1)], "GET", 200, extra_check=check_log))
+
+    passed = sum(1 for r in results if r)
+    print(f"\n{passed}/{len(results)} cases passed")
+    return 0 if passed == len(results) else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/docker/production/test_nginx_failover.py
+++ b/deploy/docker/production/test_nginx_failover.py
@@ -9,16 +9,20 @@ an operational/behavioral check, deliberately NOT wired into pytest: it needs an
 nginx binary and spawns processes, which does not belong in the unit-test stack.
 
 What it asserts (deterministic, ordering forced with upstream `weight`):
+  - The checked-in nginx/memory/Docker policy still matches this behavioral harness
   1. GET, first peer 502, second 200                 -> final 200 (failover)
   2. POST body sent, first peer 502                   -> final 502, NOT retried
   3. POST, first peer connection-refused (pre-send)   -> retried -> final 200
   4. PUT body sent, first peer 502                     -> retried -> final 200
   5. GET, two peers 502, third healthy, tries=2        -> final 502 (third NOT tried)
-  6. Targeted log redaction: query string never logged; $request_id present
+  6. Targeted log minimization: no query string/client address; $request_id present
+  7. Ordinary application 500 response                       -> NOT logged
+  8. Upstream gateway 502 response                           -> logged
+  9. Upstream gateway 504 response                           -> logged
 
 Cases requiring wall-clock/quarantine timing and multi-nginx-worker shared health
-state (quarantine/recovery, handoff-timeout cutoff) are covered by the independent
-review's exact-version (nginx 1.21.6) validation; see data/smaht-721-review-sol-3n.
+state (quarantine/recovery, handoff-timeout cutoff) are outside this harness. The
+production Docker build runs `nginx -t` against the pinned nginx 1.21.6 config.
 
 Version note
 ------------
@@ -41,6 +45,7 @@ import sys
 import tempfile
 import threading
 import time
+from pathlib import Path
 
 
 def free_port():
@@ -54,7 +59,7 @@ def free_port():
 class MockUpstream(threading.Thread):
     """Minimal loopback HTTP upstream with a fixed behavior.
 
-    mode: "200" | "502" -- reads the full request (incl. body via Content-Length),
+    status: 200 | 500 | 502 -- reads the full request (incl. body via Content-Length),
     then returns that status. A "refused" peer is modeled by simply NOT starting a
     server on its port (connect() then fails pre-send).
     """
@@ -63,7 +68,7 @@ class MockUpstream(threading.Thread):
         super().__init__(daemon=True)
         self.port = port
         self.status = status
-        self._stop = False
+        self._stopped = False
         self._srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self._srv.bind(("127.0.0.1", port))
@@ -71,7 +76,7 @@ class MockUpstream(threading.Thread):
         self._srv.settimeout(0.3)
 
     def run(self):
-        while not self._stop:
+        while not self._stopped:
             try:
                 conn, _ = self._srv.accept()
             except socket.timeout:
@@ -102,7 +107,12 @@ class MockUpstream(threading.Thread):
                         break
                     have += len(chunk)
             body = b"ok" if self.status == 200 else b"bad"
-            reason = "OK" if self.status == 200 else "Bad Gateway"
+            reason = {
+                200: "OK",
+                500: "Internal Server Error",
+                502: "Bad Gateway",
+                504: "Gateway Timeout",
+            }[self.status]
             resp = (
                 f"HTTP/1.1 {self.status} {reason}\r\n"
                 f"Content-Length: {len(body)}\r\n"
@@ -115,7 +125,7 @@ class MockUpstream(threading.Thread):
             conn.close()
 
     def stop(self):
-        self._stop = True
+        self._stopped = True
         try:
             self._srv.close()
         except OSError:
@@ -135,12 +145,12 @@ pid {workdir}/nginx.pid;
 events {{ worker_connections 64; }}
 http {{
     log_format upstream_debug
-        '$remote_addr method=$request_method uri=$uri status=$status '
+        'method=$request_method uri="$uri" status=$status '
         'req_id=$request_id upstream_addr="$upstream_addr" '
         'upstream_status="$upstream_status"';
-    map $upstream_addr   $ul_failover {{ "~,"     1; default 0; }}
-    map $upstream_status $ul_5xx      {{ "~5[0-9][0-9]" 1; default 0; }}
-    map "$ul_failover$ul_5xx" $ul_log {{ default 1; "00" 0; }}
+    map $upstream_addr   $ul_failover        {{ "~,"      1; default 0; }}
+    map $upstream_status $ul_gateway_failure {{ "~50[24]" 1; default 0; }}
+    map "$ul_failover$ul_gateway_failure" $ul_log {{ default 1; "00" 0; }}
     access_log {access_log} upstream_debug if=$ul_log;
 
     proxy_next_upstream error timeout http_502;
@@ -211,7 +221,7 @@ def run_case(nginx_bin, name, upstream_specs, method, expect_status, extra_check
     try:
         for behavior, weight in upstream_specs:
             port = free_port()
-            if behavior in (200, 502):
+            if isinstance(behavior, int):
                 mk = MockUpstream(port, behavior)
                 mk.start()
                 mocks.append(mk)
@@ -244,6 +254,42 @@ def run_case(nginx_bin, name, upstream_specs, method, expect_status, extra_check
         shutil.rmtree(workdir, ignore_errors=True)
 
 
+def validate_checked_in_policy():
+    """Keep the minimal test config tied to the production policy it represents."""
+    repo_root = Path(__file__).resolve().parents[3]
+    nginx_conf = (repo_root / "deploy/docker/production/nginx.conf").read_text()
+    base_ini = (repo_root / "base.ini").read_text()
+    dockerfile = (repo_root / "Dockerfile").read_text()
+
+    log_format = re.search(
+        r"log_format\s+upstream_debug(?P<body>.*?);", nginx_conf, re.S
+    )
+    upstream = re.search(r"upstream\s+app\s*\{(?P<body>.*?)\n\s*\}", nginx_conf, re.S)
+    active_peers = re.findall(
+        r"^\s*server 0\.0\.0\.0:654[3-7] fail_timeout=15s;\s*$",
+        upstream.group("body") if upstream else "",
+        re.M,
+    )
+    checks = {
+        "retry conditions": "proxy_next_upstream error timeout http_502;" in nginx_conf,
+        "two total attempts": "proxy_next_upstream_tries 2;" in nginx_conf,
+        "30s handoff cutoff": "proxy_next_upstream_timeout 30s;" in nginx_conf,
+        "five active 15s peers": len(active_peers) == 5,
+        "no backup peer": not re.search(
+            r"^\s*server\s+[^;]*\bbackup\b", upstream.group("body") if upstream else "", re.M
+        ),
+        "gateway-only status log": '"~50[24]" 1' in nginx_conf,
+        "client address omitted": bool(log_format) and "$remote_addr" not in log_format.group("body"),
+        "450MB parent cap": re.findall(r"^rss_limit\s*=\s*(\S+)", base_ini, re.M) == ["450MB"],
+        "pinned nginx syntax gate": "RUN nginx -v && nginx -t" in dockerfile,
+    }
+    failed = [name for name, ok in checks.items() if not ok]
+    ok = not failed
+    detail = "all guardrails present" if ok else "missing/mismatched: " + ", ".join(failed)
+    print(f"[{'PASS' if ok else 'FAIL'}] checked-in production policy: {detail}")
+    return ok
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--nginx", default=shutil.which("nginx"))
@@ -253,9 +299,9 @@ def main():
         return 77
     ver = subprocess.run([args.nginx, "-v"], capture_output=True, text=True)
     print(f"nginx: {ver.stderr.strip() or ver.stdout.strip()}")
-    print("(Run against pinned 1.21.6 for authoritative results; see report §14.)\n")
+    print("(Run against pinned 1.21.6 for authoritative results.)\n")
 
-    results = []
+    results = [validate_checked_in_policy()]
     # 1. GET failover: first peer 502 (heavy weight -> first hop), second 200.
     results.append(run_case(args.nginx, "GET 502->200 failover",
                             [(502, 100), (200, 1)], "GET", 200))
@@ -272,15 +318,38 @@ def main():
     results.append(run_case(args.nginx, "tries=2: 502,502,(healthy 3rd) -> 502",
                             [(502, 100), (502, 50), (200, 1)], "GET", 502))
 
-    # 6. Log redaction + correlation id (reuse case 1's failover log).
+    # 6. Log minimization + correlation id (reuse case 1's failover log).
     def check_log(log_txt):
         no_qs = "SECRET123" not in log_txt and "token=" not in log_txt
         has_id = "req_id=" in log_txt and not re.search(r"req_id=(\s|$)", log_txt)
-        has_uri = "uri=/probe" in log_txt
-        return (no_qs and has_id and has_uri,
-                f"query_string_redacted={no_qs} req_id_present={has_id} uri_logged={has_uri}")
-    results.append(run_case(args.nginx, "targeted log: no query string, has req_id",
+        has_uri = 'uri="/probe"' in log_txt
+        no_client_addr = not log_txt.startswith("127.0.0.1 ")
+        return (no_qs and has_id and has_uri and no_client_addr,
+                f"query_string_redacted={no_qs} req_id_present={has_id} "
+                f"uri_logged={has_uri} client_addr_omitted={no_client_addr}")
+    results.append(run_case(args.nginx, "targeted log: minimized, has req_id",
                             [(502, 100), (200, 1)], "GET", 200, extra_check=check_log))
+
+    # 7. An ordinary application 500 is already in the LB log; do not duplicate it.
+    def check_no_targeted_log(log_txt):
+        empty = not log_txt.strip()
+        return empty, f"targeted_log_empty={empty}"
+    results.append(run_case(args.nginx, "application 500 is not targeted-log noise",
+                            [(500, 1)], "GET", 500, extra_check=check_no_targeted_log))
+
+    # 8. A gateway 502 with no successful retry remains a worker-failure signal.
+    def check_gateway_log(log_txt):
+        logged = 'upstream_status="502"' in log_txt
+        return logged, f"gateway_failure_logged={logged}"
+    results.append(run_case(args.nginx, "gateway 502 remains targeted-log signal",
+                            [(502, 1)], "GET", 502, extra_check=check_gateway_log))
+
+    # 9. Exhausted upstream timeouts surface as 504 and must remain visible too.
+    def check_timeout_log(log_txt):
+        logged = 'upstream_status="504"' in log_txt
+        return logged, f"gateway_timeout_logged={logged}"
+    results.append(run_case(args.nginx, "gateway 504 remains targeted-log signal",
+                            [(504, 1)], "GET", 504, extra_check=check_timeout_log))
 
     passed = sum(1 for r in results if r)
     print(f"\n{passed}/{len(results)} cases passed")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "2.3.9"
+version = "2.3.10"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Hardens nginx failover and observability for waitress worker SIGKILL/restart churn. The per-worker `rss_limit` increase proposed in the first revision is deferred: this PR leaves the cap at **450MB**.

The branch includes merged `main` through PR 722. Release metadata is reconciled as **2.4.2** for PR 721, retaining PR 722 under 2.4.1 in the changelog.

## Capacity boundary

The five `snovault.memlimit` checks cover Python parent RSS; they do not form a task-wide bound because thread-local Node SSR children, nginx buffers, and watchdog overshoot are outside those caps. Raising every parent from 450MB to 600MB would permit another 750MB of parent RSS in an 8 GiB task. A future increase therefore needs a same-window process-tree/cgroup budget, canary alarms, and a defined rollback threshold.

Making port 6547 active does warm the fifth worker's lazy Node SSR children and can raise task RSS even at the unchanged parent cap. This PR does not claim that the unchanged cap bounds total task memory.

## nginx changes

- Makes all five workers active (`6547` was `backup`) so normal traffic round-robins across five parents instead of concentrating on four.
- Reduces `fail_timeout` from 45s to 15s so a recovered peer becomes selectable sooner. `max_fails` remains at its default of 1. Supervisord's `startsecs=6` is a liveness window, not a measured socket-readiness time.
- Sets `proxy_next_upstream_tries 2`, allowing at most **two total upstream attempts**, and `proxy_next_upstream_timeout 30s`, which limits when another handoff may begin rather than imposing an end-to-end deadline.
- Keeps nginx's default method protection: POST/LOCK/PATCH are not retried after being sent upstream; pre-send connection failures may retry any method, and PUT/DELETE/OPTIONS and other unprotected methods may retry.
- Adds an `upstream_debug` stream for multiple-attempt failover and upstream 502/504 gateway failures. It logs method, normalized URI without the query string, nginx request ID, timing, and upstream addresses/statuses. It omits the client address, and ordinary application 5xx responses remain solely in the LB log.

## Deliberate limits

- A request that selects two failed peers can return an error even if a third peer is healthy. This bounds retry amplification and latency during correlated failures.
- A worker failure after response bytes reach the client cannot be retried; the client receives a truncated/failed response.
- Non-protected methods such as PUT and DELETE may be replayed once. The policy does not enable nginx's `non_idempotent` option.
- The targeted nginx stream is separate from the LB log, so its retention and access controls must match.

## Validation

- The production Docker build runs `nginx -v && nginx -t` after installing the checked-in config, gating syntax and directive compatibility against the pinned nginx 1.21.6.
- `python3 deploy/docker/production/test_nginx_failover.py`: **10/10 pass** locally on nginx 1.27.0. The offline harness checks the checked-in 450MB/five-peer/retry/logging guardrails; GET failover; POST after-send no-retry; POST pre-send retry; PUT retry; the two-attempt limit; query/client-address minimization; exclusion of ordinary application 500s; and inclusion of upstream 502/504 signals.
- Merged-main Sentry regression suite: **7 passed** offline; focused flake8 is clean.
- Python compilation, `git diff --check`, release-version parsing, and conflict-marker checks pass. `pyproject.toml` and the top changelog entry are both 2.4.2.

The prior UNIT run's two setup errors were traced to one shared remote OpenSearch create request: the initial `sequencing` index `PUT` timed out after 20 seconds but completed server-side, then the client's retry received `resource_already_exists`. All 1,240 executed tests passed before those fixture errors, and the cleanup step ran. No nginx/application workaround is included for that transient remote-test condition; this merged commit triggers a fresh isolated CI run.

No deployment, AWS, production-service, or live-Sentry action is included.
