### PR TITLE
fix(cypress): harden post-deploy suite against live-data volatility and login timing

### DIFF
--- a/deploy/post_deploy_testing/cypress/e2e/03b_browse_by_donor.cy.js
+++ b/deploy/post_deploy_testing/cypress/e2e/03b_browse_by_donor.cy.js
@@ -5,7 +5,12 @@ import {
     dataNavBarItemSelectorStr,
     navUserAcctLoginBtnSelector,
 } from '../support/selectorVars';
-import { parseIntSafe, reconcileApiTotalWithUiCount } from '../support/utils/dataMatrixUtils';
+import {
+    parseIntSafe,
+    parsePositiveIntegerCount,
+    reconcileApiTotalWithUiCount,
+    toBarIdentity,
+} from '../support/utils/dataMatrixUtils';
 
 
 /* ----------------------------- ROLE MATRIX -----------------------------
@@ -510,11 +515,13 @@ function getRenderedBarParts() {
                 .find('.bar-part[data-term]')
                 .each((__, barPartEl) => {
                     const sequencer = barPartEl.getAttribute('data-term');
-                    const dataCount = parseInt(barPartEl.getAttribute('data-count'), 10);
-                    if (Number.isFinite(dataCount) && dataCount > 0) {
+                    const dataCount = Number(barPartEl.getAttribute('data-count'));
+                    if (Number.isInteger(dataCount) && dataCount > 0) {
                         const key = JSON.stringify([tissueTerm, sequencer]);
                         if (!barPartsByKey.has(key)) {
-                            barPartsByKey.set(key, { tissueTerm, sequencer, dataCount });
+                            // Sampling retains identity only. The count is live
+                            // render state and must be re-read at execution.
+                            barPartsByKey.set(key, toBarIdentity({ tissueTerm, sequencer }));
                         }
                     }
                 });
@@ -693,18 +700,17 @@ function stepFacetChartBarPlotTests(caps) {
                     'Should be able to select a bar-part sample from the rendered chart'
                 ).to.be.greaterThan(0);
 
-                sample.forEach(({ tissueTerm, sequencer, dataCount }) => {
+                sample.forEach(({ tissueTerm, sequencer }) => {
                     cy.log(`Testing bar part: Tissue = ${tissueTerm}, Sequencer = ${sequencer}`);
 
                     cy.window().scrollTo(0, 0).end()
                         .then(() => getRenderedBarPart(tissueTerm, sequencer))
                         .then(($barPart) => {
                             assertTissueAxisLabel([tissueTerm], tissueTerm);
-                            const expectedFilteredResults = parseInt($barPart.attr('data-count'), 10);
-                            expect(
-                                expectedFilteredResults,
-                                'Bar data-count should match the value discovered from the chart'
-                            ).to.equal(dataCount);
+                            const expectedFilteredResults = parsePositiveIntegerCount(
+                                $barPart.attr('data-count'),
+                                `Current bar data-count for ${tissueTerm} x ${sequencer}`
+                            );
                             const acceptedVariants = getTissueVariants([tissueTerm]);
                             cy.window().scrollTo('top').end()
                                 .wrap($barPart).hoverIn().end()

--- a/deploy/post_deploy_testing/cypress/e2e/03b_browse_by_donor.cy.js
+++ b/deploy/post_deploy_testing/cypress/e2e/03b_browse_by_donor.cy.js
@@ -5,7 +5,7 @@ import {
     dataNavBarItemSelectorStr,
     navUserAcctLoginBtnSelector,
 } from '../support/selectorVars';
-import { getApiTotalFromUrl, parseIntSafe } from '../support/utils/dataMatrixUtils';
+import { parseIntSafe, reconcileApiTotalWithUiCount } from '../support/utils/dataMatrixUtils';
 
 
 /* ----------------------------- ROLE MATRIX -----------------------------
@@ -211,6 +211,27 @@ function checkChartTotal(title, expectedTotal) {
         });
 }
 
+// Compares a value read from the UI against an expected number that itself
+// came from a different UI read moments earlier. Both numbers describe the
+// same underlying live dataset, so persistent disagreement is a real
+// diagnostic - but a single mismatch may just be one read catching mid-render
+// or mid-filter state, so re-read once before failing with both values
+// attached.
+function assertCountEventuallyEquals(readActualCount, expectedCount, message) {
+    return readActualCount().then((actual) => {
+        if (actual === expectedCount) return actual;
+        return cy.wait(1000)
+            .then(() => readActualCount())
+            .then((reread) => {
+                expect(
+                    reread,
+                    `${message} (persisted after re-read; first read was ${actual}, expected ${expectedCount})`
+                ).to.equal(expectedCount);
+                return reread;
+            });
+    });
+}
+
 function loginIfNeeded(roleKey) {
     const caps = ROLE_MATRIX[roleKey];
     if (caps.isAuthenticated) cy.loginSMaHT(roleKey).end();
@@ -351,6 +372,10 @@ function stepSidebarToggle(caps) {
         .end();
 }
 
+// Tissue x sequencer combinations of particular interest. These are used as a
+// *preference* when sampling bars to test (see selectBarPartSample) - never a
+// hard requirement, since whether a given pair currently has any files is a
+// live-data fact that changes independently of this test suite.
 const tissueSequencerPairs = [
     {
         tissueTerms: [
@@ -360,20 +385,14 @@ const tissueSequencerPairs = [
             'Brain',
         ],
         sequencer: 'Illumina NovaSeq X Plus',
-        min: 3,
-        max: 25,
     },
     {
         tissueTerms: ['3A - Whole Blood', 'Whole Blood', 'Blood'],
         sequencer: 'ONT PromethION 24',
-        min: 2,
-        max: 25,
     },
     {
         tissueTerms: ['3I - Liver', 'Liver'],
         sequencer: 'PacBio Revio',
-        min: 2,
-        max: 25,
     },
 ];
 
@@ -469,63 +488,53 @@ function assertTextMatchesAnyVariant(actualText, acceptedVariants, message) {
     ).to.equal(true);
 }
 
-function getExistingTissueBarPart(tissueTerms, sequencer) {
-    const tissueVariants = getTissueVariants(tissueTerms);
-    const tpcCodes = tissueTerms
-        .map((tissueTerm) => /^([A-Z0-9]+)\s+-/.exec(tissueTerm)?.[1] || null)
-        .filter(Boolean);
-
+// Discover every tissue x sequencer bar-part that is actually rendered in the
+// current chart (data-driven; the chart contents change with live data), so
+// tests never depend on a specific pair being present.
+function getRenderedBarParts() {
     return cy.get('body').then(($body) => {
-        let resolvedTissueTerm = tissueVariants.find((tissueTerm) => {
-            return $body.find(
-                `.bar-plot-chart .chart-bar[data-term="${tissueTerm}"] .bar-part[data-term="${sequencer}"]`
-            ).length > 0;
+        const barParts = [];
+
+        $body.find('.bar-plot-chart .chart-bar[data-term]').each((_, chartBar) => {
+            const tissueTerm = chartBar.getAttribute('data-term');
+
+            Cypress.$(chartBar)
+                .find('.bar-part[data-term]')
+                .each((__, barPartEl) => {
+                    const sequencer = barPartEl.getAttribute('data-term');
+                    const dataCount = parseInt(barPartEl.getAttribute('data-count'), 10);
+                    if (Number.isFinite(dataCount) && dataCount > 0) {
+                        barParts.push({ tissueTerm, sequencer, dataCount });
+                    }
+                });
         });
 
-        if (!resolvedTissueTerm) {
-            const rotatedLabels = Array.from($body.find('.bar-plot-chart .rotated-label[data-term]'));
-            const matchingLabel = rotatedLabels.find((labelNode) => {
-                const dataTerm = (labelNode.getAttribute('data-term') || '').trim();
-                const title = (labelNode.getAttribute('title') || '').trim();
-                const innerText = (labelNode.textContent || '').replace(/\s+/g, ' ').trim();
-
-                const matchesKnownVariant =
-                    tissueVariants.includes(dataTerm) ||
-                    tissueVariants.includes(title) ||
-                    tissueVariants.includes(innerText);
-
-                const matchesTpcCode = tpcCodes.some((tpcCode) => {
-                    return dataTerm.startsWith(`${tpcCode} -`) || title.startsWith(`${tpcCode} -`);
-                });
-
-                return matchesKnownVariant || matchesTpcCode;
-            });
-
-            resolvedTissueTerm = matchingLabel?.getAttribute('data-term')?.trim();
-        }
-
-        if (!resolvedTissueTerm && tpcCodes.length > 0) {
-            const matchingChartBar = Array.from($body.find('.bar-plot-chart .chart-bar')).find((chartBar) => {
-                const dataTerm = chartBar.getAttribute('data-term') || '';
-                const hasMatchingCode = tpcCodes.some((tpcCode) => dataTerm.startsWith(`${tpcCode} -`));
-                const hasSequencer = chartBar.querySelector(`.bar-part[data-term="${sequencer}"]`);
-                return hasMatchingCode && hasSequencer;
-            });
-
-            resolvedTissueTerm = matchingChartBar?.getAttribute('data-term');
-        }
-
-        expect(
-            resolvedTissueTerm,
-            `Expected one tissue term for ${sequencer} to exist: ${tissueVariants.join(', ')}`
-        ).to.be.a('string');
-
-        return cy
-            .get(
-                `.bar-plot-chart .chart-bar[data-term="${resolvedTissueTerm}"] .bar-part[data-term="${sequencer}"]`
-            )
-            .then(($barPart) => ({ $barPart, resolvedTissueTerm }));
+        return barParts;
     });
+}
+
+// Build a small, deterministic sample of bar-parts to exercise. Known
+// tissue/sequencer combinations of particular interest are preferred *if
+// currently rendered*, but are never required - if none of them are present
+// in the live chart, the sample falls back to whatever bars do exist so
+// coverage doesn't drop to zero just because production data shifted.
+function selectBarPartSample(renderedBarParts, sampleSize = 3) {
+    const preferred = [];
+
+    tissueSequencerPairs.forEach(({ tissueTerms, sequencer }) => {
+        const variants = getTissueVariants(tissueTerms);
+        const match = renderedBarParts.find(
+            (part) => part.sequencer === sequencer && variants.includes(part.tissueTerm)
+        );
+        if (match) preferred.push(match);
+    });
+
+    const preferredKeys = new Set(preferred.map((part) => `${part.tissueTerm} ${part.sequencer}`));
+    const remaining = renderedBarParts
+        .filter((part) => !preferredKeys.has(`${part.tissueTerm} ${part.sequencer}`))
+        .sort((a, b) => (a.tissueTerm + a.sequencer).localeCompare(b.tissueTerm + b.sequencer));
+
+    return [...preferred, ...remaining].slice(0, sampleSize);
 }
 
 function assertTissueAxisLabel(tissueTerms, resolvedTissueTerm) {
@@ -634,78 +643,100 @@ function stepFacetChartBarPlotTests(caps) {
                 .should('contain', 'Tissue')
                 .end();
 
-            tissueSequencerPairs.forEach(({ tissueTerms, sequencer, min, max }) => {
-                cy.log(`Testing bar part: Tissue = ${tissueTerms.join(' | ')}, Sequencer = ${sequencer}`);
+            getRenderedBarParts().then((renderedBarParts) => {
+                expect(
+                    renderedBarParts.length,
+                    'Facet chart should render at least one tissue x sequencer bar with files'
+                ).to.be.greaterThan(0);
 
-                cy.window().scrollTo(0, 0).end()
-                    .then(() => getExistingTissueBarPart(tissueTerms, sequencer))
-                    .then(({ $barPart, resolvedTissueTerm }) => {
-                        assertTissueAxisLabel(tissueTerms, resolvedTissueTerm);
-                        const expectedFilteredResults = parseInt($barPart.attr('data-count'));
-                        expect(expectedFilteredResults).to.be.gte(min);
-                        expect(expectedFilteredResults).to.be.lt(max);
-                        const acceptedVariants = getTissueVariants(tissueTerms);
-                        cy.window().scrollTo('top').end()
-                            .wrap($barPart).hoverIn().end()
-                            .get('.cursor-component-root .details-title').should('contain', sequencer).end()
-                            .get('.cursor-component-root .detail-crumbs .crumb').invoke('text').then((crumbText) => {
-                                const normalizedCrumbText = crumbText.replace(/\s+/g, ' ').trim();
-                                const matchesVariant = acceptedVariants.some((variant) => {
-                                    return normalizedCrumbText.includes(variant);
+                const sample = selectBarPartSample(renderedBarParts, 3);
+                expect(
+                    sample.length,
+                    'Should be able to select a bar-part sample from the rendered chart'
+                ).to.be.greaterThan(0);
+
+                sample.forEach(({ tissueTerm, sequencer, dataCount }) => {
+                    cy.log(`Testing bar part: Tissue = ${tissueTerm}, Sequencer = ${sequencer}`);
+
+                    cy.window().scrollTo(0, 0).end()
+                        .get(`.bar-plot-chart .chart-bar[data-term="${tissueTerm}"] .bar-part[data-term="${sequencer}"]`)
+                        .then(($barPart) => {
+                            assertTissueAxisLabel([tissueTerm], tissueTerm);
+                            const expectedFilteredResults = parseInt($barPart.attr('data-count'), 10);
+                            expect(
+                                expectedFilteredResults,
+                                'Bar data-count should match the value discovered from the chart'
+                            ).to.equal(dataCount);
+                            const acceptedVariants = getTissueVariants([tissueTerm]);
+                            cy.window().scrollTo('top').end()
+                                .wrap($barPart).hoverIn().end()
+                                .get('.cursor-component-root .details-title').should('contain', sequencer).end()
+                                .get('.cursor-component-root .detail-crumbs .crumb').invoke('text').then((crumbText) => {
+                                    const normalizedCrumbText = crumbText.replace(/\s+/g, ' ').trim();
+                                    const matchesVariant = acceptedVariants.some((variant) => {
+                                        return normalizedCrumbText.includes(variant);
+                                    });
+                                    expect(
+                                        matchesVariant,
+                                        `Popover tissue crumb should reference the clicked tissue (${tissueTerm}) for ${sequencer}`
+                                    ).to.equal(true);
+                                }).end()
+                                .get('.cursor-component-root .details-title .primary-count').invoke('text').then((text) => {
+                                    const number = parseInt(text, 10);
+                                    expect(number).to.eq(expectedFilteredResults);
+                                })
+                                // file count – retry until text is numeric and equals expected
+                                .get('.cursor-component-root .details a') // Adjust selector if needed
+                                .should('contain.text', 'Files') // Ensure the correct link
+                                .then(($a) => {
+                                    const text = $a.text();      // e.g. "39 Files"
+                                    const href = $a.attr('href');
+                                    const fullUrl = href.startsWith('http')
+                                        ? href
+                                        : `${Cypress.config('baseUrl')}${href}`;
+
+                                    // Extract number before "Files"
+                                    const uiCount = parseIntSafe(text);
+
+                                    // Reconcile API total with UI count, tolerating one round
+                                    // of transient data churn before failing with diagnostics.
+                                    return reconcileApiTotalWithUiCount(fullUrl, uiCount, {
+                                        context: `Bar-part Files link (${tissueTerm} x ${sequencer})`,
+                                    });
                                 });
-                                expect(
-                                    matchesVariant,
-                                    `Popover tissue crumb should contain one accepted variant for ${sequencer}`
-                                ).to.equal(true);
+                            // `{ force: true }` is used a bunch here to prevent Cypress from attempting to scroll browser up/down during the test -- which may interfere w. mouse hover events.
+                            // See https://github.com/cypress-io/cypress/issues/2353#issuecomment-413347535
+                            cy.window().then((w) => {
+                                w.scrollTo(0, 0);
                             }).end()
-                            .get('.cursor-component-root .details-title .primary-count').invoke('text').then((text) => {
-                                const number = parseInt(text, 10);
-                                expect(number).to.eq(expectedFilteredResults);
-                            })
-                            // file count – retry until text is numeric and equals expected
-                            .get('.cursor-component-root .details a') // Adjust selector if needed
-                            .should('contain.text', 'Files') // Ensure the correct link
-                            .then(($a) => {
-                                const text = $a.text();      // e.g. "39 Files"
-                                const href = $a.attr('href');
-                                const fullUrl = href.startsWith('http')
-                                    ? href
-                                    : `${Cypress.config('baseUrl')}${href}`;
+                                .wrap($barPart, { force: true }).scrollToCenterElement().trigger('mouseover', { force: true }).trigger('mousemove', { force: true }).wait(300).click({ force: true }).end()
+                                .get('.cursor-component-root .actions.buttons-container .btn-primary').should('contain', "Explore").click({ force: true }).end() // Browser will scroll after click itself (e.g. triggered by app)
+                                .location('search')
+                                .should('include', 'external_id=')
+                                .get('#slow-load-container').should('not.have.class', 'visible')
+                                .then(() => {
+                                    // Both counts describe the same filtered dataset;
+                                    // resync with a re-read before failing (Cluster C).
+                                    return assertCountEventuallyEquals(
+                                        () => cy.searchPageTotalResultCount(),
+                                        expectedFilteredResults,
+                                        `Filtered search results count should reconcile with bar count (${expectedFilteredResults}) for ${tissueTerm} x ${sequencer}`
+                                    );
+                                })
+                                .getQuickInfoBar().then((info) => {
+                                    cy
+                                        .get('.properties-controls button[data-tip="Clear all filters"]')
+                                        .click({ force: true })
+                                        .get(".facet[data-field=\"external_id\"] .facet-list-element.selected .facet-item").should('not.exist').end();
 
-                                // Extract number before "Files"
-                                const uiCount = parseIntSafe(text);
-
-                                // Compare UI count with API total
-                                getApiTotalFromUrl(fullUrl).then((apiTotal) => {
-                                    expect(apiTotal, `API total (${apiTotal}) should match UI count (${uiCount})`)
-                                        .to.equal(uiCount);
+                                    assertCountEventuallyEquals(
+                                        () => cy.get("div.above-facets-table-row #results-count").invoke("text").then((t) => parseInt(t, 10)),
+                                        info.donor,
+                                        `Cleared-filters results count should reconcile with donor count from QuickInfoBar (${info.donor})`
+                                    ).wait(500); // wait to ensure chart animation completes before next iteration
                                 });
-                            });
-                        // `{ force: true }` is used a bunch here to prevent Cypress from attempting to scroll browser up/down during the test -- which may interfere w. mouse hover events.
-                        // See https://github.com/cypress-io/cypress/issues/2353#issuecomment-413347535
-                        cy.window().then((w) => {
-                            w.scrollTo(0, 0);
-                        }).end()
-                            .wrap($barPart, { force: true }).scrollToCenterElement().trigger('mouseover', { force: true }).trigger('mousemove', { force: true }).wait(300).click({ force: true }).end()
-                            .get('.cursor-component-root .actions.buttons-container .btn-primary').should('contain', "Explore").click({ force: true }).end() // Browser will scroll after click itself (e.g. triggered by app)
-                            .location('search')
-                            .should('include', 'external_id=')
-                            .get('#slow-load-container').should('not.have.class', 'visible')
-                            .searchPageTotalResultCount().then((totalCount) => {
-                                expect(totalCount).to.equal(expectedFilteredResults);
-                            })
-                            .getQuickInfoBar().then((info) => {
-                                cy
-                                    .get('.properties-controls button[data-tip="Clear all filters"]')
-                                    .click({ force: true })
-                                    .get(".facet[data-field=\"external_id\"] .facet-list-element.selected .facet-item").should('not.exist').end()
-                                    .get("div.above-facets-table-row #results-count")
-                                    .invoke("text")
-                                    .then((count) => {
-                                        expect(info.donor).to.equal(parseInt(count));
-                                    }).wait(500); // wait to ensure chart animation completes before next iteration
-                            });
-                    });
+                        });
+                });
             });
         });
     } else {
@@ -907,12 +938,8 @@ function stepSearchTableRowsTests(caps) {
                         expect(uiCount, `Row ${rowIndex}: Files count must be > 0`).to.be.greaterThan(0);
                         expect(href, `Row ${rowIndex}: Files href must exist`).to.be.a('string').and.not.be.empty;
 
-                        getApiTotalFromUrl(href).then((apiCount) => {
-                            expect(
-                                apiCount,
-                                `Row ${rowIndex}: Could not determine file count from API response`
-                            ).to.be.a('number');
-                            expect(apiCount, `Row ${rowIndex}: API file count must match UI`).to.equal(uiCount);
+                        reconcileApiTotalWithUiCount(href, uiCount, {
+                            context: `Row ${rowIndex}: search-table Files link`,
                         });
                     });
 

--- a/deploy/post_deploy_testing/cypress/e2e/03b_browse_by_donor.cy.js
+++ b/deploy/post_deploy_testing/cypress/e2e/03b_browse_by_donor.cy.js
@@ -217,19 +217,27 @@ function checkChartTotal(title, expectedTotal) {
 // diagnostic - but a single mismatch may just be one read catching mid-render
 // or mid-filter state, so re-read once before failing with both values
 // attached.
-function assertCountEventuallyEquals(readActualCount, expectedCount, message) {
-    return readActualCount().then((actual) => {
-        if (actual === expectedCount) return actual;
-        return cy.wait(1000)
-            .then(() => readActualCount())
-            .then((reread) => {
-                expect(
-                    reread,
-                    `${message} (persisted after re-read; first read was ${actual}, expected ${expectedCount})`
-                ).to.equal(expectedCount);
-                return reread;
-            });
-    });
+function assertCountsEventuallyEqual(readActualCount, readExpectedCount, message, retries = 1) {
+    let firstMismatch = null;
+
+    function attempt(remaining) {
+        return readActualCount().then((actual) =>
+            readExpectedCount().then((expected) => {
+                if (actual === expected) return actual;
+                if (!firstMismatch) firstMismatch = { actual, expected };
+                if (remaining > 0) {
+                    return cy.wait(1000).then(() => attempt(remaining - 1));
+                }
+                throw new Error(
+                    `${message} persisted after re-read; ` +
+                    `first actual/expected: ${firstMismatch.actual}/${firstMismatch.expected}, ` +
+                    `final actual/expected: ${actual}/${expected}`
+                );
+            })
+        );
+    }
+
+    return attempt(retries);
 }
 
 function loginIfNeeded(roleKey) {
@@ -493,7 +501,7 @@ function assertTextMatchesAnyVariant(actualText, acceptedVariants, message) {
 // tests never depend on a specific pair being present.
 function getRenderedBarParts() {
     return cy.get('body').then(($body) => {
-        const barParts = [];
+        const barPartsByKey = new Map();
 
         $body.find('.bar-plot-chart .chart-bar[data-term]').each((_, chartBar) => {
             const tissueTerm = chartBar.getAttribute('data-term');
@@ -504,12 +512,15 @@ function getRenderedBarParts() {
                     const sequencer = barPartEl.getAttribute('data-term');
                     const dataCount = parseInt(barPartEl.getAttribute('data-count'), 10);
                     if (Number.isFinite(dataCount) && dataCount > 0) {
-                        barParts.push({ tissueTerm, sequencer, dataCount });
+                        const key = JSON.stringify([tissueTerm, sequencer]);
+                        if (!barPartsByKey.has(key)) {
+                            barPartsByKey.set(key, { tissueTerm, sequencer, dataCount });
+                        }
                     }
                 });
         });
 
-        return barParts;
+        return [...barPartsByKey.values()];
     });
 }
 
@@ -529,20 +540,47 @@ function selectBarPartSample(renderedBarParts, sampleSize = 3) {
         if (match) preferred.push(match);
     });
 
-    const preferredKeys = new Set(preferred.map((part) => `${part.tissueTerm} ${part.sequencer}`));
+    const uniquePreferred = [...new Map(
+        preferred.map((part) => [JSON.stringify([part.tissueTerm, part.sequencer]), part])
+    ).values()];
+    const preferredKeys = new Set(
+        uniquePreferred.map((part) => JSON.stringify([part.tissueTerm, part.sequencer]))
+    );
     const remaining = renderedBarParts
-        .filter((part) => !preferredKeys.has(`${part.tissueTerm} ${part.sequencer}`))
+        .filter((part) => !preferredKeys.has(JSON.stringify([part.tissueTerm, part.sequencer])))
         .sort((a, b) => (a.tissueTerm + a.sequencer).localeCompare(b.tissueTerm + b.sequencer));
 
-    return [...preferred, ...remaining].slice(0, sampleSize);
+    return [...uniquePreferred, ...remaining].slice(0, sampleSize);
+}
+
+// Filter by attribute values in JavaScript rather than interpolating live data
+// into a CSS selector; tissue/sequencer labels may legally contain quotes or
+// other selector-significant characters.
+function getRenderedBarPart(tissueTerm, sequencer) {
+    let barPart;
+    return cy.get('.bar-plot-chart .chart-bar[data-term]')
+        .should(($chartBars) => {
+            const chartBar = [...$chartBars].find(
+                (candidate) => candidate.getAttribute('data-term') === tissueTerm
+            );
+            barPart = chartBar && [...Cypress.$(chartBar).find('.bar-part[data-term]')].find(
+                (candidate) => candidate.getAttribute('data-term') === sequencer
+            );
+            expect(barPart, `Rendered bar-part for ${tissueTerm} x ${sequencer}`).to.exist;
+        })
+        .then(() => cy.wrap(barPart));
 }
 
 function assertTissueAxisLabel(tissueTerms, resolvedTissueTerm) {
     const acceptedVariants = [...new Set([...getTissueVariants(tissueTerms), resolvedTissueTerm])];
 
-    cy.get(`.bar-plot-chart .rotated-label[data-term="${resolvedTissueTerm}"]`)
-        .should('exist')
-        .then(($label) => {
+    cy.get('.bar-plot-chart .rotated-label[data-term]')
+        .should(($labels) => {
+            const label = [...$labels].find(
+                (candidate) => candidate.getAttribute('data-term') === resolvedTissueTerm
+            );
+            expect(label, `Axis label for ${resolvedTissueTerm}`).to.exist;
+            const $label = Cypress.$(label);
             const labelText = $label.text().replace(/\s+/g, ' ').trim();
             const labelTitle = ($label.attr('title') || '').trim();
 
@@ -659,7 +697,7 @@ function stepFacetChartBarPlotTests(caps) {
                     cy.log(`Testing bar part: Tissue = ${tissueTerm}, Sequencer = ${sequencer}`);
 
                     cy.window().scrollTo(0, 0).end()
-                        .get(`.bar-plot-chart .chart-bar[data-term="${tissueTerm}"] .bar-part[data-term="${sequencer}"]`)
+                        .then(() => getRenderedBarPart(tissueTerm, sequencer))
                         .then(($barPart) => {
                             assertTissueAxisLabel([tissueTerm], tissueTerm);
                             const expectedFilteredResults = parseInt($barPart.attr('data-count'), 10);
@@ -700,9 +738,14 @@ function stepFacetChartBarPlotTests(caps) {
 
                                     // Reconcile API total with UI count, tolerating one round
                                     // of transient data churn before failing with diagnostics.
-                                    return reconcileApiTotalWithUiCount(fullUrl, uiCount, {
-                                        context: `Bar-part Files link (${tissueTerm} x ${sequencer})`,
-                                    });
+                                    return reconcileApiTotalWithUiCount(
+                                        fullUrl,
+                                        () => cy.get('.cursor-component-root .details a')
+                                            .should('contain.text', 'Files')
+                                            .invoke('text')
+                                            .then(parseIntSafe),
+                                        { context: `Bar-part Files link (${tissueTerm} x ${sequencer})` }
+                                    );
                                 });
                             // `{ force: true }` is used a bunch here to prevent Cypress from attempting to scroll browser up/down during the test -- which may interfere w. mouse hover events.
                             // See https://github.com/cypress-io/cypress/issues/2353#issuecomment-413347535
@@ -714,27 +757,23 @@ function stepFacetChartBarPlotTests(caps) {
                                 .location('search')
                                 .should('include', 'external_id=')
                                 .get('#slow-load-container').should('not.have.class', 'visible')
-                                .then(() => {
-                                    // Both counts describe the same filtered dataset;
-                                    // resync with a re-read before failing (Cluster C).
-                                    return assertCountEventuallyEquals(
-                                        () => cy.searchPageTotalResultCount(),
-                                        expectedFilteredResults,
-                                        `Filtered search results count should reconcile with bar count (${expectedFilteredResults}) for ${tissueTerm} x ${sequencer}`
-                                    );
-                                })
-                                .getQuickInfoBar().then((info) => {
-                                    cy
-                                        .get('.properties-controls button[data-tip="Clear all filters"]')
-                                        .click({ force: true })
-                                        .get(".facet[data-field=\"external_id\"] .facet-list-element.selected .facet-item").should('not.exist').end();
-
-                                    assertCountEventuallyEquals(
+                                .url()
+                                .then((filteredResultsUrl) => reconcileApiTotalWithUiCount(
+                                    filteredResultsUrl,
+                                    () => cy.searchPageTotalResultCount(),
+                                    { context: `Filtered search results for ${tissueTerm} x ${sequencer}` }
+                                ))
+                                .then(() => cy
+                                    .get('.properties-controls button[data-tip="Clear all filters"]')
+                                    .click({ force: true })
+                                    .get(".facet[data-field=\"external_id\"] .facet-list-element.selected .facet-item")
+                                    .should('not.exist')
+                                    .then(() => assertCountsEventuallyEqual(
                                         () => cy.get("div.above-facets-table-row #results-count").invoke("text").then((t) => parseInt(t, 10)),
-                                        info.donor,
-                                        `Cleared-filters results count should reconcile with donor count from QuickInfoBar (${info.donor})`
-                                    ).wait(500); // wait to ensure chart animation completes before next iteration
-                                });
+                                        () => cy.getQuickInfoBar().then((currentInfo) => currentInfo.donor),
+                                        'Cleared-filters results count should reconcile with the current donor count from QuickInfoBar'
+                                    ))
+                                );
                         });
                 });
             });
@@ -938,9 +977,15 @@ function stepSearchTableRowsTests(caps) {
                         expect(uiCount, `Row ${rowIndex}: Files count must be > 0`).to.be.greaterThan(0);
                         expect(href, `Row ${rowIndex}: Files href must exist`).to.be.a('string').and.not.be.empty;
 
-                        reconcileApiTotalWithUiCount(href, uiCount, {
-                            context: `Row ${rowIndex}: search-table Files link`,
-                        });
+                        return reconcileApiTotalWithUiCount(
+                            href,
+                            () => cy.get(dataRowSelector)
+                                .eq(rowIndex)
+                                .find('.search-result-column-block[data-field="files"] a')
+                                .invoke('text')
+                                .then(parseCountFromLabel),
+                            { context: `Row ${rowIndex}: search-table Files link` }
+                        );
                     });
 
                 // --- Tissues detail: open panel and verify header + list count ---

--- a/deploy/post_deploy_testing/cypress/e2e/09a_data_overview.cy.js
+++ b/deploy/post_deploy_testing/cypress/e2e/09a_data_overview.cy.js
@@ -4,7 +4,8 @@ import {
     testDonorAssayFilesCoverageToggle,
     testDonorTissueMode,
     testMatrixPopoverValidation,
-    testTissueAssayFilesDonorsToggle
+    testTissueAssayFilesDonorsToggle,
+    waitForMatrixModeRender
 } from "../support/utils/dataMatrixUtils";
 
 const EMPTY_DM_PROD_OPTS = {
@@ -308,6 +309,12 @@ function activateProductionDataMatrix(caps) {
             .parents(".tab-card")
             .should("have.class", "is-active")
             .and("have.attr", "aria-hidden", "false");
+
+        // The tab becoming active only means the panel is displayed; the
+        // matrix contents inside it can still be mid-render/refresh for a
+        // moment after that, which is what produced the intermittent
+        // "grouping-row label-section span never found" failures.
+        waitForMatrixModeRender("#data-matrix-for_production");
     });
 }
 
@@ -323,6 +330,10 @@ function activateBenchmarkingDataMatrix() {
         .parents(".tab-card")
         .should("have.class", "is-active")
         .and("have.attr", "aria-hidden", "false");
+
+    // See activateProductionDataMatrix - the panel becoming active doesn't
+    // guarantee the matrix contents inside it have finished rendering.
+    waitForMatrixModeRender("#data-matrix-for_benchmarking");
 }
 
 /** Data Matrix (Production) — expand donors and validate popovers */

--- a/deploy/post_deploy_testing/cypress/support/commands.js
+++ b/deploy/post_deploy_testing/cypress/support/commands.js
@@ -2,8 +2,8 @@ import _ from 'underscore';
 const jose = require('jose');
 
 import {
-    navUserAcctDropdownBtnSelector,
     navUserAcctLoginBtnSelector,
+    navUserAcctLoggedInMenuSelector,
 } from './selectorVars';
 
 /** Expected to throw error of some sort if not on search page, or no results. */
@@ -95,7 +95,7 @@ Cypress.Commands.add('loginSMaHT', function (role, options = { useEnvToken: fals
     //ensure user is logged out first
     if (options.forceLogout) {
         cy.get('body').then(($body) => {
-            if ($body.find(navUserAcctDropdownBtnSelector + '#account-menu-item').length > 0) {
+            if ($body.find(navUserAcctLoggedInMenuSelector).length > 0) {
                 cy.logoutSMaHT().end();
             }
         });
@@ -141,6 +141,17 @@ Cypress.Commands.add('loginSMaHT', function (role, options = { useEnvToken: fals
                     })
                     .end();
             })
+            // Login mutates SPA state asynchronously (updateAppSessionState +
+            // an in-place navigate re-render the navbar); wait for the
+            // authenticated account menu to actually be present before
+            // treating login as complete. The generic `.user-account-item`
+            // selector also matches the logged-out login button, so a plain
+            // "not contain Login / Register" check here could pass on stale
+            // DOM - navUserAcctLoggedInMenuSelector can only match the menu.
+            .get('#slow-load-container', { timeout: 20000 })
+            .should('not.have.class', 'visible')
+            .get(navUserAcctLoggedInMenuSelector, { timeout: 20000 })
+            .should('be.visible')
             .validateUser(userDisplayName)
             .end();
     }
@@ -188,7 +199,7 @@ Cypress.Commands.add('loginSMaHT', function (role, options = { useEnvToken: fals
 });
 
 Cypress.Commands.add('validateUser', function (userDisplayName = '') {
-    return cy.get(navUserAcctDropdownBtnSelector)
+    return cy.get(navUserAcctLoggedInMenuSelector, { timeout: 20000 })
         .should('not.contain.text', 'Login / Register')
         .then((accountListItem) => {
             Cypress.log({
@@ -200,7 +211,11 @@ Cypress.Commands.add('validateUser', function (userDisplayName = '') {
 });
 
 Cypress.Commands.add('logoutSMaHT', function (options = { useEnvToken: true }) {
-    cy.getLoadedMenuItem(navUserAcctDropdownBtnSelector)
+    // Use the id-scoped selector (not the ambiguous navUserAcctDropdownBtnSelector,
+    // which also matches the logged-out login button) so a not-yet-applied login
+    // fails with a clear "element not found" instead of silently asserting
+    // dropdown-toggle against #loginbtn.
+    cy.getLoadedMenuItem(navUserAcctLoggedInMenuSelector)
         .click({ force: true })
         .should("have.class", "dropdown-open-for")
         .then(() => {

--- a/deploy/post_deploy_testing/cypress/support/commands.js
+++ b/deploy/post_deploy_testing/cypress/support/commands.js
@@ -105,7 +105,7 @@ Cypress.Commands.add('loginSMaHT', function (role, options = { useEnvToken: fals
         return cy
             .window()
             .then((w) => {
-                cy.request({
+                return cy.request({
                     url: '/login',
                     method: 'POST',
                     body: JSON.stringify({ id_token: token }),
@@ -115,31 +115,25 @@ Cypress.Commands.add('loginSMaHT', function (role, options = { useEnvToken: fals
                         'Content-Type': 'application/json; charset=UTF-8',
                     },
                     followRedirect: true,
-                })
-                    .then(function (resp) {
-                        if (resp.status && resp.status === 200) {
-                            cy.request({
-                                url: '/session-properties',
-                                method: 'GET',
-                                headers: {
-                                    Accept: 'application/json',
-                                    'Content-Type':
-                                        'application/json; charset=UTF-8',
-                                },
-                            })
-                                .then(function (userInfoResponse) {
-                                    w.SMaHT.JWT.saveUserInfoLocalStorage(
-                                        userInfoResponse.body
-                                    );
-                                    // Triggers app.state.session change (req'd to update UI)
-                                    w.SMaHT.app.updateAppSessionState();
-                                    // Refresh curr page/context
-                                    w.SMaHT.navigate('', { inPlace: true });
-                                })
-                                .end();
-                        }
-                    })
-                    .end();
+                }).then(function (resp) {
+                    expect(resp.status, 'login response status').to.equal(200);
+                    return cy.request({
+                        url: '/session-properties',
+                        method: 'GET',
+                        headers: {
+                            Accept: 'application/json',
+                            'Content-Type': 'application/json; charset=UTF-8',
+                        },
+                    }).then(function (userInfoResponse) {
+                        expect(userInfoResponse.status, 'session-properties response status').to.equal(200);
+                        expect(userInfoResponse.body, 'authenticated session properties').to.be.an('object');
+                        w.SMaHT.JWT.saveUserInfoLocalStorage(userInfoResponse.body);
+                        // Triggers app.state.session change (req'd to update UI)
+                        w.SMaHT.app.updateAppSessionState();
+                        // Refresh curr page/context
+                        w.SMaHT.navigate('', { inPlace: true });
+                    });
+                });
             })
             // Login mutates SPA state asynchronously (updateAppSessionState +
             // an in-place navigate re-render the navbar); wait for the
@@ -165,7 +159,7 @@ Cypress.Commands.add('loginSMaHT', function (role, options = { useEnvToken: fals
         }
     }
 
-    cy.fixture('roles.json').then((roles) => {
+    return cy.fixture('roles.json').then((roles) => {
         let email, auth0UserId, shortname;
         if (roles && roles[role] && roles[role].email && roles[role].auth0UserId) {
             ({ email, auth0UserId, shortname } = roles[role]);
@@ -199,15 +193,18 @@ Cypress.Commands.add('loginSMaHT', function (role, options = { useEnvToken: fals
 });
 
 Cypress.Commands.add('validateUser', function (userDisplayName = '') {
+    Cypress.log({
+        name: 'Validate User',
+        message: 'Validating user is ' + userDisplayName,
+    });
     return cy.get(navUserAcctLoggedInMenuSelector, { timeout: 20000 })
         .should('not.contain.text', 'Login / Register')
-        .then((accountListItem) => {
-            Cypress.log({
-                name: 'Validate User',
-                message: 'Validating user is ' + userDisplayName,
-            });
-            expect(accountListItem.text()).to.contain(userDisplayName);
-        }).end();
+        .and(($accountListItem) => {
+            if (userDisplayName) {
+                expect($accountListItem.text(), 'authenticated user display name')
+                    .to.contain(userDisplayName);
+            }
+        });
 });
 
 Cypress.Commands.add('logoutSMaHT', function (options = { useEnvToken: true }) {
@@ -215,7 +212,7 @@ Cypress.Commands.add('logoutSMaHT', function (options = { useEnvToken: true }) {
     // which also matches the logged-out login button) so a not-yet-applied login
     // fails with a clear "element not found" instead of silently asserting
     // dropdown-toggle against #loginbtn.
-    cy.getLoadedMenuItem(navUserAcctLoggedInMenuSelector)
+    return cy.getLoadedMenuItem(navUserAcctLoggedInMenuSelector)
         .click({ force: true })
         .should("have.class", "dropdown-open-for")
         .then(() => {

--- a/deploy/post_deploy_testing/cypress/support/selectorVars.js
+++ b/deploy/post_deploy_testing/cypress/support/selectorVars.js
@@ -11,5 +11,11 @@ export const navUserAcctDropdownBtnSelector =
     '#top-nav .navbar-collapse .navbar-acct.navbar-nav .user-account-item';
 export const navUserAcctLoginBtnSelector =
     '#top-nav .navbar-collapse .navbar-acct.navbar-nav > a.user-account-item';
+// Both the logged-out login button and the logged-in account menu carry the
+// `.user-account-item` class, so `navUserAcctDropdownBtnSelector` alone cannot
+// tell them apart. Use this selector whenever a check must only ever match the
+// authenticated account menu (e.g. confirming login/logout actually applied).
+export const navUserAcctLoggedInMenuSelector =
+    '#top-nav .navbar-collapse .navbar-acct.navbar-nav a#account-menu-item.user-account-item';
 export const dataNavBarItemSelectorStr =
     '#top-nav div.navbar-collapse .navbar-nav a.id-data-menu-item';

--- a/deploy/post_deploy_testing/cypress/support/utils/__tests__/dataMatrixUtils.test.js
+++ b/deploy/post_deploy_testing/cypress/support/utils/__tests__/dataMatrixUtils.test.js
@@ -1,4 +1,11 @@
-import { getApiTotalFromResponse } from '../dataMatrixUtils';
+import {
+    countsMatch,
+    getApiTotalFromResponse,
+    matrixRenderStateIsReady,
+    parsePositiveIntegerCount,
+    requireMatchingCounts,
+    toBarIdentity,
+} from '../dataMatrixUtils';
 
 
 describe('getApiTotalFromResponse', () => {
@@ -18,5 +25,73 @@ describe('getApiTotalFromResponse', () => {
         [200, { total: -1 }],
     ])('rejects unexpected or malformed response status=%s body=%p', (status, body) => {
         expect(() => getApiTotalFromResponse({ status, body }, url)).toThrow(url);
+    });
+});
+
+describe('matrixRenderStateIsReady', () => {
+    const hydratedState = {
+        surfaceExists: true,
+        surfaceVisible: true,
+        surfaceRefreshing: false,
+        overlayExists: false,
+        visualExists: true,
+        visualVisible: true,
+        visualLoading: false,
+    };
+
+    test('accepts hydrated Donor x Tissue markup without requiring grouping labels', () => {
+        expect(matrixRenderStateIsReady({
+            ...hydratedState,
+            mode: 'donor-tissue',
+            hasLabelSectionSpan: false,
+        })).toBe(true);
+    });
+
+    test('accepts another hydrated matrix shape', () => {
+        expect(matrixRenderStateIsReady({
+            ...hydratedState,
+            mode: 'donor-assay',
+            hasLabelSectionSpan: true,
+        })).toBe(true);
+    });
+
+    test.each([
+        [{ ...hydratedState, visualExists: false }, 'empty pre-hydration surface'],
+        [{ ...hydratedState, visualLoading: true }, 'loading visual shell'],
+        [{ ...hydratedState, surfaceRefreshing: true }, 'refreshing surface'],
+        [{ ...hydratedState, overlayExists: true }, 'refresh overlay'],
+    ])('rejects %s (%s)', (state) => {
+        expect(matrixRenderStateIsReady(state)).toBe(false);
+    });
+});
+
+describe('dynamic bar count counterfactuals', () => {
+    test('uses the current count when discovery saw 20 and execution sees 12', () => {
+        const sampledIdentity = toBarIdentity({
+            tissueTerm: '3AL - Brain, Temporal Lobe',
+            sequencer: 'Illumina NovaSeq X Plus',
+            dataCount: 20,
+        });
+        const currentBarCount = parsePositiveIntegerCount('12', 'current bar');
+
+        expect(sampledIdentity).toEqual({
+            tissueTerm: '3AL - Brain, Temporal Lobe',
+            sequencer: 'Illumina NovaSeq X Plus',
+        });
+        expect(countsMatch(currentBarCount, 12)).toBe(true);
+    });
+
+    test('fails a persistent mismatch against the current count', () => {
+        const currentBarCount = parsePositiveIntegerCount('12', 'current bar');
+        expect(countsMatch(currentBarCount, 11)).toBe(false);
+        expect(() => requireMatchingCounts(
+            currentBarCount,
+            11,
+            'persistent current UI/API divergence: 12/11'
+        )).toThrow('persistent current UI/API divergence: 12/11');
+    });
+
+    test.each(['0', '-1', '1.5', 'not-a-number', ''])('rejects invalid current bar count %p', (rawCount) => {
+        expect(() => parsePositiveIntegerCount(rawCount, 'current bar')).toThrow('current bar');
     });
 });

--- a/deploy/post_deploy_testing/cypress/support/utils/__tests__/dataMatrixUtils.test.js
+++ b/deploy/post_deploy_testing/cypress/support/utils/__tests__/dataMatrixUtils.test.js
@@ -1,0 +1,22 @@
+import { getApiTotalFromResponse } from '../dataMatrixUtils';
+
+
+describe('getApiTotalFromResponse', () => {
+    const url = '/browse/?type=File&format=json';
+
+    test('accepts successful numeric totals and the documented empty-result response', () => {
+        expect(getApiTotalFromResponse({ status: 200, body: { total: 12 } }, url)).toBe(12);
+        expect(getApiTotalFromResponse({ status: 404, body: { total: 0 } }, url)).toBe(0);
+    });
+
+    test.each([
+        [404, { total: '0' }],
+        [404, { total: 1 }],
+        [500, { total: 0 }],
+        [200, {}],
+        [200, { total: '12' }],
+        [200, { total: -1 }],
+    ])('rejects unexpected or malformed response status=%s body=%p', (status, body) => {
+        expect(() => getApiTotalFromResponse({ status, body }, url)).toThrow(url);
+    });
+});

--- a/deploy/post_deploy_testing/cypress/support/utils/dataMatrixUtils.js
+++ b/deploy/post_deploy_testing/cypress/support/utils/dataMatrixUtils.js
@@ -6,33 +6,38 @@
 // `failOnStatusCode:false` lets us read that body instead of throwing a
 // CypressError; any other non-200 status, or a body without a numeric
 // `total`, still fails loudly with the response attached.
+export function getApiTotalFromResponse(response, url) {
+    const { status, body } = response;
+    const isDocumentedEmptyResult = status === 404 && body && body.total === 0;
+
+    if (status !== 200 && !isDocumentedEmptyResult) {
+        throw new Error(
+            `getApiTotalFromUrl: unexpected response for ${url} - status ${status}, body: ${JSON.stringify(body).slice(0, 500)}`
+        );
+    }
+
+    if (!Number.isFinite(body?.total) || body.total < 0) {
+        throw new Error(
+            `getApiTotalFromUrl: response for ${url} (status ${status}) has no valid numeric 'total' field: ${JSON.stringify(body).slice(0, 500)}`
+        );
+    }
+
+    return body.total;
+}
+
 export function getApiTotalFromUrl(url) {
-    // Ensure the URL requests JSON format (append if missing)
+    // Ensure the URL requests JSON format (append if missing).
     const normalizedUrl = String(url).replace(/^(https?:\/\/[^/]+)\/\/+/, '$1/').replace(/^\/\/+/, '/');
-    const fullUrl = normalizedUrl.includes('format=json') ? normalizedUrl : `${normalizedUrl}&format=json&frame=raw`;
+    const separator = normalizedUrl.includes('?') ? '&' : '?';
+    const fullUrl = normalizedUrl.includes('format=json')
+        ? normalizedUrl
+        : `${normalizedUrl}${separator}format=json&frame=raw`;
 
     return cy.request({
         method: 'GET',
         url: fullUrl,
         failOnStatusCode: false,
-    }).then((response) => {
-        const { status, body } = response;
-        const isDocumentedEmptyResult = status === 404 && body && body.total === 0;
-
-        if (status !== 200 && !isDocumentedEmptyResult) {
-            throw new Error(
-                `getApiTotalFromUrl: unexpected response for ${fullUrl} - status ${status}, body: ${JSON.stringify(body).slice(0, 500)}`
-            );
-        }
-
-        if (typeof body?.total !== 'number') {
-            throw new Error(
-                `getApiTotalFromUrl: response for ${fullUrl} (status ${status}) has no numeric 'total' field: ${JSON.stringify(body).slice(0, 500)}`
-            );
-        }
-
-        return body.total;
-    });
+    }).then((response) => getApiTotalFromResponse(response, fullUrl));
 }
 
 /**
@@ -42,20 +47,40 @@ export function getApiTotalFromUrl(url) {
  * single re-read, this throws with the exact URL, UI count, and API total so
  * the failure is a diagnostic rather than a bare `expected X to equal Y`.
  */
-export function reconcileApiTotalWithUiCount(url, uiCount, { context = '', retries = 1, retryDelayMs = 1500 } = {}) {
+export function reconcileApiTotalWithUiCount(url, readUiCount, { context = '', retries = 1, retryDelayMs = 1500 } = {}) {
     const label = context ? `${context}: ` : '';
+    if (typeof readUiCount !== 'function') {
+        throw new Error('reconcileApiTotalWithUiCount requires a UI count reader so retries cannot reuse a stale value');
+    }
+    let firstMismatch = null;
 
     function attempt(remaining) {
-        return getApiTotalFromUrl(url).then((apiTotal) => {
-            if (apiTotal === uiCount) {
-                return apiTotal;
+        // Re-read both sides on every attempt. Retrying only the API while
+        // retaining a stale DOM capture can manufacture either convergence or
+        // a misleading persistent-divergence failure during a live update.
+        return readUiCount().then((uiCount) => {
+            if (!Number.isFinite(uiCount) || uiCount < 0) {
+                throw new Error(`${label}invalid UI count ${uiCount} for ${url}`);
             }
-            if (remaining > 0) {
-                return cy.wait(retryDelayMs).then(() => attempt(remaining - 1));
-            }
-            throw new Error(
-                `${label}UI/API count divergence persisted after re-read - url: ${url}, uiCount: ${uiCount}, apiTotal: ${apiTotal}`
-            );
+
+            return getApiTotalFromUrl(url).then((apiTotal) => {
+                if (apiTotal === uiCount) {
+                    return apiTotal;
+                }
+
+                if (!firstMismatch) firstMismatch = { uiCount, apiTotal };
+                if (remaining > 0) {
+                    // This is a bounded polling interval, not a load-completion
+                    // sleep: the next attempt re-reads both authoritative values.
+                    return cy.wait(retryDelayMs).then(() => attempt(remaining - 1));
+                }
+
+                throw new Error(
+                    `${label}UI/API count divergence persisted after re-read - url: ${url}, ` +
+                    `first uiCount/apiTotal: ${firstMismatch.uiCount}/${firstMismatch.apiTotal}, ` +
+                    `final uiCount/apiTotal: ${uiCount}/${apiTotal}`
+                );
+            });
         });
     }
 
@@ -218,9 +243,15 @@ function assertPopover({ donor, assay, tissue, value, blockType = 'regular', dep
 
                                         // Reconcile API total with UI count, tolerating one
                                         // round of transient data churn before failing.
-                                        return reconcileApiTotalWithUiCount(fullUrl, uiCount, {
-                                            context: 'Popover total (regular block) vs API total',
-                                        });
+                                        return reconcileApiTotalWithUiCount(
+                                            fullUrl,
+                                            () => cy.get('.secondary-row .col-4')
+                                                .eq(2)
+                                                .find('.value')
+                                                .invoke('text')
+                                                .then((text) => parseInt(String(text).trim(), 10)),
+                                            { context: 'Popover total (regular block) vs API total' }
+                                        );
                                     });
                             } else {
                                 Cypress.log({
@@ -264,9 +295,15 @@ function assertPopover({ donor, assay, tissue, value, blockType = 'regular', dep
 
                                         // Reconcile API total with UI count, tolerating one
                                         // round of transient data churn before failing.
-                                        return reconcileApiTotalWithUiCount(fullUrl, uiCount, {
-                                            context: 'Popover total (row-summary) vs API total',
-                                        });
+                                        return reconcileApiTotalWithUiCount(
+                                            fullUrl,
+                                            () => cy.get('.secondary-row .col-4')
+                                                .eq(2)
+                                                .find('.value')
+                                                .invoke('text')
+                                                .then((text) => parseInt(String(text).trim(), 10)),
+                                            { context: 'Popover total (row-summary) vs API total' }
+                                        );
                                     });
                             } else {
                                 Cypress.log({
@@ -290,20 +327,15 @@ function assertPopover({ donor, assay, tissue, value, blockType = 'regular', dep
                     cy.get('.secondary-row .col-4', { timeout: 10000 })
                         .then(($cols) => {
                             const numericValues = [];
-                            let totalFilesValue = null;
 
                             [...$cols].forEach((col) => {
                                 const $col = Cypress.$(col);
-                                const label = $col.find('.label').text().trim();
                                 const rawText = $col.find('.value').text().trim();
                                 const numericValue = parseIntSafe(
                                     rawText.replace(/,/g, '')
                                 );
                                 if (!Number.isNaN(numericValue)) {
                                     numericValues.push(numericValue);
-                                    if (label === 'Total Files') {
-                                        totalFilesValue = numericValue;
-                                    }
                                 }
                             });
 
@@ -311,10 +343,6 @@ function assertPopover({ donor, assay, tissue, value, blockType = 'regular', dep
                                 numericValues,
                                 `Popover numeric metrics should include expected value ${value}`
                             ).to.include(value);
-
-                            const uiCountForApiValidation = totalFilesValue !== null
-                                ? totalFilesValue
-                                : (numericValues.length > 0 ? Math.max(...numericValues) : value);
 
                             if (verifyTotalFromApi) {
                                 // Get the URL from the "Browse Files" button in footer
@@ -328,9 +356,20 @@ function assertPopover({ donor, assay, tissue, value, blockType = 'regular', dep
 
                                         // Reconcile API total with UI count, tolerating one
                                         // round of transient data churn before failing.
-                                        return reconcileApiTotalWithUiCount(fullUrl, uiCountForApiValidation, {
-                                            context: 'Popover total (col-summary) vs API total',
-                                        });
+                                        return reconcileApiTotalWithUiCount(
+                                            fullUrl,
+                                            () => cy.get('.secondary-row .col-4').then(($currentCols) => {
+                                                const totalFilesColumn = [...$currentCols].find((col) =>
+                                                    Cypress.$(col).find('.label').text().trim() === 'Total Files'
+                                                );
+                                                const fallbackValues = [...$currentCols]
+                                                    .map((col) => parseIntSafe(Cypress.$(col).find('.value').text().replace(/,/g, '')));
+                                                return totalFilesColumn
+                                                    ? parseIntSafe(Cypress.$(totalFilesColumn).find('.value').text().replace(/,/g, ''))
+                                                    : Math.max(...fallbackValues, value);
+                                            }),
+                                            { context: 'Popover total (col-summary) vs API total' }
+                                        );
                                     });
                             } else {
                                 Cypress.log({
@@ -909,11 +948,17 @@ export function testMatrixPopoverValidation(
 }
 
 export function waitForMatrixModeRender(matrixId) {
-    cy.get(`${matrixId} .matrix-render-surface`, { timeout: 20000 })
-        .should('exist')
-        .and('not.have.class', 'is-refreshing');
-
-    cy.get(`${matrixId} .matrix-refresh-overlay`).should('not.exist');
+    return cy.get(`${matrixId} .matrix-render-surface`, { timeout: 20000 })
+        .should('be.visible')
+        .and('not.have.class', 'is-refreshing')
+        // The surface exists before matrix hydration begins. A rendered label
+        // is the stable signal needed by the assertions that follow.
+        .find('.grouping-row .label-section span')
+        .should('have.length.greaterThan', 0)
+        .then(() => cy.get(`${matrixId} .matrix-refresh-overlay`).should('not.exist'))
+        .then(() => cy.get(`${matrixId} .matrix-render-surface`)
+            .should('be.visible')
+            .and('not.have.class', 'is-refreshing'));
 }
 
 function getDisplayedMatrixFileCount(matrixId) {

--- a/deploy/post_deploy_testing/cypress/support/utils/dataMatrixUtils.js
+++ b/deploy/post_deploy_testing/cypress/support/utils/dataMatrixUtils.js
@@ -1,4 +1,11 @@
-// Sends a GET request to the given URL and returns the `total` field from JSON response
+// Sends a GET request to the given URL and returns the `total` field from JSON response.
+//
+// SMaHT's browse/search API returns HTTP 404 with a valid JSON body (`total: 0`,
+// "No results found") whenever a filter combination currently matches zero
+// results - that is a documented, correct contract, not a transport failure.
+// `failOnStatusCode:false` lets us read that body instead of throwing a
+// CypressError; any other non-200 status, or a body without a numeric
+// `total`, still fails loudly with the response attached.
 export function getApiTotalFromUrl(url) {
     // Ensure the URL requests JSON format (append if missing)
     const normalizedUrl = String(url).replace(/^(https?:\/\/[^/]+)\/\/+/, '$1/').replace(/^\/\/+/, '/');
@@ -6,8 +13,53 @@ export function getApiTotalFromUrl(url) {
 
     return cy.request({
         method: 'GET',
-        url: fullUrl
-    }).its('body.total');
+        url: fullUrl,
+        failOnStatusCode: false,
+    }).then((response) => {
+        const { status, body } = response;
+        const isDocumentedEmptyResult = status === 404 && body && body.total === 0;
+
+        if (status !== 200 && !isDocumentedEmptyResult) {
+            throw new Error(
+                `getApiTotalFromUrl: unexpected response for ${fullUrl} - status ${status}, body: ${JSON.stringify(body).slice(0, 500)}`
+            );
+        }
+
+        if (typeof body?.total !== 'number') {
+            throw new Error(
+                `getApiTotalFromUrl: response for ${fullUrl} (status ${status}) has no numeric 'total' field: ${JSON.stringify(body).slice(0, 500)}`
+            );
+        }
+
+        return body.total;
+    });
+}
+
+/**
+ * Compares a UI-derived count against the live API `total` for the same URL,
+ * tolerating one round of transient data churn between when the UI value was
+ * read and when this check runs. If the two values still disagree after a
+ * single re-read, this throws with the exact URL, UI count, and API total so
+ * the failure is a diagnostic rather than a bare `expected X to equal Y`.
+ */
+export function reconcileApiTotalWithUiCount(url, uiCount, { context = '', retries = 1, retryDelayMs = 1500 } = {}) {
+    const label = context ? `${context}: ` : '';
+
+    function attempt(remaining) {
+        return getApiTotalFromUrl(url).then((apiTotal) => {
+            if (apiTotal === uiCount) {
+                return apiTotal;
+            }
+            if (remaining > 0) {
+                return cy.wait(retryDelayMs).then(() => attempt(remaining - 1));
+            }
+            throw new Error(
+                `${label}UI/API count divergence persisted after re-read - url: ${url}, uiCount: ${uiCount}, apiTotal: ${apiTotal}`
+            );
+        });
+    }
+
+    return attempt(retries);
 }
 
 // Safely parse a number from text content (e.g. " 11 " → 11)
@@ -164,10 +216,10 @@ function assertPopover({ donor, assay, tissue, value, blockType = 'regular', dep
                                             ? href
                                             : `${Cypress.config('baseUrl')}${href}`;
 
-                                        // Fetch API total and compare it with UI count
-                                        return getApiTotalFromUrl(fullUrl).then((apiTotal) => {
-                                            expect(apiTotal, `API total (${apiTotal}) should match UI count (${uiCount})`)
-                                                .to.equal(uiCount);
+                                        // Reconcile API total with UI count, tolerating one
+                                        // round of transient data churn before failing.
+                                        return reconcileApiTotalWithUiCount(fullUrl, uiCount, {
+                                            context: 'Popover total (regular block) vs API total',
                                         });
                                     });
                             } else {
@@ -210,10 +262,10 @@ function assertPopover({ donor, assay, tissue, value, blockType = 'regular', dep
                                             ? href
                                             : `${Cypress.config('baseUrl')}${href}`;
 
-                                        // Fetch API total and compare it with UI count
-                                        return getApiTotalFromUrl(fullUrl).then((apiTotal) => {
-                                            expect(apiTotal, `API total (${apiTotal}) should match UI count (${uiCount})`)
-                                                .to.equal(uiCount);
+                                        // Reconcile API total with UI count, tolerating one
+                                        // round of transient data churn before failing.
+                                        return reconcileApiTotalWithUiCount(fullUrl, uiCount, {
+                                            context: 'Popover total (row-summary) vs API total',
                                         });
                                     });
                             } else {
@@ -274,12 +326,10 @@ function assertPopover({ donor, assay, tissue, value, blockType = 'regular', dep
                                             ? href
                                             : `${Cypress.config('baseUrl')}${href}`;
 
-                                        // Fetch API total and compare it with UI count
-                                        return getApiTotalFromUrl(fullUrl).then((apiTotal) => {
-                                            expect(
-                                                apiTotal,
-                                                `API total (${apiTotal}) should match popover Total Files (${uiCountForApiValidation})`
-                                            ).to.equal(uiCountForApiValidation);
+                                        // Reconcile API total with UI count, tolerating one
+                                        // round of transient data churn before failing.
+                                        return reconcileApiTotalWithUiCount(fullUrl, uiCountForApiValidation, {
+                                            context: 'Popover total (col-summary) vs API total',
                                         });
                                     });
                             } else {
@@ -858,7 +908,7 @@ export function testMatrixPopoverValidation(
     });
 }
 
-function waitForMatrixModeRender(matrixId) {
+export function waitForMatrixModeRender(matrixId) {
     cy.get(`${matrixId} .matrix-render-surface`, { timeout: 20000 })
         .should('exist')
         .and('not.have.class', 'is-refreshing');

--- a/deploy/post_deploy_testing/cypress/support/utils/dataMatrixUtils.js
+++ b/deploy/post_deploy_testing/cypress/support/utils/dataMatrixUtils.js
@@ -47,6 +47,29 @@ export function getApiTotalFromUrl(url) {
  * single re-read, this throws with the exact URL, UI count, and API total so
  * the failure is a diagnostic rather than a bare `expected X to equal Y`.
  */
+export function countsMatch(currentUiCount, currentApiTotal) {
+    return currentUiCount === currentApiTotal;
+}
+
+export function requireMatchingCounts(currentUiCount, currentApiTotal, message) {
+    if (!countsMatch(currentUiCount, currentApiTotal)) {
+        throw new Error(message);
+    }
+    return currentApiTotal;
+}
+
+export function toBarIdentity({ tissueTerm, sequencer }) {
+    return { tissueTerm, sequencer };
+}
+
+export function parsePositiveIntegerCount(rawCount, context = 'count') {
+    const count = Number(rawCount);
+    if (!Number.isInteger(count) || count <= 0) {
+        throw new Error(`${context} must be a positive integer; received ${rawCount}`);
+    }
+    return count;
+}
+
 export function reconcileApiTotalWithUiCount(url, readUiCount, { context = '', retries = 1, retryDelayMs = 1500 } = {}) {
     const label = context ? `${context}: ` : '';
     if (typeof readUiCount !== 'function') {
@@ -64,7 +87,7 @@ export function reconcileApiTotalWithUiCount(url, readUiCount, { context = '', r
             }
 
             return getApiTotalFromUrl(url).then((apiTotal) => {
-                if (apiTotal === uiCount) {
+                if (countsMatch(uiCount, apiTotal)) {
                     return apiTotal;
                 }
 
@@ -75,7 +98,9 @@ export function reconcileApiTotalWithUiCount(url, readUiCount, { context = '', r
                     return cy.wait(retryDelayMs).then(() => attempt(remaining - 1));
                 }
 
-                throw new Error(
+                return requireMatchingCounts(
+                    uiCount,
+                    apiTotal,
                     `${label}UI/API count divergence persisted after re-read - url: ${url}, ` +
                     `first uiCount/apiTotal: ${firstMismatch.uiCount}/${firstMismatch.apiTotal}, ` +
                     `final uiCount/apiTotal: ${uiCount}/${apiTotal}`
@@ -947,18 +972,48 @@ export function testMatrixPopoverValidation(
     });
 }
 
+export function matrixRenderStateIsReady({
+    surfaceExists,
+    surfaceVisible,
+    surfaceRefreshing,
+    overlayExists,
+    visualExists,
+    visualVisible,
+    visualLoading,
+}) {
+    return surfaceExists && surfaceVisible && !surfaceRefreshing && !overlayExists &&
+        visualExists && visualVisible && !visualLoading;
+}
+
 export function waitForMatrixModeRender(matrixId) {
+    // `StackedBlockVisual` renders `.stacked-block-viz-container.is-loading`
+    // for the pre-hydration shell and removes `is-loading` for every hydrated
+    // matrix mode. Unlike a grouping-label descendant, this contract is owned
+    // by the shared render component and also applies to Donor x Tissue.
     return cy.get(`${matrixId} .matrix-render-surface`, { timeout: 20000 })
         .should('be.visible')
         .and('not.have.class', 'is-refreshing')
-        // The surface exists before matrix hydration begins. A rendered label
-        // is the stable signal needed by the assertions that follow.
-        .find('.grouping-row .label-section span')
-        .should('have.length.greaterThan', 0)
+        .find('.stacked-block-viz-container')
+        .should('be.visible')
+        .and('not.have.class', 'is-loading')
         .then(() => cy.get(`${matrixId} .matrix-refresh-overlay`).should('not.exist'))
-        .then(() => cy.get(`${matrixId} .matrix-render-surface`)
-            .should('be.visible')
-            .and('not.have.class', 'is-refreshing'));
+        .then(() => cy.get(matrixId).should(($matrix) => {
+            const $surface = $matrix.find('.matrix-render-surface');
+            const $visual = $surface.find('.stacked-block-viz-container');
+            const renderState = {
+                surfaceExists: $surface.length > 0,
+                surfaceVisible: $surface.is(':visible'),
+                surfaceRefreshing: $surface.hasClass('is-refreshing'),
+                overlayExists: $surface.find('.matrix-refresh-overlay').length > 0,
+                visualExists: $visual.length > 0,
+                visualVisible: $visual.is(':visible'),
+                visualLoading: $visual.hasClass('is-loading'),
+            };
+            expect(
+                matrixRenderStateIsReady(renderState),
+                `${matrixId} should have a hydrated, visible, non-refreshing render state`
+            ).to.equal(true);
+        }));
 }
 
 function getDisplayedMatrixFileCount(matrixId) {


### PR DESCRIPTION
## Summary

Hardens the live-site post-deploy Cypress suite against confirmed data churn and login/render races without weakening authentication, authorization, response-shape, navigation, or persistent UI/API consistency failures.

### Evidence baseline

- `Cypress Tests - Data`: **25/25** sampled scheduled runs failed over ~27 days.
- `Cypress Tests - Staging`: about 20/25 sampled runs failed while unchanged test code also had clean runs.
- `03b_browse_by_donor.cy.js` failed in **11/11** sampled failing runs and was the dominant source of red builds.
- Authenticated staging run [29922521482](https://github.com/smaht-dac/smaht-portal/actions/runs/29922521482) exercised PR head `ddf2bb33` and identified two PR regressions. Commit `312eb77d` corrects both; that correction still requires a later authenticated validation run.

## Changes

### Dynamic donor facet coverage and run-29922521482 correction

- Replaces required hard-coded tissue/sequencer pairs with a deterministic sample of up to three positive bar identities actually rendered by the live chart.
- Keeps known pairs as preferences only when present, de-duplicates identities, and fails clearly if no eligible bar exists.
- Avoids interpolating live labels into CSS selectors.
- **Run feedback:** sampling no longer carries discovery-time `data-count`. The selected bar is safely re-queried at execution, its current count must be a positive integer, and that current count drives popover/filter/API checks. Thus discovery `20` → current `12` is allowed only when current popover/search/API values also reconcile to `12`; persistent current-value divergence still fails.
- Preserves axis-label, popover, Files-link, filter-navigation, and API/UI assertions.

### Empty-result API handling and count reconciliation

- Accepts only documented `404` responses with exact numeric `total: 0`; successful responses require a finite, nonnegative numeric total. Unexpected statuses and malformed totals fail with URL/status/body diagnostics.
- Uses `failOnStatusCode:false` only so Cypress can classify responses rather than throwing a generic transport error.
- Reconciliation requires a UI reader and re-reads both DOM count and API total on its bounded retry. Persistent divergence reports URL plus first/final values.
- Post-navigation and cleared-filter checks compare freshly read authoritative values, with no broad tolerance.

### Login/navbar synchronization

- Auth-only helpers use `#account-menu-item`, never `.user-account-item` (which also matches `#loginbtn`).
- Login/session requests and login/validation/logout helpers return Cypress chains so failures propagate.
- Login validates response/session shape, waits for slow-load completion and the authenticated menu, and retries the expected role/display-name assertion.
- `cy.session()` and `testIsolation:false` remain unchanged.

### Matrix hydration and run-29922521482 correction

- Production/benchmarking activation uses a returned matrix readiness chain.
- **Run feedback:** removes `.grouping-row .label-section span` as a universal requirement; valid Donor×Tissue markup can omit it.
- Readiness now follows the shared `StackedBlockVisual` contract: visible render surface, no refresh overlay, not refreshing, and a visible `.stacked-block-viz-container` whose pre-hydration `.is-loading` class has cleared. A final combined state recheck prevents accepting the empty/loading shell.
- Mode-specific tests remain responsible for their expected labels, blocks, summaries, and controls.

## Assertions deliberately preserved

- No test is skipped or disabled.
- Authentication/role, protected navigation, response shape/status, axis/popover/filter behavior, and exact internal consistency remain asserted.
- A documented empty API result does not excuse a nonzero UI count.
- No broad count tolerance was introduced.
- `03a_browse_by_file.cy.js` is deliberately unchanged: run 29922521482 showed rescued retries but did not preserve the initiating error, so it remains a separately diagnosed follow-up rather than a speculative edit.

## Regression coverage and validation

Added deterministic Jest cases in `deploy/post_deploy_testing/cypress/support/utils/__tests__/dataMatrixUtils.test.js` for:

- documented 404/zero versus malformed/unexpected responses;
- valid hydrated Donor×Tissue without grouping-label spans;
- another valid hydrated matrix shape;
- empty pre-hydration, loading, refreshing, and overlay states being rejected;
- discovery count `20` / current count `12` converging on current `12`;
- persistent current UI/API `12/11` mismatch failing;
- invalid current bar counts failing.

Locally performed:

- `git diff --check` — passed.
- Node module-syntax checks for the three corrected files — passed.
- Direct deterministic probes: 2 valid + 4 invalid matrix states, discovery `20` → current `12`, persistent `12/11` failure, and invalid-count cases — passed.
- Verified the PR diff does not touch `03a_browse_by_file.cy.js`.

Focused Jest/ESLint were not runnable in this disposable checkout because `node_modules` is absent. Incompatible transient latest `npx` tooling was not installed or claimed as validation.

## Limitations

No staging login, secret use, remote-environment mutation, or workflow rerun was performed while making the run-feedback corrections. A subsequent authenticated Staging/Data Cypress execution is still required to validate real navbar timing, protected-role behavior, and matrix/chart interactions at head `312eb77d`.

## Risk and rollback

Changes are test-only. The bounded reconciliation retry adds latency only after mismatch. Dynamic sampling intentionally varies with available data but is deterministic for a rendered chart. Matrix readiness now depends on a shared component loading-class contract rather than mode-specific descendants. Revert commits `312eb77d`, `ddf2bb33`, and `a3b6957a` to roll back; there are no schema, data, or application changes.

## Follow-ups outside this draft

- Diagnose the rescued `03a` retry via exact Replay/error evidence before changing it.
- Evaluate `cy.session()` and per-spec test isolation separately after scheduled evidence.
- Consider a controlled data contract or split availability/data-shape suites.
