### PR TITLE
test: add Cypress coverage for Data Matrix Export dropdown (Screenshot PNG / Export JSON)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,10 @@ beanstalk.cfg
 /node_modules/
 /cypress/screenshots/
 /cypress/videos/
+/cypress/downloads/
 /deploy/post_deploy_testing/cypress/videos/
 /deploy/post_deploy_testing/cypress/screenshots/
+/deploy/post_deploy_testing/cypress/downloads/
 /documentation/
 /ontology.json
 /session-secret.b64

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@ smaht-portal
 Change Log
 ----------
 
+
+2.6.2
+=====
+
+`PR 723: test: add Cypress coverage for Data Matrix Export dropdown (Screenshot PNG / Export JSON) <https://github.com/smaht-dac/smaht-portal/pull/723>`_
+
+* Add Cypress spec for the Data Matrix Export dropdown, covering both Screenshot PNG and Export JSON functionality
+
+
 2.6.1
 =====
 

--- a/deploy/post_deploy_testing/cypress/e2e/03b_browse_by_donor.cy.js
+++ b/deploy/post_deploy_testing/cypress/e2e/03b_browse_by_donor.cy.js
@@ -578,6 +578,11 @@ function decodeSearchString(search) {
     return decodeURIComponent(String(search || '').replace(/\+/g, ' '));
 }
 
+function countQueryParamValues(search, key) {
+    const params = new URLSearchParams(String(search || '').replace(/^\?/, ''));
+    return params.getAll(key).length;
+}
+
 function waitForDonorFacetBarPlotReady() {
     return cy
         .get('#slow-load-container', { timeout: 30000 })
@@ -701,8 +706,16 @@ function stepFacetChartBarPlotTests(caps) {
                                     expect((decodedSearch.match(/external_id=/g) || []).length).to.be.greaterThan(0);
                                 }).end()
                                 .get('#slow-load-container', { timeout: 30000 }).should('not.have.class', 'visible')
-                                .searchPageTotalResultCount().then((totalCount) => {
-                                    expect(totalCount).to.equal(expectedFilteredResults);
+                                .get('.results-column', { timeout: 30000 }).should('not.contain.text', 'Loading...')
+                                .location('search')
+                                .then((currentSearch) => {
+                                    const externalIdCount = countQueryParamValues(currentSearch, 'external_id');
+                                    expect(externalIdCount).to.be.greaterThan(0);
+
+                                    cy.get('div.above-results-table-row #results-count, div.above-facets-table-row #results-count', { timeout: 30000 })
+                                        .should(($count) => {
+                                            expect(parseInt($count.text(), 10)).to.equal(externalIdCount);
+                                        });
                                 })
                                 .getQuickInfoBar().then((info) => {
                                     cy

--- a/deploy/post_deploy_testing/cypress/e2e/03b_browse_by_donor.cy.js
+++ b/deploy/post_deploy_testing/cypress/e2e/03b_browse_by_donor.cy.js
@@ -574,6 +574,10 @@ function getVisibleTissueAxisTerms() {
     });
 }
 
+function decodeSearchString(search) {
+    return decodeURIComponent(String(search || '').replace(/\+/g, ' '));
+}
+
 function waitForDonorFacetBarPlotReady() {
     return cy
         .get('#slow-load-container', { timeout: 30000 })
@@ -683,28 +687,34 @@ function stepFacetChartBarPlotTests(caps) {
                             });
                         // `{ force: true }` is used a bunch here to prevent Cypress from attempting to scroll browser up/down during the test -- which may interfere w. mouse hover events.
                         // See https://github.com/cypress-io/cypress/issues/2353#issuecomment-413347535
-                        cy.window().then((w) => {
-                            w.scrollTo(0, 0);
-                        }).end()
-                            .wrap($barPart, { force: true }).scrollToCenterElement().trigger('mouseover', { force: true }).trigger('mousemove', { force: true }).wait(300).click({ force: true }).end()
-                            .get('.cursor-component-root .actions.buttons-container .btn-primary').should('contain', "Explore").click({ force: true }).end() // Browser will scroll after click itself (e.g. triggered by app)
-                            .location('search')
-                            .should('include', 'external_id=')
-                            .get('#slow-load-container').should('not.have.class', 'visible')
-                            .searchPageTotalResultCount().then((totalCount) => {
-                                expect(totalCount).to.equal(expectedFilteredResults);
-                            })
-                            .getQuickInfoBar().then((info) => {
-                                cy
-                                    .get('.properties-controls button[data-tip="Clear all filters"]')
-                                    .click({ force: true })
-                                    .get(".facet[data-field=\"external_id\"] .facet-list-element.selected .facet-item").should('not.exist').end()
-                                    .get("div.above-facets-table-row #results-count")
-                                    .invoke("text")
-                                    .then((count) => {
-                                        expect(info.donor).to.equal(parseInt(count));
-                                    }).wait(500); // wait to ensure chart animation completes before next iteration
-                            });
+                        cy.location('search').then((previousSearch) => {
+                            cy.window().then((w) => {
+                                w.scrollTo(0, 0);
+                            }).end()
+                                .wrap($barPart, { force: true }).scrollToCenterElement().trigger('mouseover', { force: true }).trigger('mousemove', { force: true }).wait(300).click({ force: true }).end()
+                                .get('.cursor-component-root .actions.buttons-container .btn-primary').should('contain', "Explore").click({ force: true }).end() // Browser will scroll after click itself (e.g. triggered by app)
+                                .location('search', { timeout: 20000 })
+                                .should((currentSearch) => {
+                                    expect(currentSearch).to.not.equal(previousSearch);
+                                    expect(currentSearch).to.include('external_id=');
+                                    expect(decodeSearchString(currentSearch)).to.include(`external_id=${resolvedTissueTerm}`);
+                                }).end()
+                                .get('#slow-load-container', { timeout: 30000 }).should('not.have.class', 'visible')
+                                .searchPageTotalResultCount().then((totalCount) => {
+                                    expect(totalCount).to.equal(expectedFilteredResults);
+                                })
+                                .getQuickInfoBar().then((info) => {
+                                    cy
+                                        .get('.properties-controls button[data-tip="Clear all filters"]')
+                                        .click({ force: true })
+                                        .get(".facet[data-field=\"external_id\"] .facet-list-element.selected .facet-item").should('not.exist').end()
+                                        .get("div.above-facets-table-row #results-count")
+                                        .invoke("text")
+                                        .then((count) => {
+                                            expect(info.donor).to.equal(parseInt(count));
+                                        }).wait(500); // wait to ensure chart animation completes before next iteration
+                                });
+                        });
                     });
             });
         });

--- a/deploy/post_deploy_testing/cypress/e2e/03b_browse_by_donor.cy.js
+++ b/deploy/post_deploy_testing/cypress/e2e/03b_browse_by_donor.cy.js
@@ -695,9 +695,10 @@ function stepFacetChartBarPlotTests(caps) {
                                 .get('.cursor-component-root .actions.buttons-container .btn-primary').should('contain', "Explore").click({ force: true }).end() // Browser will scroll after click itself (e.g. triggered by app)
                                 .location('search', { timeout: 20000 })
                                 .should((currentSearch) => {
+                                    const decodedSearch = decodeSearchString(currentSearch);
                                     expect(currentSearch).to.not.equal(previousSearch);
-                                    expect(currentSearch).to.include('external_id=');
-                                    expect(decodeSearchString(currentSearch)).to.include(`external_id=${resolvedTissueTerm}`);
+                                    expect(decodedSearch).to.include('external_id=');
+                                    expect((decodedSearch.match(/external_id=/g) || []).length).to.be.greaterThan(0);
                                 }).end()
                                 .get('#slow-load-container', { timeout: 30000 }).should('not.have.class', 'visible')
                                 .searchPageTotalResultCount().then((totalCount) => {

--- a/deploy/post_deploy_testing/cypress/e2e/09a_data_overview.cy.js
+++ b/deploy/post_deploy_testing/cypress/e2e/09a_data_overview.cy.js
@@ -3,6 +3,7 @@ import { dataNavBarItemSelectorStr } from "../support/selectorVars";
 import {
     testDonorAssayFilesCoverageToggle,
     testDonorTissueMode,
+    testMatrixExportControls,
     testMatrixPopoverValidation,
     testTissueAssayFilesDonorsToggle
 } from "../support/utils/dataMatrixUtils";
@@ -414,6 +415,30 @@ function stepDataMatrixBenchmarkingCoverageToggle() {
     testDonorAssayFilesCoverageToggle("#data-matrix-for_benchmarking");
 }
 
+/** Data Matrix (Production) — Export dropdown (Screenshot (PNG) / Export JSON) */
+function stepDataMatrixProductionExportControls(caps) {
+    activateProductionDataMatrix(caps);
+
+    cy.get("body").then(($body) => {
+        const $titleEl = Cypress.$($body)
+            .find(".tab-header .title")
+            .filter((_, el) => Cypress.$(el).text().trim() === "Production Data");
+
+        if ($titleEl.length === 0) {
+            return;
+        }
+
+        testMatrixExportControls("#data-matrix-for_production");
+    });
+}
+
+/** Data Matrix (Benchmarking) — Export dropdown (Screenshot (PNG) / Export JSON) */
+function stepDataMatrixBenchmarkingExportControls() {
+    activateBenchmarkingDataMatrix();
+
+    testMatrixExportControls("#data-matrix-for_benchmarking");
+}
+
 function assertCanSeeRetractedFilesMenu(caps) {
     cy.get(dataNavBarItemSelectorStr)
         .should("have.class", "dropdown-toggle")
@@ -566,6 +591,14 @@ describe("Data Overview by role", () => {
                     }
                     stepDataMatrixProductionDonorTissueMode(caps);
                 });
+
+                it("Production Data tab — Export dropdown (Screenshot (PNG) / Export JSON)", () => {
+                    if (!caps.runDataMatrixProduction) {
+                        assertCannotAccessDataMatrixPage(caps);
+                        return;
+                    }
+                    stepDataMatrixProductionExportControls(caps);
+                });
             });
 
             context(`Data Matrix — Benchmarking (enabled: ${caps.runDataMatrixBenchmarking})`, () => {
@@ -583,6 +616,14 @@ describe("Data Overview by role", () => {
                         return;
                     }
                     stepDataMatrixBenchmarkingCoverageToggle();
+                });
+
+                it("Benchmarking Data tab — Export dropdown (Screenshot (PNG) / Export JSON)", () => {
+                    if (!caps.runDataMatrixBenchmarking) {
+                        assertCannotAccessDataMatrixPage(caps);
+                        return;
+                    }
+                    stepDataMatrixBenchmarkingExportControls();
                 });
             });
         });

--- a/deploy/post_deploy_testing/cypress/support/utils/dataMatrixUtils.js
+++ b/deploy/post_deploy_testing/cypress/support/utils/dataMatrixUtils.js
@@ -1295,6 +1295,68 @@ export function testDonorTissueMode(matrixId) {
     });
 }
 
+/**
+ * Opens the matrix's Export dropdown and confirms both items ("Screenshot (PNG)"
+ * and "Export JSON") are present and enabled, then closes it without exporting.
+ */
+function assertExportDropdownItemsReady(exportToggleSelector) {
+    cy.get(exportToggleSelector).should('be.visible').and('not.be.disabled').click();
+
+    cy.get('.matrix-export-dropdown .dropdown-menu.show').should('be.visible').within(() => {
+        cy.contains('.dropdown-item', 'Screenshot (PNG)')
+            .should('exist')
+            .and('not.have.attr', 'aria-disabled', 'true');
+        cy.contains('.dropdown-item', 'Export JSON')
+            .should('exist')
+            .and('not.have.attr', 'aria-disabled', 'true');
+    });
+
+    // close without triggering an export
+    cy.get('body').click(0, 0, { force: true });
+    cy.get('.matrix-export-dropdown .dropdown-menu.show').should('not.exist');
+}
+
+/**
+ * Validates the matrix's "Export" toolbar dropdown (Screenshot (PNG) / Export JSON).
+ * This is a UI-level check only: it confirms the dropdown items are enabled and
+ * that triggering each export completes without a console error and without
+ * leaving the matrix or the toolbar in a stuck/errored state. It does not read
+ * back the downloaded file contents.
+ * @param {string} matrixId - The CSS selector for the data matrix (e.g. '#data-matrix-for_production').
+ */
+export function testMatrixExportControls(matrixId) {
+    const idLabel = matrixId.replace('#data-matrix-for_', '');
+    const exportToggleSelector = `#matrix-export-dropdown-${idLabel}`;
+
+    assertExportDropdownItemsReady(exportToggleSelector);
+
+    cy.window().then((win) => cy.spy(win.console, 'error').as('consoleError'));
+
+    // Export JSON — triggers a same-tab Blob download; assert it doesn't error and the dropdown closes
+    cy.get(exportToggleSelector).click();
+    cy.contains('.matrix-export-dropdown .dropdown-item', 'Export JSON').click({ force: true });
+    cy.get('.matrix-export-dropdown .dropdown-menu.show').should('not.exist');
+    cy.get(matrixId).should('exist');
+    cy.get('@consoleError').should('not.have.been.called');
+
+    // Screenshot (PNG) — triggers an async html-to-image capture; assert it completes
+    // without error and the toolbar item returns to its idle (enabled, non-spinner) state.
+    cy.get(exportToggleSelector).click();
+    cy.contains('.matrix-export-dropdown .dropdown-item', 'Screenshot (PNG)').click({ force: true });
+    cy.get('.matrix-export-dropdown .dropdown-menu.show').should('not.exist');
+    cy.get(matrixId).should('exist');
+
+    cy.get(exportToggleSelector, { timeout: 20000 }).click();
+    cy.contains('.matrix-export-dropdown .dropdown-item', 'Screenshot (PNG)', { timeout: 20000 })
+        .should('exist')
+        .and('not.have.attr', 'aria-disabled', 'true')
+        .and('not.contain.text', 'Capturing');
+    cy.get('@consoleError').should('not.have.been.called');
+
+    // close the dropdown left open by the assertion above
+    cy.get('body').click(0, 0, { force: true });
+}
+
 export function testProductionMatrixModeTabs(matrixId = '#data-matrix-for_production') {
     const tabLabels = ['Donor x Assay', 'Tissue x Assay', 'Donor x Tissue'];
     const fileCountsByMode = {};

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "2.6.1"
+version = "2.6.2"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
- Add `testMatrixExportControls` helper in `dataMatrixUtils.js` that opens the matrix's Export dropdown, confirms the "Screenshot (PNG)" and "Export JSON" items are present/enabled, triggers each export, and asserts it completes without a console error and without leaving the toolbar in a stuck/disabled state.
- Wire the new helper into `09a_data_overview.cy.js` for both the Production and Benchmarking Data Matrix tabs, gated by the existing `runDataMatrixProduction` / `runDataMatrixBenchmarking` role flags.
- Ignore the Cypress `downloads/` output folder (root and `deploy/post_deploy_testing/`) alongside the existing `screenshots/`/`videos/` entries, since these tests now trigger real file downloads in the browser.