### PR TITLE
fix: down-sample Sentry performance transactions for internal /index endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Change Log
 
 `PR 722: Down-sample Sentry performance transactions for the internal /index endpoint <https://github.com/smaht-dac/smaht-portal/pull/722>`_
 
-* Replaces the flat ``traces_sample_rate`` with a ``traces_sampler`` in ``init_sentry`` (``src/encoded/__init__.py``) that samples the continuously-polled indexer ``/index`` transaction at a very low nonzero rate (0.001) while keeping all user-facing routes at the normal 0.1 rate. This contains Sentry transaction-quota burn driven by the indexer without changing error/exception capture, which remains governed by the separate ``sample_rate`` (kept at its default 1.0).
+* Replaces the flat ``traces_sample_rate`` with a ``traces_sampler`` in ``init_sentry`` (``src/encoded/__init__.py``) that samples the continuously-polled indexer ``/index`` transaction at a very low nonzero rate (0.001), preserves inherited sampling decisions for other transactions, and keeps locally started user-facing transactions at the normal 0.1 rate. This contains Sentry transaction-quota burn driven by the indexer without changing error/exception capture, which remains governed by the separate ``sample_rate`` (kept at its default 1.0).
 
 
 2.3.9

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,14 @@ Change Log
 ----------
 
 
+2.3.10
+======
+
+`PR 722: Down-sample Sentry performance transactions for the internal /index endpoint <https://github.com/smaht-dac/smaht-portal/pull/722>`_
+
+* Replaces the flat ``traces_sample_rate`` with a ``traces_sampler`` in ``init_sentry`` (``src/encoded/__init__.py``) that samples the continuously-polled indexer ``/index`` transaction at a very low nonzero rate (0.001) while keeping all user-facing routes at the normal 0.1 rate. This contains Sentry transaction-quota burn driven by the indexer without changing error/exception capture, which remains governed by the separate ``sample_rate`` (kept at its default 1.0).
+
+
 2.3.9
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "2.3.9"
+version = "2.3.10"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/__init__.py
+++ b/src/encoded/__init__.py
@@ -34,9 +34,19 @@ from .schema_formats import format_checker  # noqa
 
 # snovault.app.STATIC_MAX_AGE (8 seconds) is WAY too low for /static and /profiles - Will March 15 2022
 CGAP_STATIC_MAX_AGE = 1800
-# default trace_rate for sentry
+# Default performance-transaction sample rate for sentry on normal (user-facing) routes.
 # tune this to get more data points when analyzing performance
 SENTRY_TRACE_RATE = .1
+# The ES indexer polls the internal /index endpoint continuously (see snovault's
+# es_index_data command, which POSTs /index in a tight loop), so /index dominates
+# performance-transaction volume without adding user-facing signal. Sample it at a very
+# low but nonzero rate so a little indexing visibility remains and can be tuned later.
+# NOTE: this governs PERFORMANCE TRANSACTION sampling ONLY; error/exception capture is
+# controlled by the separate `sample_rate` option (kept at its default 1.0) and is not
+# affected here - exceptions raised while serving /index are still reported to Sentry.
+SENTRY_INDEX_TRACE_RATE = .001
+# WSGI PATH_INFO of the internal indexer endpoint whose transactions we down-sample.
+SENTRY_INDEX_TRANSACTION_PATH = '/index'
 DEFAULT_AUTH0_DOMAIN = 'hms-dbmi.auth0.com'
 DEFAULT_AUTH0_ALLOWED_CONNECTIONS = 'github,google-oauth2,partners,hms-it'
 
@@ -202,11 +212,42 @@ def app_version(config):
             config.registry.settings["ga_config"] = json.load(json_file)
 
 
+def sentry_traces_sampler(sampling_context):
+    """ Per-transaction performance sample-rate decision for sentry.
+
+    Returns the fraction of performance transactions to record for the current
+    request. The internal indexer endpoint (/index) is polled continuously by the
+    ES indexer and would otherwise dominate the performance-transaction quota
+    without adding user-facing signal, so it is sampled at a very low but nonzero
+    rate; every other (user-facing) route keeps the normal SENTRY_TRACE_RATE.
+
+    IMPORTANT: this affects PERFORMANCE TRANSACTIONS ONLY. Error/exception events are
+    governed by the separate `sample_rate` sentry_sdk.init option (kept at its default
+    of 1.0 in init_sentry) and are never suppressed by this function.
+
+    The WSGI environ is matched robustly: any transaction whose PATH_INFO is not
+    exactly the /index endpoint (including a missing or non-HTTP sampling context)
+    falls through to the normal rate, so normal user routes are never accidentally
+    suppressed.
+    """
+    wsgi_environ = (sampling_context or {}).get('wsgi_environ') or {}
+    if wsgi_environ.get('PATH_INFO') == SENTRY_INDEX_TRANSACTION_PATH:
+        return SENTRY_INDEX_TRACE_RATE
+    return SENTRY_TRACE_RATE
+
+
 def init_sentry(dsn):
     """ Helper function that initializes sentry SDK if a dsn is specified. """
     if dsn:
         sentry_sdk.init(dsn,
-                        traces_sample_rate=SENTRY_TRACE_RATE,
+                        # Performance-transaction sampling is decided per-transaction so the
+                        # continuously-polled /index endpoint can be down-sampled. A traces_sampler
+                        # supersedes traces_sample_rate, so the flat rate is intentionally omitted.
+                        traces_sampler=sentry_traces_sampler,
+                        # Error/exception events use this SEPARATE rate. Keep the SDK default (1.0 =
+                        # capture every error) explicit so it is clear the sampler above does not,
+                        # and cannot, hide exceptions.
+                        sample_rate=1.0,
                         integrations=[PyramidIntegration(), SqlalchemyIntegration()])
 
 

--- a/src/encoded/__init__.py
+++ b/src/encoded/__init__.py
@@ -219,7 +219,9 @@ def sentry_traces_sampler(sampling_context):
     request. The internal indexer endpoint (/index) is polled continuously by the
     ES indexer and would otherwise dominate the performance-transaction quota
     without adding user-facing signal, so it is sampled at a very low but nonzero
-    rate; every other (user-facing) route keeps the normal SENTRY_TRACE_RATE.
+    rate. Every other transaction preserves an upstream sampling decision when
+    present, matching the SDK behavior of the previous traces_sample_rate config;
+    locally started transactions keep the normal SENTRY_TRACE_RATE.
 
     IMPORTANT: this affects PERFORMANCE TRANSACTIONS ONLY. Error/exception events are
     governed by the separate `sample_rate` sentry_sdk.init option (kept at its default
@@ -227,12 +229,15 @@ def sentry_traces_sampler(sampling_context):
 
     The WSGI environ is matched robustly: any transaction whose PATH_INFO is not
     exactly the /index endpoint (including a missing or non-HTTP sampling context)
-    falls through to the normal rate, so normal user routes are never accidentally
-    suppressed.
+    falls through to the inherited decision or normal rate, so normal user routes
+    are never accidentally suppressed.
     """
     wsgi_environ = (sampling_context or {}).get('wsgi_environ') or {}
     if wsgi_environ.get('PATH_INFO') == SENTRY_INDEX_TRANSACTION_PATH:
         return SENTRY_INDEX_TRACE_RATE
+    parent_sampled = (sampling_context or {}).get('parent_sampled')
+    if parent_sampled is not None:
+        return parent_sampled
     return SENTRY_TRACE_RATE
 
 

--- a/src/encoded/tests/test_init_sentry.py
+++ b/src/encoded/tests/test_init_sentry.py
@@ -17,7 +17,10 @@ def _ctx(path):
 
 def test_index_transaction_is_downsampled():
     # The continuously-polled indexer endpoint is sampled at the very low nonzero rate.
-    assert sentry_traces_sampler(_ctx('/index')) == SENTRY_INDEX_TRACE_RATE
+    for parent_sampled in (None, True, False):
+        context = _ctx('/index')
+        context['parent_sampled'] = parent_sampled
+        assert sentry_traces_sampler(context) == SENTRY_INDEX_TRACE_RATE
     assert SENTRY_INDEX_TRACE_RATE == 0.001
     assert SENTRY_INDEX_TRANSACTION_PATH == '/index'
 
@@ -27,6 +30,15 @@ def test_normal_routes_keep_default_rate():
     assert SENTRY_TRACE_RATE == 0.1
     for path in ('/search/', '/browse/', '/', '/pages/some-page', '/a-file-uuid/@@download'):
         assert sentry_traces_sampler(_ctx(path)) == SENTRY_TRACE_RATE
+
+
+def test_non_index_transactions_preserve_parent_sampling_decision():
+    # A traces_sampler supersedes the SDK's automatic parent decision handling, so the callback
+    # must preserve it explicitly for both normal HTTP routes and non-HTTP transactions.
+    for base_context in (_ctx('/browse/'), {}):
+        for parent_sampled in (True, False):
+            context = dict(base_context, parent_sampled=parent_sampled)
+            assert sentry_traces_sampler(context) is parent_sampled
 
 
 def test_index_lookalike_paths_are_not_suppressed():

--- a/src/encoded/tests/test_init_sentry.py
+++ b/src/encoded/tests/test_init_sentry.py
@@ -1,0 +1,70 @@
+from unittest import mock
+
+import encoded
+from encoded import (
+    init_sentry,
+    sentry_traces_sampler,
+    SENTRY_TRACE_RATE,
+    SENTRY_INDEX_TRACE_RATE,
+    SENTRY_INDEX_TRANSACTION_PATH,
+)
+
+
+def _ctx(path):
+    """ Build a sentry sampling_context the way the WSGI integration does. """
+    return {'wsgi_environ': {'PATH_INFO': path}}
+
+
+def test_index_transaction_is_downsampled():
+    # The continuously-polled indexer endpoint is sampled at the very low nonzero rate.
+    assert sentry_traces_sampler(_ctx('/index')) == SENTRY_INDEX_TRACE_RATE
+    assert SENTRY_INDEX_TRACE_RATE == 0.001
+    assert SENTRY_INDEX_TRANSACTION_PATH == '/index'
+
+
+def test_normal_routes_keep_default_rate():
+    # User-facing routes keep the normal performance sample rate.
+    assert SENTRY_TRACE_RATE == 0.1
+    for path in ('/search/', '/browse/', '/', '/pages/some-page', '/a-file-uuid/@@download'):
+        assert sentry_traces_sampler(_ctx(path)) == SENTRY_TRACE_RATE
+
+
+def test_index_lookalike_paths_are_not_suppressed():
+    # Only the exact /index endpoint is down-sampled; lookalikes must keep the normal rate
+    # so we never accidentally suppress real user/admin routes.
+    for path in ('/index-abc', '/indexing_status', '/index/', '/reindex', '/xindex'):
+        assert sentry_traces_sampler(_ctx(path)) == SENTRY_TRACE_RATE
+
+
+def test_missing_or_alternate_context_is_not_suppressed_and_does_not_crash():
+    # Missing/empty/None sampling context (e.g. a non-HTTP transaction) must fall through
+    # to the normal rate rather than crashing or being accidentally suppressed.
+    assert sentry_traces_sampler(None) == SENTRY_TRACE_RATE
+    assert sentry_traces_sampler({}) == SENTRY_TRACE_RATE
+    assert sentry_traces_sampler({'wsgi_environ': None}) == SENTRY_TRACE_RATE
+    assert sentry_traces_sampler({'wsgi_environ': {}}) == SENTRY_TRACE_RATE
+    # A completely unrelated context shape should also be safe.
+    assert sentry_traces_sampler({'parent_sampled': None}) == SENTRY_TRACE_RATE
+
+
+def test_init_sentry_preserves_error_capture_and_uses_sampler():
+    # init_sentry must (1) keep error-event capture at the capture-all default, and
+    # (2) drive performance sampling through the per-transaction sampler rather than a
+    # flat traces_sample_rate (which the sampler would supersede anyway).
+    with mock.patch.object(encoded.sentry_sdk, 'init') as mock_init:
+        init_sentry('https://public@sentry.example.com/1')
+    assert mock_init.called
+    _args, kwargs = mock_init.call_args
+    # Error/exception events remain captured at the existing effective default (1.0).
+    assert kwargs['sample_rate'] == 1.0
+    # Performance sampling is per-transaction via our sampler...
+    assert kwargs['traces_sampler'] is sentry_traces_sampler
+    # ...and the flat rate is intentionally not passed.
+    assert 'traces_sample_rate' not in kwargs
+
+
+def test_init_sentry_is_a_noop_without_dsn():
+    # No DSN -> Sentry must not be initialized at all.
+    with mock.patch.object(encoded.sentry_sdk, 'init') as mock_init:
+        init_sentry(None)
+    assert not mock_init.called


### PR DESCRIPTION
## Summary

The Sentry monthly **transaction** quota is exhausted quickly because the ES indexer dominates performance-transaction volume. Production repeatedly runs `es-index-data`; each invocation can POST the internal `/index` WSGI endpoint up to 100 times (with early exit after consecutive empty-queue responses). This is non-user traffic that can run continuously.

This PR replaces the flat `traces_sample_rate=0.1` in `init_sentry` with a per-transaction **`traces_sampler`**. It samples `/index` at `0.001`, keeps locally started normal transactions at `0.1`, and preserves inherited parent sampling decisions for every non-`/index` transaction.

## Changes

- **`src/encoded/__init__.py`**
  - Adds `sentry_traces_sampler(sampling_context)` and `SENTRY_INDEX_TRACE_RATE = 0.001`.
  - Matches the exact WSGI `PATH_INFO == "/index"`; lookalikes such as `/indexing_status` and `/index/` retain normal behavior.
  - Missing/non-HTTP contexts safely use an inherited parent decision when present, otherwise the normal `0.1` rate.
  - Keeps `/index` quota control authoritative even when an upstream trace is sampled.
  - Configures `traces_sampler=...` and explicit `sample_rate=1.0` in `init_sentry`.
- **`src/encoded/tests/test_init_sentry.py`**
  - Adds focused offline coverage for exact path matching, lookalikes, missing/non-HTTP contexts, inherited parent decisions, SDK initialization, and no-DSN behavior.
- **`pyproject.toml` / `CHANGELOG.rst`**
  - Syncs with current `main` and records release `2.4.1`.

## Error capture remains at full rate

`traces_sampler` gates performance transactions only. Error events use the separate `sample_rate`, explicitly set to `1.0`; no `before_send` or `ignore_errors` filter is introduced. An offline transport test against the locked Sentry SDK 1.45.1 confirmed that an error raised inside an unsampled transaction still emits an error-event envelope.

## Validation (offline only)

- `NO_SERVER_FIXTURES=true PYTHONPATH="$PWD/src" PYENV_VERSION=smaht-portal311 python -m pytest -q src/encoded/tests/test_init_sentry.py` — **7 passed**
- `PYTHONPATH="$PWD/src" PYENV_VERSION=smaht-portal311 python -m flake8 src/encoded/__init__.py src/encoded/tests/test_init_sentry.py` — clean
- `git diff --check origin/main...HEAD` — clean
- Version/changelog consistency — `2.4.1`
- Locked SDK behavior checked locally from Sentry SDK `1.45.1`; no Sentry, AWS, deployed service, production system, or database was contacted.

## Rollback / tuning

Revert the sampler changes to restore the flat `0.1`. Tune `SENTRY_INDEX_TRACE_RATE` toward `0.01–0.1` for more `/index` visibility or toward `0` for greater transaction-quota savings.
