### PR TITLE
feat(notifications): add data-release email notification enrollment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,8 +100,10 @@ authoritative files over copied details; use `README.rst` for the longer macOS s
   `-m "not workbook"` and `make test-npm` means `-m workbook`; trust the recipes in `Makefile`.
   `make test-static` runs static pytest checks plus frontend lint. `make remote-test` uses the shared
   AWS-authenticated OpenSearch test service and is the CI path, not a credential-free local check.
-- React/Jest tests live in `src/encoded/static/components/__tests__/`; Cypress specifications and
-  configuration live under `deploy/post_deploy_testing/`. Use the `cypress:*` scripts in
+- There is no Jest/UI unit-test harness (`src/encoded/static/components/__tests__/` holds only a
+  `.jshintrc`; no jest dependency, config, or npm test script). Frontend invariants are covered by
+  static source-contract pytest checks in `src/encoded/tests/test_static.py`. Cypress specifications
+  and configuration live under `deploy/post_deploy_testing/`. Use the `cypress:*` scripts in
   `package.json`; they require Auth0 credentials and an explicit/local or deployed target.
 
 ## Integration and operational sharp edges

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Change Log
 2.4.5
 =====
 
-`PR #716: Add data-release email notification enrollment <https://github.com/smaht-dac/smaht-portal/pull/716>`_
+`PR #725: Add data-release email notification enrollment <https://github.com/smaht-dac/smaht-portal/pull/725>`_
 
 * Users can enroll their profile email in data-release email notifications from their
   profile page; enrollment subscribes the email to an SNS topic and records the state

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,23 @@ Change Log
 ----------
 
 
+2.4.5
+=====
+
+`PR #716: Add data-release email notification enrollment <https://github.com/smaht-dac/smaht-portal/pull/716>`_
+
+* Users can enroll their profile email in data-release email notifications from their
+  profile page; enrollment subscribes the email to an SNS topic and records the state
+  on the ``User`` item (``data_release_notification_enrolled``)
+* New endpoints: ``POST /register_notification``, ``POST /deregister_notification``
+  (authenticated users only), and ``GET /health/data-release-notifications``
+  (topic availability)
+* Deployment prerequisite: the feature stays hidden unless an SNS topic ARN is
+  configured (``sns_topic`` in settings or the ``SNS_TOPIC`` GAC key), and the portal
+  task role needs ``sns:Subscribe``, ``sns:Unsubscribe``, and
+  ``sns:ListSubscriptionsByTopic`` on that topic
+
+
 2.4.4
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "2.4.4"
+version = "2.4.5"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/__init__.py
+++ b/src/encoded/__init__.py
@@ -65,6 +65,7 @@ def include_encoded(config):
         For detailed explanation see: https://docs.pylonsproject.org/projects/pyramid/en/latest/api/config.html
     """
     config.include('encoded.authentication')
+    config.include('encoded.notifications')
     config.include('encoded.root')
     config.include('encoded.types')
     config.include('encoded.metadata')

--- a/src/encoded/notifications.py
+++ b/src/encoded/notifications.py
@@ -1,0 +1,218 @@
+"""Data-release email notification enrollment views."""
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+from boto3 import client as boto_client
+from botocore.exceptions import BotoCoreError, ClientError
+from dcicutils.secrets_utils import assume_identity
+from pyramid.httpexceptions import (
+    HTTPBadGateway,
+    HTTPServiceUnavailable,
+    HTTPUnauthorized,
+    HTTPUnprocessableEntity,
+)
+from pyramid.security import Authenticated, NO_PERMISSION_REQUIRED
+from pyramid.view import view_config
+from snovault import COLLECTIONS
+from snovault.crud_views import update_item
+
+
+log = logging.getLogger(__name__)
+
+
+# The GAC key follows the existing all-caps identity convention. The lower-case
+# registry key matches Pyramid's settings/registry conventions in this project.
+SNS_TOPIC_GAC_KEY = "SNS_TOPIC"
+SNS_TOPIC_REGISTRY_KEY = "sns_topic"
+DATA_RELEASE_NOTIFICATION_ENROLLED = "data_release_notification_enrolled"
+NOTIFICATION_AVAILABLE = "data_release_notifications_available"
+PENDING_CONFIRMATION = "PendingConfirmation"
+
+
+def includeme(config) -> None:
+    configure_sns_topic(config)
+    config.add_route(
+        "data-release-notification-availability",
+        "/health/data-release-notifications",
+    )
+    config.add_route("register-notification", "/register_notification")
+    config.add_route("deregister-notification", "/deregister_notification")
+    config.scan(__name__)
+
+
+def configure_sns_topic(config) -> None:
+    """Record the optional data-release SNS topic in the application registry."""
+    topic = config.registry.settings.get(SNS_TOPIC_REGISTRY_KEY)
+    if not topic and "IDENTITY" in os.environ:
+        identity = assume_identity()
+        topic = identity.get(SNS_TOPIC_GAC_KEY)
+    if topic:
+        if is_sns_topic_arn(topic):
+            config.registry[SNS_TOPIC_REGISTRY_KEY] = topic
+        else:
+            log.error("Ignoring invalid SNS topic ARN in application configuration")
+
+
+def is_sns_topic_arn(value: Any) -> bool:
+    """Return whether ``value`` has the shape of an SNS topic ARN."""
+    if not isinstance(value, str):
+        return False
+    parts = value.split(":")
+    return (
+        len(parts) == 6
+        and parts[0] == "arn"
+        and parts[1].startswith("aws")
+        and parts[2] == "sns"
+        and bool(parts[3])
+        and parts[4].isdigit()
+        and len(parts[4]) == 12
+        and bool(parts[5])
+    )
+
+
+def notification_topic_available(registry) -> bool:
+    return bool(registry.get(SNS_TOPIC_REGISTRY_KEY))
+
+
+@view_config(
+    route_name="data-release-notification-availability",
+    request_method="GET",
+    permission=NO_PERMISSION_REQUIRED,
+)
+def notification_availability(context, request) -> Dict[str, bool]:
+    """Expose topic availability without making an AWS request."""
+    request.response.cache_control.max_age = 300
+    request.response.cache_control.public = True
+    return {NOTIFICATION_AVAILABLE: notification_topic_available(request.registry)}
+
+
+def authenticated_user(request):
+    """Return the current user resource, never a caller-selected profile."""
+    for principal in request.effective_principals:
+        if principal.startswith("userid."):
+            user_uuid = principal[len("userid.") :]
+            try:
+                return request.registry[COLLECTIONS]["user"][user_uuid]
+            except KeyError as error:
+                raise HTTPUnauthorized(title="Authenticated user profile not found") from error
+    raise HTTPUnauthorized(title="A user profile is required")
+
+
+def get_topic_or_raise(request) -> str:
+    topic = request.registry.get(SNS_TOPIC_REGISTRY_KEY)
+    if not topic:
+        raise HTTPServiceUnavailable(
+            title="Data-release email notifications are not available"
+        )
+    return topic
+
+
+def get_user_email_or_raise(user) -> str:
+    email = user.upgrade_properties().get("email")
+    if not isinstance(email, str) or not email.strip():
+        raise HTTPUnprocessableEntity(
+            title="The authenticated user profile does not have an email address"
+        )
+    return email.strip().lower()
+
+
+def update_enrollment_state(user, request, enrolled: bool) -> None:
+    properties = user.upgrade_properties().copy()
+    properties[DATA_RELEASE_NOTIFICATION_ENROLLED] = enrolled
+    update_item(user, request, properties)
+
+
+def sns_error(operation: str, error: Exception) -> HTTPBadGateway:
+    log.error("SNS %s failed: %s", operation, error.__class__.__name__)
+    return HTTPBadGateway(
+        title="AWS could not update the data-release email subscription"
+    )
+
+
+@view_config(
+    route_name="register-notification",
+    request_method="POST",
+    effective_principals=Authenticated,
+)
+def register_notification(context, request) -> Dict[str, Any]:
+    """Request an SNS email subscription for the authenticated user's email."""
+    topic = get_topic_or_raise(request)
+    user = authenticated_user(request)
+    properties = user.upgrade_properties()
+    if properties.get(DATA_RELEASE_NOTIFICATION_ENROLLED) is True:
+        return enrollment_response(enrolled=True, changed=False)
+
+    email = get_user_email_or_raise(user)
+    try:
+        boto_client("sns").subscribe(
+            TopicArn=topic,
+            Protocol="email",
+            Endpoint=email,
+            ReturnSubscriptionArn=True,
+        )
+    except (BotoCoreError, ClientError) as error:
+        raise sns_error("subscribe", error) from error
+
+    update_enrollment_state(user, request, enrolled=True)
+    return enrollment_response(enrolled=True, changed=True)
+
+
+def enrollment_response(*, enrolled: bool, changed: bool) -> Dict[str, Any]:
+    return {
+        "status": "success",
+        DATA_RELEASE_NOTIFICATION_ENROLLED: enrolled,
+        "changed": changed,
+    }
+
+
+def find_subscription_arn(sns_client, topic: str, email: str) -> Optional[str]:
+    """Find the confirmed subscription ARN for an email, following pagination."""
+    next_token = None
+    while True:
+        request: Dict[str, str] = {"TopicArn": topic}
+        if next_token:
+            request["NextToken"] = next_token
+        response = sns_client.list_subscriptions_by_topic(**request)
+        for subscription in response.get("Subscriptions", []):
+            endpoint = subscription.get("Endpoint")
+            if (
+                subscription.get("Protocol") == "email"
+                and isinstance(endpoint, str)
+                and endpoint.casefold() == email.casefold()
+            ):
+                subscription_arn = subscription.get("SubscriptionArn")
+                if subscription_arn and subscription_arn != PENDING_CONFIRMATION:
+                    return subscription_arn
+        next_token = response.get("NextToken")
+        if not next_token:
+            return None
+
+
+@view_config(
+    route_name="deregister-notification",
+    request_method="POST",
+    effective_principals=Authenticated,
+)
+def deregister_notification(context, request) -> Dict[str, Any]:
+    """Remove the authenticated user's SNS subscription, if it exists."""
+    topic = get_topic_or_raise(request)
+    user = authenticated_user(request)
+    properties = user.upgrade_properties()
+    if properties.get(DATA_RELEASE_NOTIFICATION_ENROLLED) is not True:
+        return enrollment_response(enrolled=False, changed=False)
+
+    email = get_user_email_or_raise(user)
+    try:
+        sns_client = boto_client("sns")
+        subscription_arn = find_subscription_arn(sns_client, topic, email)
+        if subscription_arn:
+            sns_client.unsubscribe(SubscriptionArn=subscription_arn)
+    except (BotoCoreError, ClientError) as error:
+        raise sns_error("unsubscribe", error) from error
+
+    # No confirmed subscription is an idempotent success (including a request
+    # still awaiting confirmation); there is then no active delivery to stop.
+    update_enrollment_state(user, request, enrolled=False)
+    return enrollment_response(enrolled=False, changed=True)

--- a/src/encoded/notifications.py
+++ b/src/encoded/notifications.py
@@ -119,6 +119,9 @@ def get_user_email_or_raise(user) -> str:
 
 
 def update_enrollment_state(user, request, enrolled: bool) -> None:
+    # Deliberately calls snovault's update_item directly: owners lack 'edit'
+    # on their own User item (ONLY_OWNER_VIEW_PROFILE_ACL), and the write is
+    # limited to existing properties plus one server-set boolean.
     properties = user.upgrade_properties().copy()
     properties[DATA_RELEASE_NOTIFICATION_ENROLLED] = enrolled
     update_item(user, request, properties)

--- a/src/encoded/schemas/user.json
+++ b/src/encoded/schemas/user.json
@@ -106,6 +106,12 @@
             "title": "Institution",
             "type": "string",
             "comment": "Can be user supplied - purely informational"
+        },
+        "data_release_notification_enrolled": {
+            "title": "Data Release Notification Enrollment",
+            "description": "Whether the user requested enrollment in data-release email announcements.",
+            "type": "boolean",
+            "default": false
         }
     },
     "facets": {

--- a/src/encoded/static/components/item-pages/UserView.js
+++ b/src/encoded/static/components/item-pages/UserView.js
@@ -29,25 +29,13 @@ import {
     pageTitleViews,
 } from './../PageTitleSection';
 import { Term } from './../util/Schemas';
+import {
+    DataReleaseNotificationEnrollment,
+    DATA_RELEASE_NOTIFICATION_ENROLLED,
+} from './components/DataReleaseNotificationEnrollment';
 
 // eslint-disable-next-line no-unused-vars
 import { Item } from './../util/typedefs';
-
-const DATA_RELEASE_NOTIFICATION_ENROLLED =
-    'data_release_notification_enrolled';
-let notificationAvailabilityPromise = null;
-
-function getNotificationAvailability() {
-    if (!notificationAvailabilityPromise) {
-        notificationAvailabilityPromise = ajax
-            .promise('/health/data-release-notifications')
-            .catch((error) => {
-                notificationAvailabilityPromise = null;
-                throw error;
-            });
-    }
-    return notificationAvailabilityPromise;
-}
 
 /**
  * Contains the User profile page view as well as Impersonate User form.
@@ -374,237 +362,6 @@ class SyncedAccessKeyTable extends React.PureComponent {
     }
 }
 
-class DataReleaseNotificationEnrollment extends React.PureComponent {
-    static propTypes = {
-        user: PropTypes.shape({
-            email: PropTypes.string.isRequired,
-            data_release_notification_enrolled: PropTypes.bool,
-        }).isRequired,
-        onChange: PropTypes.func.isRequired,
-    };
-
-    constructor(props) {
-        super(props);
-        _.bindAll(
-            this,
-            'enroll',
-            'showUnenrollConfirmation',
-            'unenroll',
-            'hideModal'
-        );
-        this.state = {
-            available: null,
-            submitting: false,
-            modal: null,
-        };
-    }
-
-    componentDidMount() {
-        this.mounted = true;
-        getNotificationAvailability().then(
-            (response) => {
-                if (this.mounted) {
-                    this.setState({
-                        available: Boolean(
-                            response.data_release_notifications_available
-                        ),
-                    });
-                }
-            },
-            () => {
-                if (this.mounted) {
-                    this.setState({ available: false });
-                }
-            }
-        );
-    }
-
-    componentWillUnmount() {
-        this.mounted = false;
-    }
-
-    enroll() {
-        const { onChange } = this.props;
-        this.setState({ submitting: true });
-        ajax.load(
-            '/register_notification',
-            () => {
-                onChange(true);
-                this.setState({
-                    submitting: false,
-                    modal: 'enrolled',
-                });
-            },
-            'POST',
-            () => {
-                this.setState({ submitting: false });
-                Alerts.queue({
-                    title: 'Enrollment failed',
-                    message:
-                        'Data-release email enrollment could not be completed. Please try again.',
-                    style: 'danger',
-                });
-            },
-            '{}'
-        );
-    }
-
-    showUnenrollConfirmation() {
-        this.setState({ modal: 'unenroll' });
-    }
-
-    unenroll() {
-        const { onChange } = this.props;
-        this.setState({ submitting: true });
-        ajax.load(
-            '/deregister_notification',
-            () => {
-                onChange(false);
-                this.setState({ submitting: false, modal: null });
-                Alerts.queue({
-                    title: 'Unenrolled from data-release announcements',
-                    message:
-                        'You can enroll again from your profile at any time.',
-                    style: 'success',
-                });
-            },
-            'POST',
-            () => {
-                this.setState({ submitting: false });
-                Alerts.queue({
-                    title: 'Unenrollment failed',
-                    message:
-                        'Your enrollment was not changed. Please try again.',
-                    style: 'danger',
-                });
-            },
-            '{}'
-        );
-    }
-
-    hideModal() {
-        const { submitting } = this.state;
-        if (!submitting) {
-            this.setState({ modal: null });
-        }
-    }
-
-    renderModal() {
-        const { user } = this.props;
-        const { modal, submitting } = this.state;
-        if (modal === 'enrolled') {
-            return (
-                <Modal show onHide={this.hideModal}>
-                    <Modal.Header closeButton>
-                        <Modal.Title>Confirm your email subscription</Modal.Title>
-                    </Modal.Header>
-                    <Modal.Body>
-                        <p>
-                            AWS will email <strong>{user.email}</strong>. You
-                            must acknowledge that email by following its
-                            confirmation link to complete your subscription.
-                        </p>
-                    </Modal.Body>
-                    <Modal.Footer>
-                        <button
-                            type="button"
-                            className="btn btn-primary"
-                            onClick={this.hideModal}>
-                            Done
-                        </button>
-                    </Modal.Footer>
-                </Modal>
-            );
-        }
-        if (modal === 'unenroll') {
-            return (
-                <Modal show onHide={this.hideModal}>
-                    <Modal.Header closeButton={!submitting}>
-                        <Modal.Title>
-                            Unenroll from data-release announcements?
-                        </Modal.Title>
-                    </Modal.Header>
-                    <Modal.Body>
-                        <div className="alert alert-warning mb-0" role="alert">
-                            You will stop receiving data-release announcements
-                            at <strong>{user.email}</strong>. You can enroll
-                            again from your profile at any time.
-                        </div>
-                    </Modal.Body>
-                    <Modal.Footer>
-                        <button
-                            type="button"
-                            className="btn btn-secondary"
-                            disabled={submitting}
-                            onClick={this.hideModal}>
-                            Cancel
-                        </button>
-                        <button
-                            type="button"
-                            className="btn btn-danger"
-                            disabled={submitting}
-                            onClick={this.unenroll}>
-                            {submitting ? 'Unenrolling…' : 'Unenroll'}
-                        </button>
-                    </Modal.Footer>
-                </Modal>
-            );
-        }
-        return null;
-    }
-
-    render() {
-        const { user } = this.props;
-        const { available, submitting } = this.state;
-        if (!available) {
-            return null;
-        }
-        const enrolled = Boolean(user[DATA_RELEASE_NOTIFICATION_ENROLLED]);
-        let actionLabel = enrolled ? 'Unenroll' : 'Enroll';
-        if (submitting) {
-            actionLabel = enrolled ? 'Unenrolling…' : 'Enrolling…';
-        }
-        return (
-            <div className="card mt-3 data-release-notification-enrollment">
-                <div className="card-header">
-                    <h3 className="block-title">
-                        <i className="icon icon-bell far icon-fw me-12" />
-                        Data Release Announcements
-                    </h3>
-                </div>
-                <div className="card-body d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3">
-                    <div>
-                        <p className="mb-0">
-                            Receive an email when new SMaHT data is released.
-                        </p>
-                        {enrolled ? (
-                            <small className="text-secondary">
-                                Enrolled as {user.email}
-                            </small>
-                        ) : null}
-                    </div>
-                    <button
-                        type="button"
-                        className={
-                            enrolled
-                                ? 'btn btn-outline-danger flex-shrink-0'
-                                : 'btn btn-primary flex-shrink-0'
-                        }
-                        disabled={submitting}
-                        onClick={
-                            enrolled
-                                ? this.showUnenrollConfirmation
-                                : this.enroll
-                        }>
-                        {actionLabel}
-                    </button>
-                </div>
-                {this.renderModal()}
-            </div>
-        );
-    }
-}
-
 function AccessKeyTableContainer({ children, bodyClassName = 'card-body' }) {
     return (
         <div className="access-keys-container card mt-36">
@@ -903,6 +660,8 @@ export default class UserView extends React.Component {
                             </div>
                         </div>
 
+                        <SyncedAccessKeyTable {...{ user }} />
+
                         {isOwnProfile ? (
                             <DataReleaseNotificationEnrollment
                                 user={user}
@@ -911,8 +670,6 @@ export default class UserView extends React.Component {
                                 }
                             />
                         ) : null}
-
-                        <SyncedAccessKeyTable {...{ user }} />
                     </div>
                 </div>
             </div>

--- a/src/encoded/static/components/item-pages/UserView.js
+++ b/src/encoded/static/components/item-pages/UserView.js
@@ -33,6 +33,22 @@ import { Term } from './../util/Schemas';
 // eslint-disable-next-line no-unused-vars
 import { Item } from './../util/typedefs';
 
+const DATA_RELEASE_NOTIFICATION_ENROLLED =
+    'data_release_notification_enrolled';
+let notificationAvailabilityPromise = null;
+
+function getNotificationAvailability() {
+    if (!notificationAvailabilityPromise) {
+        notificationAvailabilityPromise = ajax
+            .promise('/health/data-release-notifications')
+            .catch((error) => {
+                notificationAvailabilityPromise = null;
+                throw error;
+            });
+    }
+    return notificationAvailabilityPromise;
+}
+
 /**
  * Contains the User profile page view as well as Impersonate User form.
  * Only the User view is exported.
@@ -358,6 +374,237 @@ class SyncedAccessKeyTable extends React.PureComponent {
     }
 }
 
+class DataReleaseNotificationEnrollment extends React.PureComponent {
+    static propTypes = {
+        user: PropTypes.shape({
+            email: PropTypes.string.isRequired,
+            data_release_notification_enrolled: PropTypes.bool,
+        }).isRequired,
+        onChange: PropTypes.func.isRequired,
+    };
+
+    constructor(props) {
+        super(props);
+        _.bindAll(
+            this,
+            'enroll',
+            'showUnenrollConfirmation',
+            'unenroll',
+            'hideModal'
+        );
+        this.state = {
+            available: null,
+            submitting: false,
+            modal: null,
+        };
+    }
+
+    componentDidMount() {
+        this.mounted = true;
+        getNotificationAvailability().then(
+            (response) => {
+                if (this.mounted) {
+                    this.setState({
+                        available: Boolean(
+                            response.data_release_notifications_available
+                        ),
+                    });
+                }
+            },
+            () => {
+                if (this.mounted) {
+                    this.setState({ available: false });
+                }
+            }
+        );
+    }
+
+    componentWillUnmount() {
+        this.mounted = false;
+    }
+
+    enroll() {
+        const { onChange } = this.props;
+        this.setState({ submitting: true });
+        ajax.load(
+            '/register_notification',
+            () => {
+                onChange(true);
+                this.setState({
+                    submitting: false,
+                    modal: 'enrolled',
+                });
+            },
+            'POST',
+            () => {
+                this.setState({ submitting: false });
+                Alerts.queue({
+                    title: 'Enrollment failed',
+                    message:
+                        'Data-release email enrollment could not be completed. Please try again.',
+                    style: 'danger',
+                });
+            },
+            '{}'
+        );
+    }
+
+    showUnenrollConfirmation() {
+        this.setState({ modal: 'unenroll' });
+    }
+
+    unenroll() {
+        const { onChange } = this.props;
+        this.setState({ submitting: true });
+        ajax.load(
+            '/deregister_notification',
+            () => {
+                onChange(false);
+                this.setState({ submitting: false, modal: null });
+                Alerts.queue({
+                    title: 'Unenrolled from data-release announcements',
+                    message:
+                        'You can enroll again from your profile at any time.',
+                    style: 'success',
+                });
+            },
+            'POST',
+            () => {
+                this.setState({ submitting: false });
+                Alerts.queue({
+                    title: 'Unenrollment failed',
+                    message:
+                        'Your enrollment was not changed. Please try again.',
+                    style: 'danger',
+                });
+            },
+            '{}'
+        );
+    }
+
+    hideModal() {
+        const { submitting } = this.state;
+        if (!submitting) {
+            this.setState({ modal: null });
+        }
+    }
+
+    renderModal() {
+        const { user } = this.props;
+        const { modal, submitting } = this.state;
+        if (modal === 'enrolled') {
+            return (
+                <Modal show onHide={this.hideModal}>
+                    <Modal.Header closeButton>
+                        <Modal.Title>Confirm your email subscription</Modal.Title>
+                    </Modal.Header>
+                    <Modal.Body>
+                        <p>
+                            AWS will email <strong>{user.email}</strong>. You
+                            must acknowledge that email by following its
+                            confirmation link to complete your subscription.
+                        </p>
+                    </Modal.Body>
+                    <Modal.Footer>
+                        <button
+                            type="button"
+                            className="btn btn-primary"
+                            onClick={this.hideModal}>
+                            Done
+                        </button>
+                    </Modal.Footer>
+                </Modal>
+            );
+        }
+        if (modal === 'unenroll') {
+            return (
+                <Modal show onHide={this.hideModal}>
+                    <Modal.Header closeButton={!submitting}>
+                        <Modal.Title>
+                            Unenroll from data-release announcements?
+                        </Modal.Title>
+                    </Modal.Header>
+                    <Modal.Body>
+                        <div className="alert alert-warning mb-0" role="alert">
+                            You will stop receiving data-release announcements
+                            at <strong>{user.email}</strong>. You can enroll
+                            again from your profile at any time.
+                        </div>
+                    </Modal.Body>
+                    <Modal.Footer>
+                        <button
+                            type="button"
+                            className="btn btn-secondary"
+                            disabled={submitting}
+                            onClick={this.hideModal}>
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            className="btn btn-danger"
+                            disabled={submitting}
+                            onClick={this.unenroll}>
+                            {submitting ? 'Unenrolling…' : 'Unenroll'}
+                        </button>
+                    </Modal.Footer>
+                </Modal>
+            );
+        }
+        return null;
+    }
+
+    render() {
+        const { user } = this.props;
+        const { available, submitting } = this.state;
+        if (!available) {
+            return null;
+        }
+        const enrolled = Boolean(user[DATA_RELEASE_NOTIFICATION_ENROLLED]);
+        let actionLabel = enrolled ? 'Unenroll' : 'Enroll';
+        if (submitting) {
+            actionLabel = enrolled ? 'Unenrolling…' : 'Enrolling…';
+        }
+        return (
+            <div className="card mt-3 data-release-notification-enrollment">
+                <div className="card-header">
+                    <h3 className="block-title">
+                        <i className="icon icon-bell far icon-fw me-12" />
+                        Data Release Announcements
+                    </h3>
+                </div>
+                <div className="card-body d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3">
+                    <div>
+                        <p className="mb-0">
+                            Receive an email when new SMaHT data is released.
+                        </p>
+                        {enrolled ? (
+                            <small className="text-secondary">
+                                Enrolled as {user.email}
+                            </small>
+                        ) : null}
+                    </div>
+                    <button
+                        type="button"
+                        className={
+                            enrolled
+                                ? 'btn btn-outline-danger flex-shrink-0'
+                                : 'btn btn-primary flex-shrink-0'
+                        }
+                        disabled={submitting}
+                        onClick={
+                            enrolled
+                                ? this.showUnenrollConfirmation
+                                : this.enroll
+                        }>
+                        {actionLabel}
+                    </button>
+                </div>
+                {this.renderModal()}
+            </div>
+        );
+    }
+}
+
 function AccessKeyTableContainer({ children, bodyClassName = 'card-body' }) {
     return (
         <div className="access-keys-container card mt-36">
@@ -505,6 +752,7 @@ export default class UserView extends React.Component {
             status: PropTypes.string,
             timezone: PropTypes.string,
             role: PropTypes.string,
+            data_release_notification_enrolled: PropTypes.bool,
         }),
         href: PropTypes.string.isRequired,
         schemas: PropTypes.shape({
@@ -523,6 +771,22 @@ export default class UserView extends React.Component {
         }),
     };
 
+    constructor(props) {
+        super(props);
+        _.bindAll(this, 'handleNotificationEnrollmentChange');
+    }
+
+    handleNotificationEnrollmentChange(enrolled) {
+        const { context: user } = this.props;
+        store.dispatch({
+            type: 'CONTEXT',
+            payload: {
+                ...user,
+                [DATA_RELEASE_NOTIFICATION_ENROLLED]: enrolled,
+            },
+        });
+    }
+
     mayEdit() {
         const { context } = this.props;
         return _.any((context && context.actions) || [], function (action) {
@@ -540,6 +804,13 @@ export default class UserView extends React.Component {
         } = this.props;
         const { email, project } = user;
         const mayEdit = this.mayEdit();
+        const currentUser = JWT.getUserDetails();
+        const isOwnProfile = Boolean(
+            currentUser &&
+                currentUser.email &&
+                email &&
+                currentUser.email.toLowerCase() === email.toLowerCase()
+        );
         // Todo: remove
         const ifCurrentlyEditingClass =
             this.state && this.state.currentlyEditing
@@ -631,6 +902,15 @@ export default class UserView extends React.Component {
                                 <ProfileWorkFields user={user} />
                             </div>
                         </div>
+
+                        {isOwnProfile ? (
+                            <DataReleaseNotificationEnrollment
+                                user={user}
+                                onChange={
+                                    this.handleNotificationEnrollmentChange
+                                }
+                            />
+                        ) : null}
 
                         <SyncedAccessKeyTable {...{ user }} />
                     </div>
@@ -811,7 +1091,7 @@ export function ImpersonateUserForm({ updateAppSessionState }) {
     );
 
     return (
-        <div className='user-profile-page bg-light'>
+        <div className="user-profile-page bg-light">
             <div id="content" className="container card mt-36 col-12 col-lg-6">
                 <div className="card-body mt-3">
                     {/* <h2 className="text-400 mt-5">Impersonate a User</h2> */}

--- a/src/encoded/static/components/item-pages/UserView.js
+++ b/src/encoded/static/components/item-pages/UserView.js
@@ -737,7 +737,7 @@ const AccessKeyTableRow = React.memo(function AccessKeyTableRow({
 
 export default class UserView extends React.Component {
     static onEditableFieldSave(nextContext) {
-        store.dispatch({ type: 'CONTEXT', payload: nextContext });
+        store.dispatch({ type: 'SET_CONTEXT', payload: nextContext });
     }
 
     static propTypes = {
@@ -779,7 +779,7 @@ export default class UserView extends React.Component {
     handleNotificationEnrollmentChange(enrolled) {
         const { context: user } = this.props;
         store.dispatch({
-            type: 'CONTEXT',
+            type: 'SET_CONTEXT',
             payload: {
                 ...user,
                 [DATA_RELEASE_NOTIFICATION_ENROLLED]: enrolled,

--- a/src/encoded/static/components/item-pages/components/DataReleaseNotificationEnrollment.js
+++ b/src/encoded/static/components/item-pages/components/DataReleaseNotificationEnrollment.js
@@ -1,0 +1,172 @@
+'use strict';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import PropTypes from 'prop-types';
+
+import { ajax } from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
+import { Alerts } from '@hms-dbmi-bgm/shared-portal-components/es/components/ui/Alerts';
+
+export const DATA_RELEASE_NOTIFICATION_ENROLLED =
+    'data_release_notification_enrolled';
+
+let notificationAvailabilityPromise = null;
+
+function getNotificationAvailability() {
+    if (!notificationAvailabilityPromise) {
+        notificationAvailabilityPromise = ajax
+            .promise('/health/data-release-notifications')
+            .catch((error) => {
+                notificationAvailabilityPromise = null;
+                throw error;
+            });
+    }
+    return notificationAvailabilityPromise;
+}
+
+/**
+ * Lets a signed-in user subscribe/unsubscribe their own email from the
+ * monthly data-release announcement list. Renders nothing until topic
+ * availability (`/health/data-release-notifications`) resolves truthy.
+ */
+export function DataReleaseNotificationEnrollment({ user, onChange }) {
+    const [available, setAvailable] = useState(null);
+    const [submitting, setSubmitting] = useState(false);
+
+    useEffect(() => {
+        let cancelled = false;
+        getNotificationAvailability().then(
+            (response) => {
+                if (!cancelled) {
+                    setAvailable(
+                        Boolean(response.data_release_notifications_available)
+                    );
+                }
+            },
+            () => {
+                if (!cancelled) {
+                    setAvailable(false);
+                }
+            }
+        );
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    const subscribe = useCallback(() => {
+        setSubmitting(true);
+        ajax.load(
+            '/register_notification',
+            () => {
+                onChange(true);
+                setSubmitting(false);
+                Alerts.queue({
+                    title: 'Confirm your subscription',
+                    message: `AWS has emailed a confirmation link to ${user.email}. You must follow it to start receiving data-release emails.`,
+                    style: 'success',
+                });
+            },
+            'POST',
+            () => {
+                setSubmitting(false);
+                Alerts.queue({
+                    title: 'Subscription failed',
+                    message:
+                        'We could not subscribe you to data-release emails. Please try again.',
+                    style: 'danger',
+                });
+            },
+            '{}'
+        );
+    }, [user.email, onChange]);
+
+    const unsubscribe = useCallback(() => {
+        setSubmitting(true);
+        ajax.load(
+            '/deregister_notification',
+            () => {
+                onChange(false);
+                setSubmitting(false);
+                Alerts.queue({
+                    title: 'Unsubscribed',
+                    message:
+                        'You will no longer receive data-release emails. You can subscribe again at any time.',
+                    style: 'success',
+                });
+            },
+            'POST',
+            () => {
+                setSubmitting(false);
+                Alerts.queue({
+                    title: 'Unsubscribe failed',
+                    message:
+                        'Your subscription was not changed. Please try again.',
+                    style: 'danger',
+                });
+            },
+            '{}'
+        );
+    }, [onChange]);
+
+    if (!available) {
+        return null;
+    }
+
+    const subscribed = Boolean(user[DATA_RELEASE_NOTIFICATION_ENROLLED]);
+    const rowCls =
+        'd-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3' +
+        (subscribed ? ' alert alert-success mb-0' : '');
+    let buttonLabel = subscribed ? 'Unsubscribe' : 'Subscribe';
+    if (submitting) {
+        buttonLabel = subscribed ? 'Unsubscribing…' : 'Subscribing…';
+    }
+
+    return (
+        <div className="card mt-36 data-release-notification-enrollment">
+            <div className="card-header">
+                <h3 className="">
+                    <i className="icon icon-fw icon-envelope fas me-12" />
+                    New Data Release - Email Sign Up
+                </h3>
+            </div>
+            <div className="card-body">
+                <div className={rowCls} role={subscribed ? 'alert' : undefined}>
+                    <p className="mb-0">
+                        {subscribed ? (
+                            <>
+                                You are currently subscribed to{' '}
+                                <strong>monthly</strong> emails about new data
+                                released on the SMaHT Data Portal.
+                            </>
+                        ) : (
+                            <>
+                                I would like to receive <strong>monthly</strong>{' '}
+                                emails to notify me about new data released on
+                                the SMaHT Data Portal.
+                            </>
+                        )}
+                    </p>
+                    <button
+                        type="button"
+                        className={`subscribe-button ${
+                            subscribed
+                                ? 'subscribed btn btn-outline-secondary'
+                                : 'btn btn-primary flex-shrink-0'
+                        }`}
+                        disabled={submitting}
+                        onClick={subscribed ? unsubscribe : subscribe}>
+                        {buttonLabel}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+DataReleaseNotificationEnrollment.propTypes = {
+    user: PropTypes.shape({
+        email: PropTypes.string.isRequired,
+        data_release_notification_enrolled: PropTypes.bool,
+    }).isRequired,
+    onChange: PropTypes.func.isRequired,
+};

--- a/src/encoded/static/scss/encoded/modules/_item-pages.scss
+++ b/src/encoded/static/scss/encoded/modules/_item-pages.scss
@@ -1306,7 +1306,7 @@ body[data-pathname^="/users/"] {
 						background-color: #ECFFF2;
 						border: 1px solid #99E199;
 					}
-					
+
 					.subscribe-button {
 						font-weight: 600;
 						border: 1px solid #0963BA;

--- a/src/encoded/static/scss/encoded/modules/_item-pages.scss
+++ b/src/encoded/static/scss/encoded/modules/_item-pages.scss
@@ -1289,6 +1289,35 @@ body[data-pathname^="/users/"] {
 
 			}
 
+			.data-release-notification-enrollment {
+				.card-header {
+					padding-left: 30px;
+					h3 {
+						font-size: 1.5rem;
+						font-weight: 400;
+					}
+				}
+				.card-body {
+					padding: 10px;
+					padding-left: 35px;
+
+					.alert-success {
+						padding-left: 10px;
+						background-color: #ECFFF2;
+						border: 1px solid #99E199;
+					}
+					
+					.subscribe-button {
+						font-weight: 600;
+						border: 1px solid #0963BA;
+
+						&.subscribed {
+							border-color: #DEE2E6;
+						}
+					}
+				}
+			}
+
 		}
 	}
 }

--- a/src/encoded/tests/test_notifications.py
+++ b/src/encoded/tests/test_notifications.py
@@ -2,7 +2,9 @@ from types import SimpleNamespace
 from unittest.mock import Mock, call
 
 import pytest
+import webtest
 from botocore.exceptions import ClientError
+from pyramid.config import Configurator
 from pyramid.httpexceptions import (
     HTTPBadGateway,
     HTTPServiceUnavailable,
@@ -387,3 +389,165 @@ def test_find_subscription_arn_follows_pagination():
         call(TopicArn=TOPIC_ARN),
         call(TopicArn=TOPIC_ARN, NextToken="page-two"),
     ]
+
+
+# Router-level tests: requests pass through a real Pyramid router so that
+# route registration, the ``effective_principals`` view predicates, and the
+# default snovault JSON renderer are exercised rather than mocked. AWS (SNS)
+# and the snovault ``update_item`` write path stay mocked, as in the unit
+# tests above, so no database or AWS access is required.
+
+
+def notification_router_app(monkeypatch, *, topic=TOPIC_ARN, userid=None, user=None):
+    monkeypatch.delenv("IDENTITY", raising=False)
+    settings = {}
+    if topic:
+        settings[notifications.SNS_TOPIC_REGISTRY_KEY] = topic
+    config = Configurator(settings=settings)
+    config.include("snovault.json_renderer")
+    config.include("encoded.notifications")
+    config.testing_securitypolicy(userid=userid)
+    config.registry[COLLECTIONS] = {
+        "user": {USER_UUID: user} if user is not None else {}
+    }
+    return webtest.TestApp(config.make_wsgi_app())
+
+
+def authenticated_router_app(monkeypatch, *, topic=TOPIC_ARN, enrolled=False):
+    user = FakeUser(enrolled=enrolled)
+    testapp = notification_router_app(
+        monkeypatch, topic=topic, userid=f"userid.{USER_UUID}", user=user
+    )
+    return testapp, user
+
+
+@pytest.mark.parametrize(
+    "route", ["/register_notification", "/deregister_notification"]
+)
+def test_router_notification_routes_not_found_without_authentication(
+    route, monkeypatch
+):
+    # The Authenticated requirement is an ``effective_principals`` view
+    # predicate rather than a permission, so an unauthenticated request does
+    # not match any view and yields 404 Not Found instead of 401.
+    testapp = notification_router_app(monkeypatch)
+
+    testapp.post_json(route, {}, status=404)
+
+
+@pytest.mark.parametrize(
+    "route", ["/register_notification", "/deregister_notification"]
+)
+def test_router_notification_routes_are_post_only(route, monkeypatch):
+    testapp, _ = authenticated_router_app(monkeypatch)
+
+    testapp.get(route, status=404)
+
+
+@pytest.mark.parametrize(
+    "route", ["/register_notification", "/deregister_notification"]
+)
+def test_router_notification_routes_reject_non_user_principal(route, monkeypatch):
+    testapp = notification_router_app(
+        monkeypatch, userid="mailto.someone@example.org"
+    )
+
+    testapp.post_json(route, {}, status=401)
+
+
+@pytest.mark.parametrize(
+    "route", ["/register_notification", "/deregister_notification"]
+)
+def test_router_notification_routes_reject_missing_topic(route, monkeypatch):
+    testapp, _ = authenticated_router_app(monkeypatch, topic=None)
+    boto_client = Mock()
+    monkeypatch.setattr(notifications, "boto_client", boto_client)
+
+    testapp.post_json(route, {}, status=503)
+
+    boto_client.assert_not_called()
+
+
+@pytest.mark.parametrize("topic,expected", [(None, False), (TOPIC_ARN, True)])
+def test_router_notification_availability(topic, expected, monkeypatch):
+    testapp = notification_router_app(monkeypatch, topic=topic)
+
+    response = testapp.get("/health/data-release-notifications", status=200)
+
+    assert response.content_type == "application/json"
+    assert response.json == {notifications.NOTIFICATION_AVAILABLE: expected}
+    assert "max-age=300" in response.headers["Cache-Control"]
+    assert "public" in response.headers["Cache-Control"]
+
+
+def test_router_register_notification_subscribes_and_updates_profile(monkeypatch):
+    testapp, user = authenticated_router_app(monkeypatch)
+    update_item = mock_profile_update(monkeypatch)
+    _, sns_client = mock_sns(monkeypatch)
+
+    response = testapp.post_json("/register_notification", {}, status=200)
+
+    assert response.content_type == "application/json"
+    assert response.json == {
+        "status": "success",
+        notifications.DATA_RELEASE_NOTIFICATION_ENROLLED: True,
+        "changed": True,
+    }
+    sns_client.subscribe.assert_called_once_with(
+        TopicArn=TOPIC_ARN,
+        Protocol="email",
+        Endpoint="user@example.org",
+        ReturnSubscriptionArn=True,
+    )
+    assert user.properties[notifications.DATA_RELEASE_NOTIFICATION_ENROLLED] is True
+    update_item.assert_called_once()
+
+    idempotent = testapp.post_json("/register_notification", {}, status=200)
+    assert idempotent.json["changed"] is False
+    sns_client.subscribe.assert_called_once()
+
+
+def test_router_deregister_notification_unsubscribes_and_updates_profile(
+    monkeypatch,
+):
+    testapp, user = authenticated_router_app(monkeypatch, enrolled=True)
+    update_item = mock_profile_update(monkeypatch)
+    _, sns_client = mock_sns(monkeypatch)
+    sns_client.list_subscriptions_by_topic.return_value = {
+        "Subscriptions": [
+            {
+                "Protocol": "email",
+                "Endpoint": "USER@EXAMPLE.ORG",
+                "SubscriptionArn": SUBSCRIPTION_ARN,
+            }
+        ]
+    }
+
+    response = testapp.post_json("/deregister_notification", {}, status=200)
+
+    assert response.content_type == "application/json"
+    assert response.json == {
+        "status": "success",
+        notifications.DATA_RELEASE_NOTIFICATION_ENROLLED: False,
+        "changed": True,
+    }
+    sns_client.unsubscribe.assert_called_once_with(
+        SubscriptionArn=SUBSCRIPTION_ARN
+    )
+    assert user.properties[notifications.DATA_RELEASE_NOTIFICATION_ENROLLED] is False
+    update_item.assert_called_once()
+
+
+def test_router_register_notification_aws_error_yields_bad_gateway(monkeypatch):
+    testapp, user = authenticated_router_app(monkeypatch)
+    update_item = mock_profile_update(monkeypatch)
+    _, sns_client = mock_sns(monkeypatch)
+    sns_client.subscribe.side_effect = ClientError(
+        {"Error": {"Code": "InternalError", "Message": "AWS failure"}},
+        "Subscribe",
+    )
+
+    testapp.post_json("/register_notification", {}, status=502)
+
+    assert user.properties[notifications.DATA_RELEASE_NOTIFICATION_ENROLLED] is False
+    update_item.assert_not_called()

--- a/src/encoded/tests/test_notifications.py
+++ b/src/encoded/tests/test_notifications.py
@@ -1,0 +1,389 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, call
+
+import pytest
+from botocore.exceptions import ClientError
+from pyramid.httpexceptions import (
+    HTTPBadGateway,
+    HTTPServiceUnavailable,
+    HTTPUnauthorized,
+    HTTPUnprocessableEntity,
+)
+from snovault import COLLECTIONS
+from snovault.schema_utils import load_schema
+
+from encoded import notifications
+
+
+TOPIC_ARN = "arn:aws:sns:us-east-1:123456789012:smaht-data-releases"
+SUBSCRIPTION_ARN = TOPIC_ARN + ":11111111-2222-3333-4444-555555555555"
+USER_UUID = "11111111-1111-4111-8111-111111111111"
+
+
+class FakeRegistry(dict):
+    def __init__(self, settings=None):
+        super().__init__()
+        self.settings = settings or {}
+
+
+class FakeUser:
+    def __init__(self, *, enrolled=False, email="User@Example.org"):
+        self.properties = {
+            "email": email,
+            notifications.DATA_RELEASE_NOTIFICATION_ENROLLED: enrolled,
+        }
+
+    def upgrade_properties(self):
+        return self.properties
+
+
+def fake_config(settings=None):
+    return SimpleNamespace(registry=FakeRegistry(settings))
+
+
+def fake_request(*, enrolled=False, email="User@Example.org", topic=TOPIC_ARN):
+    user = FakeUser(enrolled=enrolled, email=email)
+    registry = FakeRegistry()
+    if topic:
+        registry[notifications.SNS_TOPIC_REGISTRY_KEY] = topic
+    registry[COLLECTIONS] = {"user": {USER_UUID: user}}
+    request = SimpleNamespace(
+        effective_principals=["system.Authenticated", f"userid.{USER_UUID}"],
+        json={"email": "caller-supplied@example.org"},
+        registry=registry,
+        response=SimpleNamespace(
+            cache_control=SimpleNamespace(max_age=None, public=False)
+        ),
+    )
+    return request, user
+
+
+def mock_profile_update(monkeypatch):
+    update_item = Mock()
+
+    def apply_update(user, request, properties):
+        user.properties = properties
+
+    update_item.side_effect = apply_update
+    monkeypatch.setattr(notifications, "update_item", update_item)
+    return update_item
+
+
+def mock_sns(monkeypatch):
+    sns_client = Mock()
+    sns_client.subscribe.return_value = {
+        "SubscriptionArn": notifications.PENDING_CONFIRMATION
+    }
+    sns_client.list_subscriptions_by_topic.return_value = {"Subscriptions": []}
+    boto_client = Mock(return_value=sns_client)
+    monkeypatch.setattr(notifications, "boto_client", boto_client)
+    return boto_client, sns_client
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (TOPIC_ARN, True),
+        ("arn:aws-us-gov:sns:us-gov-west-1:123456789012:releases", True),
+        (None, False),
+        ("", False),
+        ("not-an-arn", False),
+        (TOPIC_ARN + ":subscription", False),
+        ("arn:aws:s3:us-east-1:123456789012:releases", False),
+        ("arn:aws:sns:us-east-1:not-an-account:releases", False),
+    ],
+)
+def test_is_sns_topic_arn(value, expected):
+    assert notifications.is_sns_topic_arn(value) is expected
+
+
+def test_includeme_registers_notification_routes(monkeypatch):
+    config = Mock()
+    monkeypatch.setattr(notifications, "configure_sns_topic", Mock())
+
+    notifications.includeme(config)
+
+    assert config.add_route.call_args_list == [
+        call(
+            "data-release-notification-availability",
+            "/health/data-release-notifications",
+        ),
+        call("register-notification", "/register_notification"),
+        call("deregister-notification", "/deregister_notification"),
+    ]
+    config.scan.assert_called_once_with(notifications.__name__)
+
+
+def test_user_profile_exposes_enrollment_flag():
+    from encoded.types.user import USER_PAGE_VIEW_ATTRIBUTES
+
+    enrollment_schema = load_schema("encoded:schemas/user.json")["properties"][
+        notifications.DATA_RELEASE_NOTIFICATION_ENROLLED
+    ]
+
+    assert enrollment_schema["type"] == "boolean"
+    assert enrollment_schema["default"] is False
+    assert (
+        notifications.DATA_RELEASE_NOTIFICATION_ENROLLED
+        in USER_PAGE_VIEW_ATTRIBUTES
+    )
+
+
+def test_configure_sns_topic_from_settings(monkeypatch):
+    monkeypatch.delenv("IDENTITY", raising=False)
+    config = fake_config({notifications.SNS_TOPIC_REGISTRY_KEY: TOPIC_ARN})
+
+    notifications.configure_sns_topic(config)
+
+    assert config.registry[notifications.SNS_TOPIC_REGISTRY_KEY] == TOPIC_ARN
+
+
+def test_configure_sns_topic_from_gac(monkeypatch):
+    monkeypatch.setenv("IDENTITY", "smaht/test-gac")
+    assume_identity = Mock(return_value={notifications.SNS_TOPIC_GAC_KEY: TOPIC_ARN})
+    monkeypatch.setattr(notifications, "assume_identity", assume_identity)
+    config = fake_config()
+
+    notifications.configure_sns_topic(config)
+
+    assume_identity.assert_called_once_with()
+    assert config.registry[notifications.SNS_TOPIC_REGISTRY_KEY] == TOPIC_ARN
+
+
+def test_configure_sns_topic_ignores_missing_or_invalid_gac_value(monkeypatch):
+    monkeypatch.setenv("IDENTITY", "smaht/test-gac")
+    assume_identity = Mock(
+        side_effect=[{}, {notifications.SNS_TOPIC_GAC_KEY: "not-an-arn"}]
+    )
+    monkeypatch.setattr(notifications, "assume_identity", assume_identity)
+
+    missing_config = fake_config()
+    notifications.configure_sns_topic(missing_config)
+    invalid_config = fake_config()
+    notifications.configure_sns_topic(invalid_config)
+
+    assert notifications.SNS_TOPIC_REGISTRY_KEY not in missing_config.registry
+    assert notifications.SNS_TOPIC_REGISTRY_KEY not in invalid_config.registry
+
+
+@pytest.mark.parametrize("topic,expected", [(None, False), (TOPIC_ARN, True)])
+def test_notification_availability_route(topic, expected):
+    request, _ = fake_request(topic=topic)
+
+    response = notifications.notification_availability(None, request)
+
+    assert response == {notifications.NOTIFICATION_AVAILABLE: expected}
+    assert request.response.cache_control.max_age == 300
+    assert request.response.cache_control.public is True
+
+
+@pytest.mark.parametrize(
+    "principals",
+    [[], ["system.Authenticated"], ["system.Authenticated", "userid.unknown"]],
+)
+def test_authenticated_user_rejects_missing_profile(principals):
+    request, _ = fake_request()
+    request.effective_principals = principals
+
+    with pytest.raises(HTTPUnauthorized):
+        notifications.authenticated_user(request)
+
+
+@pytest.mark.parametrize(
+    "view", [notifications.register_notification, notifications.deregister_notification]
+)
+def test_notification_routes_reject_missing_topic(view, monkeypatch):
+    request, _ = fake_request(topic=None)
+    boto_client = Mock()
+    monkeypatch.setattr(notifications, "boto_client", boto_client)
+
+    with pytest.raises(HTTPServiceUnavailable):
+        view(None, request)
+
+    boto_client.assert_not_called()
+
+
+def test_register_notification_requires_profile_email(monkeypatch):
+    request, _ = fake_request(email="  ")
+    boto_client = Mock()
+    monkeypatch.setattr(notifications, "boto_client", boto_client)
+
+    with pytest.raises(HTTPUnprocessableEntity):
+        notifications.register_notification(None, request)
+
+    boto_client.assert_not_called()
+
+
+def test_register_notification_subscribes_and_updates_profile(monkeypatch):
+    request, user = fake_request()
+    update_item = mock_profile_update(monkeypatch)
+    boto_client, sns_client = mock_sns(monkeypatch)
+
+    response = notifications.register_notification(None, request)
+
+    assert response == {
+        "status": "success",
+        notifications.DATA_RELEASE_NOTIFICATION_ENROLLED: True,
+        "changed": True,
+    }
+    boto_client.assert_called_once_with("sns")
+    sns_client.subscribe.assert_called_once_with(
+        TopicArn=TOPIC_ARN,
+        Protocol="email",
+        Endpoint="user@example.org",
+        ReturnSubscriptionArn=True,
+    )
+    assert user.properties[notifications.DATA_RELEASE_NOTIFICATION_ENROLLED] is True
+    update_item.assert_called_once_with(user, request, user.properties)
+
+    idempotent = notifications.register_notification(None, request)
+    assert idempotent["changed"] is False
+    sns_client.subscribe.assert_called_once()
+
+
+def test_register_notification_aws_error_preserves_profile(monkeypatch):
+    request, user = fake_request()
+    update_item = mock_profile_update(monkeypatch)
+    _, sns_client = mock_sns(monkeypatch)
+    sns_client.subscribe.side_effect = ClientError(
+        {"Error": {"Code": "InternalError", "Message": "AWS failure"}},
+        "Subscribe",
+    )
+
+    with pytest.raises(HTTPBadGateway) as error:
+        notifications.register_notification(None, request)
+
+    assert "AWS could not update" in error.value.title
+    assert user.properties[notifications.DATA_RELEASE_NOTIFICATION_ENROLLED] is False
+    update_item.assert_not_called()
+
+
+def test_deregister_notification_unsubscribes_and_updates_profile(monkeypatch):
+    request, user = fake_request(enrolled=True)
+    update_item = mock_profile_update(monkeypatch)
+    boto_client, sns_client = mock_sns(monkeypatch)
+    sns_client.list_subscriptions_by_topic.return_value = {
+        "Subscriptions": [
+            {
+                "Protocol": "email",
+                "Endpoint": "USER@EXAMPLE.ORG",
+                "SubscriptionArn": SUBSCRIPTION_ARN,
+            }
+        ]
+    }
+
+    response = notifications.deregister_notification(None, request)
+
+    assert response == {
+        "status": "success",
+        notifications.DATA_RELEASE_NOTIFICATION_ENROLLED: False,
+        "changed": True,
+    }
+    boto_client.assert_called_once_with("sns")
+    sns_client.list_subscriptions_by_topic.assert_called_once_with(
+        TopicArn=TOPIC_ARN
+    )
+    sns_client.unsubscribe.assert_called_once_with(SubscriptionArn=SUBSCRIPTION_ARN)
+    assert user.properties[notifications.DATA_RELEASE_NOTIFICATION_ENROLLED] is False
+    update_item.assert_called_once_with(user, request, user.properties)
+
+    boto_client.reset_mock()
+    idempotent = notifications.deregister_notification(None, request)
+    assert idempotent["changed"] is False
+    boto_client.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "subscriptions",
+    [
+        [],
+        [
+            {
+                "Protocol": "email",
+                "Endpoint": "someone-else@example.org",
+                "SubscriptionArn": SUBSCRIPTION_ARN,
+            }
+        ],
+        [
+            {
+                "Protocol": "email",
+                "Endpoint": "user@example.org",
+                "SubscriptionArn": notifications.PENDING_CONFIRMATION,
+            }
+        ],
+    ],
+)
+def test_deregister_notification_without_active_subscription_is_idempotent(
+    subscriptions, monkeypatch
+):
+    request, user = fake_request(enrolled=True)
+    mock_profile_update(monkeypatch)
+    _, sns_client = mock_sns(monkeypatch)
+    sns_client.list_subscriptions_by_topic.return_value = {
+        "Subscriptions": subscriptions
+    }
+
+    response = notifications.deregister_notification(None, request)
+
+    assert response[notifications.DATA_RELEASE_NOTIFICATION_ENROLLED] is False
+    sns_client.unsubscribe.assert_not_called()
+    assert user.properties[notifications.DATA_RELEASE_NOTIFICATION_ENROLLED] is False
+
+
+@pytest.mark.parametrize("failed_operation", ["list", "unsubscribe"])
+def test_deregister_notification_aws_error_preserves_profile(
+    failed_operation, monkeypatch
+):
+    request, user = fake_request(enrolled=True)
+    update_item = mock_profile_update(monkeypatch)
+    _, sns_client = mock_sns(monkeypatch)
+    error = ClientError(
+        {"Error": {"Code": "InternalError", "Message": "AWS failure"}},
+        "Unsubscribe",
+    )
+    if failed_operation == "list":
+        sns_client.list_subscriptions_by_topic.side_effect = error
+    else:
+        sns_client.list_subscriptions_by_topic.return_value = {
+            "Subscriptions": [
+                {
+                    "Protocol": "email",
+                    "Endpoint": "user@example.org",
+                    "SubscriptionArn": SUBSCRIPTION_ARN,
+                }
+            ]
+        }
+        sns_client.unsubscribe.side_effect = error
+
+    with pytest.raises(HTTPBadGateway) as raised_error:
+        notifications.deregister_notification(None, request)
+
+    assert "AWS could not update" in raised_error.value.title
+    assert user.properties[notifications.DATA_RELEASE_NOTIFICATION_ENROLLED] is True
+    update_item.assert_not_called()
+
+
+def test_find_subscription_arn_follows_pagination():
+    sns_client = Mock()
+    sns_client.list_subscriptions_by_topic.side_effect = [
+        {"Subscriptions": [], "NextToken": "page-two"},
+        {
+            "Subscriptions": [
+                {
+                    "Protocol": "email",
+                    "Endpoint": "USER@EXAMPLE.ORG",
+                    "SubscriptionArn": SUBSCRIPTION_ARN,
+                }
+            ]
+        },
+    ]
+
+    result = notifications.find_subscription_arn(
+        sns_client, TOPIC_ARN, "user@example.org"
+    )
+
+    assert result == SUBSCRIPTION_ARN
+    assert sns_client.list_subscriptions_by_topic.call_args_list == [
+        call(TopicArn=TOPIC_ARN),
+        call(TopicArn=TOPIC_ARN, NextToken="page-two"),
+    ]

--- a/src/encoded/tests/test_static.py
+++ b/src/encoded/tests/test_static.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import pytest
 
 from dcicutils.qa_checkers import ChangeLogChecker, DebuggingArtifactChecker
@@ -180,3 +181,88 @@ def test_data_matrix_tab_cache_signature_includes_request_shape():
     )
     assert "this.tabCache[this.state.matrixMode]" in data_matrix_source
     assert "this.tabCache[matrixMode]" in data_matrix_source
+
+
+STATIC_SOURCE_DIR = os.path.join(REPOSITORY_ROOT_DIR, "src/encoded/static")
+# Generated bundle/CSS output directories; only hand-written sources dispatch
+# store actions directly.
+STATIC_GENERATED_DIRS = {"build", "css"}
+STORE_DISPATCH_TYPE_PATTERN = re.compile(r"\.dispatch\(\s*\{\s*type:\s*'(\w+)'")
+
+
+def _store_handled_action_types(store_source):
+    return set(re.findall(r"case '(\w+)':", store_source))
+
+
+def _dispatched_action_types():
+    dispatched = []
+    for root, dirs, files in os.walk(STATIC_SOURCE_DIR):
+        dirs[:] = [
+            directory for directory in dirs
+            if directory not in STATIC_GENERATED_DIRS
+        ]
+        for file_name in files:
+            if not file_name.endswith((".js", ".jsx")):
+                continue
+            file_path = os.path.join(root, file_name)
+            with open(file_path) as source_file:
+                source = source_file.read()
+            for action_type in STORE_DISPATCH_TYPE_PATTERN.findall(source):
+                dispatched.append(
+                    (os.path.relpath(file_path, REPOSITORY_ROOT_DIR), action_type)
+                )
+    return dispatched
+
+
+@pytest.mark.static
+def test_store_dispatch_action_types_are_handled_by_reducers():
+    """Every action type literal dispatched to the Redux store must be handled
+    by a reducer in store.js. An unhandled type falls through to each reducer's
+    `default` case and is a silent no-op (regression: UserView dispatched
+    'CONTEXT' while the context reducer only handles 'SET_CONTEXT', so profile
+    edits and notification-enrollment changes never re-rendered).
+    """
+    with open(os.path.join(STATIC_SOURCE_DIR, "store.js")) as store_file:
+        store_source = store_file.read()
+    handled_action_types = _store_handled_action_types(store_source)
+    assert "SET_CONTEXT" in handled_action_types
+    assert "BATCH_ACTIONS" in handled_action_types
+
+    dispatched_action_types = _dispatched_action_types()
+    assert dispatched_action_types, (
+        "Expected store.dispatch() call sites in the frontend sources; the"
+        " dispatch pattern in this test is likely stale."
+    )
+    unhandled = [
+        (file_path, action_type)
+        for file_path, action_type in dispatched_action_types
+        if action_type not in handled_action_types
+    ]
+    assert unhandled == [], (
+        "Dispatched Redux action types not handled by any store.js reducer"
+        f" (silent no-ops): {unhandled}"
+    )
+
+
+@pytest.mark.static
+def test_user_view_notification_enrollment_updates_store_context():
+    """The enrollment success callback must dispatch SET_CONTEXT with the user
+    context and updated enrollment flag so the profile page re-renders without
+    a reload.
+    """
+    user_view_path = os.path.join(
+        STATIC_SOURCE_DIR, "components/item-pages/UserView.js"
+    )
+    with open(user_view_path) as user_view_file:
+        user_view_source = user_view_file.read()
+
+    handler_start = user_view_source.index(
+        "handleNotificationEnrollmentChange(enrolled) {"
+    )
+    handler_end = user_view_source.index("mayEdit() {", handler_start)
+    handler_source = user_view_source[handler_start:handler_end]
+
+    dispatched_types = STORE_DISPATCH_TYPE_PATTERN.findall(handler_source)
+    assert dispatched_types == ["SET_CONTEXT"]
+    assert "...user" in handler_source
+    assert "[DATA_RELEASE_NOTIFICATION_ENROLLED]: enrolled" in handler_source

--- a/src/encoded/types/user.py
+++ b/src/encoded/types/user.py
@@ -78,7 +78,7 @@ class User(Item, SnovaultUser):
 
 
 USER_PAGE_VIEW_ATTRIBUTES = ['@id', '@type', 'uuid', 'title', 'display_title', 'email', 'consortia',
-                             'submission_centers']
+                             'submission_centers', 'data_release_notification_enrolled']
 
 
 @view_config(context=User, permission='view', request_method='GET', name='page')


### PR DESCRIPTION
## Intent

Add support for users to opt into data-release email notifications from their user profile page (Trello 882). The change spans backend, schema, and frontend:

- Backend: new src/encoded/notifications.py registers Pyramid routes /register_notification, /deregister_notification, and a GET /health/data-release-notifications availability endpoint. Enrollment works by subscribing/unsubscribing the authenticated user's own email to/from an AWS SNS topic. The SNS topic ARN is optional config, read from the GAC identity (SNS_TOPIC) or registry (sns_topic); when absent the feature is simply unavailable (503), so environments without a topic degrade gracefully. The availability endpoint deliberately does NOT make an AWS call — it only reports whether a topic is configured, and is cacheable. Auth deliberately always acts on the authenticated user's own profile/email (never a caller-supplied profile) as a security measure. notifications.includeme is wired into include_encoded in src/encoded/__init__.py.
- Schema: adds boolean user property data_release_notification_enrolled (default false) in src/encoded/schemas/user.json, tracking whether the user requested enrollment; added to USER_PAGE_VIEW_ATTRIBUTES in src/encoded/types/user.py so the user page view exposes it.
- Frontend: new React component DataReleaseNotificationEnrollment.js integrated into UserView.js, with SCSS in _item-pages.scss. It dispatches SET_CONTEXT so enrollment changes re-render immediately.
- Tests: src/encoded/tests/test_notifications.py covers the views with SNS mocked (no real AWS); src/encoded/tests/test_static.py adds source-contract checks for the frontend (this repo has no Jest harness — frontend invariants are covered by static pytest checks, as corrected in AGENTS.md).
- Version bump + CHANGELOG entry.

Validate exactly the current contents of existing PR 725; preserve the intended email-notification subscription behavior and all current main-branch content. Do not open a duplicate PR or revive prior attempts. All AWS/SNS interaction must stay mocked in tests — no real external side effects.

## What Changed

- Add `src/encoded/notifications.py` (wired into `include_encoded`) exposing `/register_notification`, `/deregister_notification`, and a cacheable `GET /health/data-release-notifications` endpoint; enrollment subscribes/unsubscribes the authenticated user's own email to an AWS SNS topic, with the topic ARN read from the GAC identity (`SNS_TOPIC`) or registry (`sns_topic`) and the feature returning 503 when no topic is configured.
- Add the boolean `data_release_notification_enrolled` user property (default `false`) in `src/encoded/schemas/user.json` and expose it via `USER_PAGE_VIEW_ATTRIBUTES` in `src/encoded/types/user.py`; add the `DataReleaseNotificationEnrollment.js` React component (integrated into `UserView.js`, styled in `_item-pages.scss`) that dispatches `SET_CONTEXT` so enrollment changes re-render immediately.
- Add `test_notifications.py` covering the views with SNS mocked and source-contract checks in `test_static.py`; bump the version and add a CHANGELOG entry, and correct the AGENTS.md note that frontend invariants are covered by static pytest checks rather than a Jest harness.

## Risk Assessment

✅ Low: The only new change is a one-line documentation fix correcting the CHANGELOG PR reference from #716 to #725 (number and URL), applied exactly as instructed; the rest of the well-tested, security-conscious feature is unchanged from the prior clean review.

## Testing

test

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `CHANGELOG.rst` - merge conflict rebasing onto origin/main
- ⚠️ `pyproject.toml` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `CHANGELOG.rst:14` - The new 2.4.5 CHANGELOG entry references `PR #716`, but the PR under review is #725 (per the authoritative intent and the repo&#39;s open-PR list; #716 is not open). #716 appears to be a stale reference to a superseded/prior attempt. ChangeLogChecker only validates the version line, not the PR number, so tests will not catch this. Update the reference (and URL) to #725 or the correct PR.
- ℹ️ `src/encoded/notifications.py:216` - If a user subscribes and then deregisters before confirming, deregister correctly treats the pending (PendingConfirmation) subscription as no active delivery and sets the flag to false, but the AWS confirmation email link remains valid. Clicking that old link later re-confirms the subscription while the portal shows the user as unsubscribed. This is inherent to SNS email double opt-in (a pending subscription has no ARN and cannot be unsubscribed via API), so there is no clean code fix; noting for awareness. The code comment acknowledges the idempotency but not the still-live link.

🔧 Fix: docs: correct CHANGELOG PR reference from #716 to #725
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `a`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
