### PR TITLE
feat(user): admin-only control panel on User profile page

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,18 @@ smaht-portal
 Change Log
 ----------
 
+2.7.0
+=====
+
+* Add an admin-only control panel to the User profile page that lets administrators edit a
+  user's ``status``, ``groups``, and ``submits_for`` (submission centers) through searchable
+  controls, applied as a single atomic PATCH of only the changed fields after a confirmation
+  modal. The full ``status`` enum and all schema groups (including ``admin`` and
+  ``read-only-admin``) are exposed, and an admin may edit their own account (warn-only). The
+  panel is frontend-only: authorization is enforced by the existing backend
+  ``restricted_fields`` permission, and the client-side admin gate is cosmetic. The panel is
+  client-rendered only (never in server-rendered output).
+
 
 2.6.2
 =====

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "2.6.2"
+version = "2.7.0"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/__tests__/UserAdminControls.test.js
+++ b/src/encoded/static/components/__tests__/UserAdminControls.test.js
@@ -102,7 +102,10 @@ describe('userAdminHelpers - change detection', () => {
 
     it('detects a changed status', () => {
         expect(
-            isFieldChanged('status', original, { ...original, status: 'deleted' })
+            isFieldChanged('status', original, {
+                ...original,
+                status: 'deleted',
+            })
         ).toBe(true);
     });
 
@@ -186,7 +189,11 @@ describe('userAdminHelpers - buildUserPatchPayload', () => {
 
 describe('userAdminHelpers - diffUserFields', () => {
     it('produces from→to rows and maps submits_for @ids to labels', () => {
-        const original = { status: 'current', groups: [], submits_for: ['/a/'] };
+        const original = {
+            status: 'current',
+            groups: [],
+            submits_for: ['/a/'],
+        };
         const draft = {
             status: 'deleted',
             groups: ['admin'],
@@ -313,9 +320,12 @@ jest.mock('@hms-dbmi-bgm/shared-portal-components/es/components/util', () => ({
     JWT: { getUserDetails: () => ({ email: 'admin@example.com' }) },
 }));
 
-jest.mock('@hms-dbmi-bgm/shared-portal-components/es/components/ui/Alerts', () => ({
-    Alerts: { queue: jest.fn() },
-}));
+jest.mock(
+    '@hms-dbmi-bgm/shared-portal-components/es/components/ui/Alerts',
+    () => ({
+        Alerts: { queue: jest.fn() },
+    })
+);
 
 // react-bootstrap ships untranspiled ESM under node_modules (ignored by the
 // Babel transform); stub the Modal to a passthrough so the component imports.
@@ -346,7 +356,12 @@ describe('UserAdminControls - render', () => {
                 status: { enum: ['current', 'deleted', 'inactive', 'revoked'] },
                 groups: {
                     items: {
-                        enum: ['admin', 'read-only-admin', 'dbgap', 'public-dbgap'],
+                        enum: [
+                            'admin',
+                            'read-only-admin',
+                            'dbgap',
+                            'public-dbgap',
+                        ],
                     },
                 },
             },

--- a/src/encoded/static/components/__tests__/UserAdminControls.test.js
+++ b/src/encoded/static/components/__tests__/UserAdminControls.test.js
@@ -13,6 +13,7 @@ const {
     getStatusEnum,
     getGroupsEnum,
     extractUserBaseline,
+    draftFromBaseline,
     normalizeLinkArray,
     sameStringSet,
     isFieldChanged,
@@ -82,6 +83,40 @@ describe('userAdminHelpers - baseline normalization', () => {
     it('handles a user with no admin-editable fields set', () => {
         expect(extractUserBaseline({})).toEqual({
             status: '',
+            groups: [],
+            submits_for: [],
+        });
+    });
+});
+
+describe('userAdminHelpers - draftFromBaseline', () => {
+    it('copies scalar and array values from the baseline', () => {
+        const baseline = {
+            status: 'current',
+            groups: ['dbgap'],
+            submits_for: ['/a/'],
+        };
+        expect(draftFromBaseline(baseline)).toEqual(baseline);
+    });
+
+    it('clones arrays so draft never shares references with the baseline', () => {
+        const baseline = {
+            status: 'current',
+            groups: ['dbgap'],
+            submits_for: ['/a/'],
+        };
+        const draft = draftFromBaseline(baseline);
+        expect(draft.groups).not.toBe(baseline.groups);
+        expect(draft.submits_for).not.toBe(baseline.submits_for);
+    });
+
+    it('tolerates missing/undefined array fields', () => {
+        expect(draftFromBaseline({ status: 'current' })).toEqual({
+            status: 'current',
+            groups: [],
+            submits_for: [],
+        });
+        expect(draftFromBaseline(undefined)).toEqual({
             groups: [],
             submits_for: [],
         });

--- a/src/encoded/static/components/__tests__/UserAdminControls.test.js
+++ b/src/encoded/static/components/__tests__/UserAdminControls.test.js
@@ -466,3 +466,26 @@ describe('UserView admin gating (source invariants)', () => {
         expect(userViewSource).toContain("'col-12 col-lg-6 col-xl-5'");
     });
 });
+
+describe('UserAdminControls component structure', () => {
+    const userAdminControlsSource = fs.readFileSync(
+        path.resolve(
+            __dirname,
+            '../item-pages/components/user/UserAdminControls.js'
+        ),
+        'utf8'
+    );
+
+    it('uses a functional component with hooks for its lifecycle and state', () => {
+        expect(userAdminControlsSource).toContain(
+            'function UserAdminControls('
+        );
+        expect(userAdminControlsSource).toContain('useState');
+        expect(userAdminControlsSource).toContain('useEffect');
+        expect(userAdminControlsSource).not.toContain(
+            'class UserAdminControls'
+        );
+        expect(userAdminControlsSource).not.toContain('componentDidMount');
+        expect(userAdminControlsSource).not.toContain('this.handle');
+    });
+});

--- a/src/encoded/static/components/__tests__/UserAdminControls.test.js
+++ b/src/encoded/static/components/__tests__/UserAdminControls.test.js
@@ -1,0 +1,418 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import fs from 'fs';
+import path from 'path';
+
+// -------------------------------------------------------------------------
+// Pure helper tests — no mocks, no DOM. These carry the real behavioral
+// coverage (payload building, diffing, array-clear semantics) because the
+// interactive react-select behavior is not runnable under the default (node)
+// Jest environment.
+// -------------------------------------------------------------------------
+const {
+    getStatusEnum,
+    getGroupsEnum,
+    extractUserBaseline,
+    normalizeLinkArray,
+    sameStringSet,
+    isFieldChanged,
+    getChangedFields,
+    buildUserPatchPayload,
+    diffUserFields,
+    computeSubmitsForOptions,
+    computeChangeWarnings,
+    formatPatchError,
+    USER_STATUS_ENUM_FALLBACK,
+    USER_GROUPS_ENUM_FALLBACK,
+} = require('../item-pages/components/user/userAdminHelpers');
+
+describe('userAdminHelpers - schema enum extraction', () => {
+    it('reads status/groups enums from the merged schema', () => {
+        const schemas = {
+            User: {
+                properties: {
+                    status: { enum: ['current', 'deleted'] },
+                    groups: { items: { enum: ['admin', 'dbgap'] } },
+                },
+            },
+        };
+        expect(getStatusEnum(schemas)).toEqual(['current', 'deleted']);
+        expect(getGroupsEnum(schemas)).toEqual(['admin', 'dbgap']);
+    });
+
+    it('falls back to hard-coded enums when schema is missing them', () => {
+        expect(getStatusEnum(null)).toEqual(USER_STATUS_ENUM_FALLBACK);
+        expect(getGroupsEnum({})).toEqual(USER_GROUPS_ENUM_FALLBACK);
+        expect(USER_STATUS_ENUM_FALLBACK).toEqual([
+            'current',
+            'deleted',
+            'inactive',
+            'revoked',
+        ]);
+        expect(USER_GROUPS_ENUM_FALLBACK).toEqual([
+            'admin',
+            'read-only-admin',
+            'dbgap',
+            'public-dbgap',
+        ]);
+    });
+});
+
+describe('userAdminHelpers - baseline normalization', () => {
+    it('normalizes a linkTo array from strings and embedded objects', () => {
+        expect(
+            normalizeLinkArray(['/a/', { '@id': '/b/' }, { atId: '/c/' }, {}])
+        ).toEqual(['/a/', '/b/', '/c/']);
+        expect(normalizeLinkArray(undefined)).toEqual([]);
+    });
+
+    it('extracts a clean scalar/@id-array baseline from an embedded user', () => {
+        const embedded = {
+            status: 'current',
+            groups: ['dbgap'],
+            submits_for: [{ '@id': '/submission-centers/x/' }],
+        };
+        expect(extractUserBaseline(embedded)).toEqual({
+            status: 'current',
+            groups: ['dbgap'],
+            submits_for: ['/submission-centers/x/'],
+        });
+    });
+
+    it('handles a user with no admin-editable fields set', () => {
+        expect(extractUserBaseline({})).toEqual({
+            status: '',
+            groups: [],
+            submits_for: [],
+        });
+    });
+});
+
+describe('userAdminHelpers - change detection', () => {
+    const original = {
+        status: 'current',
+        groups: ['dbgap'],
+        submits_for: ['/a/', '/b/'],
+    };
+
+    it('sameStringSet is order-insensitive', () => {
+        expect(sameStringSet(['/a/', '/b/'], ['/b/', '/a/'])).toBe(true);
+        expect(sameStringSet(['/a/'], ['/a/', '/b/'])).toBe(false);
+    });
+
+    it('detects a changed status', () => {
+        expect(
+            isFieldChanged('status', original, { ...original, status: 'deleted' })
+        ).toBe(true);
+    });
+
+    it('treats reordered arrays as unchanged', () => {
+        expect(
+            isFieldChanged('submits_for', original, {
+                ...original,
+                submits_for: ['/b/', '/a/'],
+            })
+        ).toBe(false);
+    });
+
+    it('getChangedFields returns only the differing fields', () => {
+        const draft = {
+            status: 'deleted',
+            groups: ['dbgap', 'admin'],
+            submits_for: ['/a/', '/b/'],
+        };
+        expect(getChangedFields(original, draft).sort()).toEqual([
+            'groups',
+            'status',
+        ]);
+    });
+});
+
+describe('userAdminHelpers - buildUserPatchPayload', () => {
+    const original = {
+        status: 'current',
+        groups: ['dbgap'],
+        submits_for: ['/a/'],
+    };
+
+    it('includes only changed keys', () => {
+        expect(
+            buildUserPatchPayload(original, { ...original, status: 'deleted' })
+        ).toEqual({ status: 'deleted' });
+    });
+
+    it('returns {} when nothing changed (toggle back to original)', () => {
+        expect(
+            buildUserPatchPayload(original, {
+                status: 'current',
+                groups: ['dbgap'],
+                submits_for: ['/a/'],
+            })
+        ).toEqual({});
+    });
+
+    it('sends the full replacement array when adding a submits_for center', () => {
+        expect(
+            buildUserPatchPayload(original, {
+                ...original,
+                submits_for: ['/a/', '/b/'],
+            })
+        ).toEqual({ submits_for: ['/a/', '/b/'] });
+    });
+
+    it('emits an empty array to clear a field (safe clear via wholesale replace)', () => {
+        expect(
+            buildUserPatchPayload(original, { ...original, submits_for: [] })
+        ).toEqual({ submits_for: [] });
+        expect(
+            buildUserPatchPayload(original, { ...original, groups: [] })
+        ).toEqual({ groups: [] });
+    });
+
+    it('accumulates multiple simultaneous changes into one payload', () => {
+        expect(
+            buildUserPatchPayload(original, {
+                status: 'inactive',
+                groups: ['dbgap', 'admin'],
+                submits_for: [],
+            })
+        ).toEqual({
+            status: 'inactive',
+            groups: ['dbgap', 'admin'],
+            submits_for: [],
+        });
+    });
+});
+
+describe('userAdminHelpers - diffUserFields', () => {
+    it('produces from→to rows and maps submits_for @ids to labels', () => {
+        const original = { status: 'current', groups: [], submits_for: ['/a/'] };
+        const draft = {
+            status: 'deleted',
+            groups: ['admin'],
+            submits_for: ['/a/', '/b/'],
+        };
+        const labelMap = { '/a/': 'Center A', '/b/': 'Center B' };
+        const rows = diffUserFields(original, draft, labelMap);
+        const byField = Object.fromEntries(rows.map((r) => [r.field, r]));
+        expect(byField.status).toEqual({
+            field: 'status',
+            from: 'current',
+            to: 'deleted',
+        });
+        expect(byField.groups).toEqual({
+            field: 'groups',
+            from: '(none)',
+            to: 'admin',
+        });
+        expect(byField.submits_for).toEqual({
+            field: 'submits_for',
+            from: 'Center A',
+            to: 'Center A, Center B',
+        });
+    });
+});
+
+describe('userAdminHelpers - computeSubmitsForOptions', () => {
+    it('maps @graph to options + labelMap and sorts by label', () => {
+        const { options, labelMap } = computeSubmitsForOptions([
+            { '@id': '/b/', display_title: 'Beta' },
+            { '@id': '/a/', display_title: 'Alpha' },
+            { display_title: 'no-id-dropped' },
+        ]);
+        expect(options).toEqual([
+            { value: '/a/', label: 'Alpha' },
+            { value: '/b/', label: 'Beta' },
+        ]);
+        expect(labelMap).toEqual({ '/a/': 'Alpha', '/b/': 'Beta' });
+    });
+});
+
+describe('userAdminHelpers - computeChangeWarnings', () => {
+    const original = { status: 'current', groups: [], submits_for: [] };
+
+    it('warns on delete/revoke status', () => {
+        const w = computeChangeWarnings(
+            original,
+            { ...original, status: 'deleted' },
+            false
+        );
+        expect(w.join(' ')).toContain('removes the user');
+    });
+
+    it('warns on granting admin', () => {
+        const w = computeChangeWarnings(
+            original,
+            { ...original, groups: ['admin'] },
+            false
+        );
+        expect(w.join(' ')).toContain('administrative privileges');
+    });
+
+    it('warns when editing own account', () => {
+        const w = computeChangeWarnings(
+            original,
+            { ...original, status: 'inactive' },
+            true
+        );
+        expect(w.join(' ')).toContain('your own account');
+    });
+
+    it('emits no warnings for a benign change to another user', () => {
+        expect(
+            computeChangeWarnings(
+                original,
+                { ...original, groups: ['dbgap'] },
+                false
+            )
+        ).toEqual([]);
+    });
+});
+
+describe('userAdminHelpers - formatPatchError', () => {
+    it('joins snovault validation errors', () => {
+        expect(
+            formatPatchError({
+                errors: [{ description: 'bad status' }, { name: 'oops' }],
+            })
+        ).toBe('bad status; oops');
+    });
+    it('falls back to detail', () => {
+        expect(formatPatchError({ detail: 'nope' })).toBe('nope');
+    });
+    it('handles empty input', () => {
+        expect(formatPatchError(null)).toContain('unknown');
+    });
+});
+
+// -------------------------------------------------------------------------
+// Render test — mock react-select (v5 pulls in emotion/DOM) and SPC so the
+// component imports under the node test environment. componentDidMount does
+// NOT run under renderToStaticMarkup, so the panel renders from the
+// embedded-context baseline set in the constructor.
+// -------------------------------------------------------------------------
+jest.mock('react-select', () => (props) => {
+    const React = require('react');
+    // Render selected values so assertions can see them.
+    const value = props.value;
+    const asText = Array.isArray(value)
+        ? value.map((v) => v.label).join(',')
+        : value
+        ? value.label
+        : '';
+    return React.createElement(
+        'div',
+        { 'data-testid': 'select', 'data-input-id': props.inputId },
+        asText
+    );
+});
+
+jest.mock('@hms-dbmi-bgm/shared-portal-components/es/components/util', () => ({
+    ajax: { load: jest.fn() },
+    navigate: jest.fn(),
+    JWT: { getUserDetails: () => ({ email: 'admin@example.com' }) },
+}));
+
+jest.mock('@hms-dbmi-bgm/shared-portal-components/es/components/ui/Alerts', () => ({
+    Alerts: { queue: jest.fn() },
+}));
+
+// react-bootstrap ships untranspiled ESM under node_modules (ignored by the
+// Babel transform); stub the Modal to a passthrough so the component imports.
+jest.mock('react-bootstrap/esm/Modal', () => {
+    const React = require('react');
+    const Modal = ({ children }) => React.createElement('div', null, children);
+    Modal.Header = ({ children }) => React.createElement('div', null, children);
+    Modal.Title = ({ children }) => React.createElement('div', null, children);
+    Modal.Body = ({ children }) => React.createElement('div', null, children);
+    Modal.Footer = ({ children }) => React.createElement('div', null, children);
+    return { __esModule: true, default: Modal };
+});
+
+describe('UserAdminControls - render', () => {
+    const UserAdminControls =
+        require('../item-pages/components/user/UserAdminControls').default;
+
+    const user = {
+        '@id': '/users/abc/',
+        email: 'target@example.com',
+        status: 'current',
+        groups: ['dbgap'],
+        submits_for: [{ '@id': '/sc/1/', display_title: 'Center One' }],
+    };
+    const schemas = {
+        User: {
+            properties: {
+                status: { enum: ['current', 'deleted', 'inactive', 'revoked'] },
+                groups: {
+                    items: {
+                        enum: ['admin', 'read-only-admin', 'dbgap', 'public-dbgap'],
+                    },
+                },
+            },
+        },
+    };
+
+    it('renders the admin panel with three controls seeded from context', () => {
+        const html = renderToStaticMarkup(
+            <UserAdminControls
+                user={user}
+                schemas={schemas}
+                mayEdit={true}
+                onUpdated={jest.fn()}
+            />
+        );
+        expect(html).toContain('data-testid="user-admin-controls"');
+        expect(html).toContain('data-input-id="user-admin-status"');
+        expect(html).toContain('data-input-id="user-admin-groups"');
+        expect(html).toContain('data-input-id="user-admin-submits-for"');
+        // Selected values reflect the user's current fields.
+        expect(html).toContain('current'); // status
+        expect(html).toContain('dbgap'); // groups
+        expect(html).toContain('Center One'); // submits_for label from embedded ctx
+    });
+
+    it('shows the full-edit link only when mayEdit', () => {
+        const withEdit = renderToStaticMarkup(
+            <UserAdminControls user={user} schemas={schemas} mayEdit={true} />
+        );
+        expect(withEdit).toContain('Open full edit page');
+        const noEdit = renderToStaticMarkup(
+            <UserAdminControls user={user} schemas={schemas} mayEdit={false} />
+        );
+        expect(noEdit).not.toContain('Open full edit page');
+    });
+});
+
+// -------------------------------------------------------------------------
+// Guard test for the non-admin path: assert UserView keeps the original,
+// byte-identical column classNames and gates the panel behind an admin check.
+// A source-string assertion (like BrowseDonorPeekMetadata.test.js) avoids
+// importing UserView's heavy dependency tree.
+// -------------------------------------------------------------------------
+describe('UserView admin gating (source invariants)', () => {
+    const userViewSource = fs.readFileSync(
+        path.resolve(__dirname, '../item-pages/UserView.js'),
+        'utf8'
+    );
+
+    it('gates the admin panel behind the isAdmin state and renders it only then', () => {
+        expect(userViewSource).toContain(
+            "import UserAdminControls from './components/user/UserAdminControls';"
+        );
+        expect(userViewSource).toContain('isAdmin ? (');
+        expect(userViewSource).toContain('<UserAdminControls');
+    });
+
+    it('resolves isAdmin after mount (no SSR hydration mismatch)', () => {
+        expect(userViewSource).toContain('componentDidMount()');
+        expect(userViewSource).toContain("groups.indexOf('admin')");
+    });
+
+    it('keeps the non-admin column classNames byte-identical to the pre-feature layout', () => {
+        expect(userViewSource).toContain(
+            "'col-12 col-lg-6 col-xl-7 mb-2 mb-lg-0'"
+        );
+        expect(userViewSource).toContain("'col-12 col-lg-6 col-xl-5'");
+    });
+});

--- a/src/encoded/static/components/item-pages/UserView.js
+++ b/src/encoded/static/components/item-pages/UserView.js
@@ -29,6 +29,7 @@ import {
     pageTitleViews,
 } from './../PageTitleSection';
 import { Term } from './../util/Schemas';
+import UserAdminControls from './components/user/UserAdminControls';
 
 // eslint-disable-next-line no-unused-vars
 import { Item } from './../util/typedefs';
@@ -523,6 +524,24 @@ export default class UserView extends React.Component {
         }),
     };
 
+    constructor(props) {
+        super(props);
+        // `isAdmin` gates the cosmetic admin control panel only. It is resolved
+        // after mount (JWT groups live in localStorage, absent during SSR) so
+        // the first client render matches the server render for everyone and
+        // the panel appears on the following commit — avoiding a structural
+        // hydration mismatch. Backend `restricted_fields` permissions are the
+        // real authorization for any edit made through the panel.
+        this.state = { isAdmin: false };
+    }
+
+    componentDidMount() {
+        const groups = JWT.getUserGroups() || [];
+        if (groups.indexOf('admin') >= 0) {
+            this.setState({ isAdmin: true });
+        }
+    }
+
     mayEdit() {
         const { context } = this.props;
         return _.any((context && context.actions) || [], function (action) {
@@ -539,7 +558,19 @@ export default class UserView extends React.Component {
             alerts = [],
         } = this.props;
         const { email, project } = user;
+        const { isAdmin } = this.state;
         const mayEdit = this.mayEdit();
+
+        // Non-admin column classes are kept byte-identical to the pre-feature
+        // layout so the non-admin render tree is unchanged. When admin, the two
+        // existing cards shrink and an Admin Controls panel is added as a third
+        // sibling column (5 + 4 + 3 = 12).
+        const infoColCls = isAdmin
+            ? 'col-12 col-xl-5 mb-2 mb-xl-0'
+            : 'col-12 col-lg-6 col-xl-7 mb-2 mb-lg-0';
+        const workColCls = isAdmin
+            ? 'col-12 col-xl-4 mb-2 mb-xl-0'
+            : 'col-12 col-lg-6 col-xl-5';
         // Todo: remove
         const ifCurrentlyEditingClass =
             this.state && this.state.currentlyEditing
@@ -567,7 +598,7 @@ export default class UserView extends React.Component {
                             />
                         </div>
                         <div className="row">
-                            <div className="col-12 col-lg-6 col-xl-7 mb-2 mb-lg-0">
+                            <div className={infoColCls}>
                                 <div className="user-info card h-100">
                                     <div className="card-header">
                                         <div className="row title-row align-items-center py-2">
@@ -627,9 +658,19 @@ export default class UserView extends React.Component {
                                     </div>
                                 </div>
                             </div>
-                            <div className="col-12 col-lg-6 col-xl-5">
+                            <div className={workColCls}>
                                 <ProfileWorkFields user={user} />
                             </div>
+                            {isAdmin ? (
+                                <div className="col-12 col-xl-3">
+                                    <UserAdminControls
+                                        user={user}
+                                        schemas={schemas}
+                                        mayEdit={mayEdit}
+                                        onUpdated={UserView.onEditableFieldSave}
+                                    />
+                                </div>
+                            ) : null}
                         </div>
 
                         <SyncedAccessKeyTable {...{ user }} />

--- a/src/encoded/static/components/item-pages/components/user/UserAdminControls.js
+++ b/src/encoded/static/components/item-pages/components/user/UserAdminControls.js
@@ -1,5 +1,11 @@
 'use strict';
 
+/**
+ * Admin-only control panel for the User profile page.
+ *
+ * @module item-pages/components/user/UserAdminControls
+ */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'underscore';
@@ -70,7 +76,7 @@ const LOAD = { loading: 1, loaded: 2, failed: 3 };
  * validator on all three fields — a non-admin who forges this panel still
  * cannot PATCH them.
  *
- * @memberof module:item-pages/components/user
+ * @memberof module:item-pages/components/user/UserAdminControls
  */
 export default class UserAdminControls extends React.Component {
     static propTypes = {
@@ -123,7 +129,11 @@ export default class UserAdminControls extends React.Component {
         this.state = {
             baselineStatus: LOAD.loading,
             original: baseline,
-            draft: { ...baseline, groups: baseline.groups.slice(), submits_for: baseline.submits_for.slice() },
+            draft: {
+                ...baseline,
+                groups: baseline.groups.slice(),
+                submits_for: baseline.submits_for.slice(),
+            },
             scOptions: [],
             scLabelMap: initialLabelMap,
             scStatus: LOAD.loading,
@@ -375,7 +385,9 @@ export default class UserAdminControls extends React.Component {
         const warnings = computeChangeWarnings(original, draft, isSelf);
 
         return (
-            <div className="user-admin-controls card h-100" data-testid="user-admin-controls">
+            <div
+                className="user-admin-controls card h-100"
+                data-testid="user-admin-controls">
                 <div className="card-header">
                     <h3 className="block-title">
                         <i className="icon icon-user-shield fas icon-fw me-12" />

--- a/src/encoded/static/components/item-pages/components/user/UserAdminControls.js
+++ b/src/encoded/static/components/item-pages/components/user/UserAdminControls.js
@@ -186,6 +186,7 @@ export default class UserAdminControls extends React.Component {
         // `embedded.@id` and `embedded.@type` to the requested fields
         // (snovault/search/search.py `list_source_fields`), so each result
         // still carries the `@id` that computeSubmitsForOptions needs.
+        this.setState({ scStatus: LOAD.loading });
         ajax.load(
             '/search/?type=SubmissionCenter&limit=all&field=display_title&field=identifier',
             (resp) => {

--- a/src/encoded/static/components/item-pages/components/user/UserAdminControls.js
+++ b/src/encoded/static/components/item-pages/components/user/UserAdminControls.js
@@ -1,0 +1,553 @@
+'use strict';
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import _ from 'underscore';
+import Modal from 'react-bootstrap/esm/Modal';
+import Select from 'react-select';
+
+import {
+    ajax,
+    navigate,
+    JWT,
+} from '@hms-dbmi-bgm/shared-portal-components/es/components/util';
+import { Alerts } from '@hms-dbmi-bgm/shared-portal-components/es/components/ui/Alerts';
+
+import {
+    getStatusEnum,
+    getGroupsEnum,
+    extractUserBaseline,
+    buildUserPatchPayload,
+    diffUserFields,
+    getChangedFields,
+    computeSubmitsForOptions,
+    computeChangeWarnings,
+    formatPatchError,
+} from './userAdminHelpers';
+
+/**
+ * react-select styling, kept local to avoid importing from the viz tree (which
+ * pulls d3 into this chunk). Mirrors `customReactSelectStyleMulti` used
+ * elsewhere in the repo for visual consistency.
+ */
+const reactSelectStyles = {
+    control: (provided, state) => {
+        return {
+            ...provided,
+            fontSize: '0.875rem',
+            borderColor: state.isFocused ? 'blue' : '#dee2e6',
+            boxShadow: state.isFocused ? '0 0 0 1px blue' : 'none',
+        };
+    },
+    valueContainer: (provided) => {
+        return { ...provided, padding: '0 6px' };
+    },
+    input: (provided) => {
+        return { ...provided, margin: '0', padding: '0' };
+    },
+    menu: (provided) => {
+        return { ...provided, marginTop: '0px' };
+    },
+    option: (provided) => {
+        return { ...provided, fontSize: '0.875rem', padding: '4px 10px' };
+    },
+    multiValue: (provided) => {
+        return { ...provided, backgroundColor: '#f2f2f2' };
+    },
+};
+
+const LOAD = { loading: 1, loaded: 2, failed: 3 };
+
+/**
+ * Admin-only right-side control panel on the User profile page. Renders three
+ * searchable controls (status enum, groups multi-select, submits_for
+ * SubmissionCenter multi-select), accumulates pending changes, confirms them in
+ * a modal, and applies them as a single atomic PATCH through the standard
+ * `ajax.load(... 'PATCH' ...)` convention.
+ *
+ * Visibility is gated cosmetically by the caller (`UserView`, on the client
+ * admin group check). Real authorization is the backend `restricted_fields`
+ * validator on all three fields — a non-admin who forges this panel still
+ * cannot PATCH them.
+ *
+ * @memberof module:item-pages/components/user
+ */
+export default class UserAdminControls extends React.Component {
+    static propTypes = {
+        user: PropTypes.object.isRequired,
+        schemas: PropTypes.object,
+        mayEdit: PropTypes.bool,
+        /** Called with the freshly re-fetched embedded user on save success. */
+        onUpdated: PropTypes.func,
+    };
+
+    static defaultProps = {
+        schemas: null,
+        mayEdit: false,
+        onUpdated: null,
+    };
+
+    constructor(props) {
+        super(props);
+        _.bindAll(
+            this,
+            'loadBaseline',
+            'loadSubmissionCenters',
+            'handleStatusChange',
+            'handleGroupsChange',
+            'handleSubmitsForChange',
+            'openConfirm',
+            'closeConfirm',
+            'handleSave',
+            'onPatchSuccess',
+            'onPatchError'
+        );
+
+        // Derive an initial baseline synchronously from the embedded context so
+        // the controls render populated before the object-frame fetch returns.
+        const baseline = extractUserBaseline(props.user);
+        // Seed submits_for chip labels from the embedded context so chips show
+        // display titles immediately; the SubmissionCenter search fetch
+        // augments this with the full option list on mount.
+        const initialLabelMap = {};
+        const embeddedSubmits =
+            props.user && Array.isArray(props.user.submits_for)
+                ? props.user.submits_for
+                : [];
+        embeddedSubmits.forEach((sc) => {
+            if (sc && typeof sc === 'object' && sc['@id']) {
+                initialLabelMap[sc['@id']] =
+                    sc.display_title || sc.identifier || sc['@id'];
+            }
+        });
+        this.state = {
+            baselineStatus: LOAD.loading,
+            original: baseline,
+            draft: { ...baseline, groups: baseline.groups.slice(), submits_for: baseline.submits_for.slice() },
+            scOptions: [],
+            scLabelMap: initialLabelMap,
+            scStatus: LOAD.loading,
+            showConfirm: false,
+            saving: false,
+        };
+    }
+
+    componentDidMount() {
+        this.loadBaseline();
+        this.loadSubmissionCenters();
+    }
+
+    /**
+     * Fetch the object frame for clean scalar / `@id`-array baseline values to
+     * diff and PATCH against (the embedded context nests linkTos as objects).
+     */
+    loadBaseline() {
+        const { user } = this.props;
+        const atId = user && user['@id'];
+        if (!atId) {
+            this.setState({ baselineStatus: LOAD.failed });
+            return;
+        }
+        ajax.load(
+            atId + '?frame=object',
+            (resp) => {
+                const original = extractUserBaseline(resp);
+                this.setState((prev) => {
+                    // Don't clobber selections the admin already made before
+                    // this fetch returned: reset the draft only when nothing
+                    // is pending.
+                    const pending =
+                        getChangedFields(prev.original, prev.draft).length > 0;
+                    return {
+                        baselineStatus: LOAD.loaded,
+                        original,
+                        draft: pending
+                            ? prev.draft
+                            : {
+                                ...original,
+                                groups: original.groups.slice(),
+                                submits_for: original.submits_for.slice(),
+                            },
+                    };
+                });
+            },
+            'GET',
+            () => {
+                // Keep the embedded-derived baseline already in state; just
+                // note the object-frame refresh failed (surfaced in render).
+                this.setState({ baselineStatus: LOAD.failed });
+            }
+        );
+    }
+
+    /** Load the bounded set of SubmissionCenters for the submits_for options. */
+    loadSubmissionCenters() {
+        // `field=` restricts the returned _source; snovault always force-adds
+        // `embedded.@id` and `embedded.@type` to the requested fields
+        // (snovault/search/search.py `list_source_fields`), so each result
+        // still carries the `@id` that computeSubmitsForOptions needs.
+        ajax.load(
+            '/search/?type=SubmissionCenter&limit=all&field=display_title&field=identifier',
+            (resp) => {
+                const { options, labelMap } = computeSubmitsForOptions(
+                    (resp && resp['@graph']) || []
+                );
+                // Ensure any @ids already on the user (but absent from search,
+                // e.g. a deleted center) still have a chip label from the
+                // embedded context.
+                const { user } = this.props;
+                (user && Array.isArray(user.submits_for)
+                    ? user.submits_for
+                    : []
+                ).forEach((sc) => {
+                    if (sc && typeof sc === 'object' && sc['@id']) {
+                        if (!labelMap[sc['@id']]) {
+                            labelMap[sc['@id']] =
+                                sc.display_title || sc.identifier || sc['@id'];
+                        }
+                    }
+                });
+                this.setState({
+                    scOptions: options,
+                    scLabelMap: labelMap,
+                    scStatus: LOAD.loaded,
+                });
+            },
+            'GET',
+            () => {
+                this.setState({ scStatus: LOAD.failed });
+            }
+        );
+    }
+
+    handleStatusChange(option) {
+        const status = option ? option.value : '';
+        this.setState(({ draft }) => {
+            return { draft: { ...draft, status } };
+        });
+    }
+
+    handleGroupsChange(selected) {
+        const groups = (selected || []).map((o) => o.value);
+        this.setState(({ draft }) => {
+            return { draft: { ...draft, groups } };
+        });
+    }
+
+    handleSubmitsForChange(selected) {
+        const submits_for = (selected || []).map((o) => o.value);
+        this.setState(({ draft }) => {
+            return { draft: { ...draft, submits_for } };
+        });
+    }
+
+    openConfirm() {
+        this.setState({ showConfirm: true });
+    }
+
+    closeConfirm() {
+        const { saving } = this.state;
+        if (saving) return;
+        this.setState({ showConfirm: false });
+    }
+
+    handleSave() {
+        const { user } = this.props;
+        const { original, draft } = this.state;
+        const payload = buildUserPatchPayload(original, draft);
+        if (Object.keys(payload).length === 0) return;
+
+        this.setState({ saving: true });
+        ajax.load(
+            user['@id'],
+            this.onPatchSuccess,
+            'PATCH',
+            this.onPatchError,
+            JSON.stringify(payload)
+        );
+    }
+
+    onPatchSuccess(resp) {
+        const { user, onUpdated } = this.props;
+        if (!resp || resp.status !== 'success') {
+            this.onPatchError(resp);
+            return;
+        }
+        // Do NOT dispatch the PATCH @graph[0] (object frame, no embeds).
+        // Re-GET the embedded frame to reconcile the on-page display, then
+        // reset the baseline so a subsequent save diffs against fresh values.
+        ajax.load(
+            user['@id'],
+            (embeddedResp) => {
+                if (typeof onUpdated === 'function') {
+                    onUpdated(embeddedResp);
+                }
+                const original = extractUserBaseline(embeddedResp);
+                this.setState({
+                    original,
+                    draft: {
+                        ...original,
+                        groups: original.groups.slice(),
+                        submits_for: original.submits_for.slice(),
+                    },
+                    saving: false,
+                    showConfirm: false,
+                });
+                Alerts.queue({
+                    title: 'User updated',
+                    message: 'The user account was updated successfully.',
+                    style: 'success',
+                });
+            },
+            'GET',
+            () => {
+                // PATCH succeeded but the reconciling re-GET failed. Keep the
+                // panel usable; surface a soft warning and reset the baseline
+                // from the draft we just persisted.
+                this.setState(({ draft }) => {
+                    return {
+                        original: {
+                            status: draft.status,
+                            groups: draft.groups.slice(),
+                            submits_for: draft.submits_for.slice(),
+                        },
+                        saving: false,
+                        showConfirm: false,
+                    };
+                });
+                Alerts.queue({
+                    title: 'User updated',
+                    message:
+                        'Changes were saved, but the page could not be refreshed automatically. Reload to see the latest values.',
+                    style: 'warning',
+                });
+            }
+        );
+    }
+
+    onPatchError(errorResp) {
+        // Keep pending draft intact so the admin can fix and retry.
+        this.setState({ saving: false, showConfirm: false });
+        Alerts.queue({
+            title: 'Update failed',
+            message: formatPatchError(errorResp),
+            style: 'danger',
+        });
+    }
+
+    render() {
+        const { user, schemas, mayEdit } = this.props;
+        const {
+            original,
+            draft,
+            scOptions,
+            scLabelMap,
+            scStatus,
+            baselineStatus,
+            showConfirm,
+            saving,
+        } = this.state;
+
+        const statusEnum = getStatusEnum(schemas);
+        const groupsEnum = getGroupsEnum(schemas);
+
+        const toOption = (v) => {
+            return { value: v, label: v };
+        };
+        const statusOptions = statusEnum.map(toOption);
+        const groupOptions = groupsEnum.map(toOption);
+
+        const selectedStatus =
+            statusOptions.find((o) => o.value === draft.status) || null;
+        const selectedGroups = (draft.groups || []).map(toOption);
+        const selectedSubmitsFor = (draft.submits_for || []).map((v) => {
+            return { value: v, label: scLabelMap[v] || v };
+        });
+
+        const changedFields = getChangedFields(original, draft);
+        const hasChanges = changedFields.length > 0;
+
+        const myDetails = JWT.getUserDetails() || {};
+        const isSelf =
+            !!myDetails.email && !!user.email && myDetails.email === user.email;
+        const diffRows = diffUserFields(original, draft, scLabelMap);
+        const warnings = computeChangeWarnings(original, draft, isSelf);
+
+        return (
+            <div className="user-admin-controls card h-100" data-testid="user-admin-controls">
+                <div className="card-header">
+                    <h3 className="block-title">
+                        <i className="icon icon-user-shield fas icon-fw me-12" />
+                        Admin Controls
+                    </h3>
+                </div>
+                <div className="card-body">
+                    {mayEdit ? (
+                        <div className="mb-3">
+                            <button
+                                type="button"
+                                className="btn btn-outline-secondary btn-sm w-100"
+                                onClick={() =>
+                                    navigate(
+                                        user['@id'] + '?currentAction=edit'
+                                    )
+                                }>
+                                <i className="icon icon-pencil-alt fas me-06" />
+                                Open full edit page
+                            </button>
+                        </div>
+                    ) : null}
+
+                    <div className="form-group mb-3">
+                        <label
+                            htmlFor="user-admin-status"
+                            className="text-500 mb-1">
+                            Status
+                        </label>
+                        <Select
+                            inputId="user-admin-status"
+                            aria-label="User status"
+                            styles={reactSelectStyles}
+                            options={statusOptions}
+                            value={selectedStatus}
+                            onChange={this.handleStatusChange}
+                            isDisabled={saving}
+                        />
+                    </div>
+
+                    <div className="form-group mb-3">
+                        <label
+                            htmlFor="user-admin-groups"
+                            className="text-500 mb-1">
+                            Groups
+                        </label>
+                        <Select
+                            inputId="user-admin-groups"
+                            aria-label="User groups"
+                            isMulti
+                            closeMenuOnSelect={false}
+                            styles={reactSelectStyles}
+                            options={groupOptions}
+                            value={selectedGroups}
+                            onChange={this.handleGroupsChange}
+                            placeholder="No groups"
+                            isDisabled={saving}
+                        />
+                    </div>
+
+                    <div className="form-group mb-3">
+                        <label
+                            htmlFor="user-admin-submits-for"
+                            className="text-500 mb-1">
+                            Submits for
+                        </label>
+                        <Select
+                            inputId="user-admin-submits-for"
+                            aria-label="Submits for submission centers"
+                            isMulti
+                            closeMenuOnSelect={false}
+                            styles={reactSelectStyles}
+                            options={scOptions}
+                            value={selectedSubmitsFor}
+                            onChange={this.handleSubmitsForChange}
+                            isLoading={scStatus === LOAD.loading}
+                            placeholder={
+                                scStatus === LOAD.failed
+                                    ? 'Failed to load submission centers'
+                                    : 'Select submission center(s)'
+                            }
+                            noOptionsMessage={() =>
+                                scStatus === LOAD.failed
+                                    ? 'Failed to load submission centers'
+                                    : 'No submission centers found'
+                            }
+                            isDisabled={saving}
+                        />
+                        {scStatus === LOAD.failed ? (
+                            <div className="text-danger small mt-1">
+                                Could not load submission centers.{' '}
+                                <button
+                                    type="button"
+                                    className="btn btn-link btn-sm p-0 align-baseline"
+                                    onClick={this.loadSubmissionCenters}>
+                                    Retry
+                                </button>
+                            </div>
+                        ) : null}
+                    </div>
+
+                    {baselineStatus === LOAD.failed ? (
+                        <div className="text-warning small mb-2">
+                            <i className="icon icon-exclamation-triangle fas me-06" />
+                            Could not refresh the latest values; editing against
+                            the values shown on the page.
+                        </div>
+                    ) : null}
+
+                    <div className="mt-3">
+                        <button
+                            type="button"
+                            className="btn btn-primary w-100"
+                            disabled={!hasChanges || saving}
+                            onClick={this.openConfirm}>
+                            Save changes
+                        </button>
+                    </div>
+                </div>
+
+                {showConfirm ? (
+                    <Modal show onHide={this.closeConfirm}>
+                        <Modal.Header closeButton>
+                            <Modal.Title className="text-400">
+                                Confirm user changes
+                            </Modal.Title>
+                        </Modal.Header>
+                        <Modal.Body>
+                            <p className="text-500">
+                                The following changes will be applied to{' '}
+                                <span className="text-600">{user.email}</span>:
+                            </p>
+                            <ul className="list-unstyled">
+                                {diffRows.map((row) => (
+                                    <li key={row.field} className="mb-1">
+                                        <span className="text-500">
+                                            {row.field}
+                                        </span>
+                                        : <code>{row.from}</code>
+                                        {' → '}
+                                        <code>{row.to}</code>
+                                    </li>
+                                ))}
+                            </ul>
+                            {warnings.length ? (
+                                <div className="alert alert-warning py-2 mb-0">
+                                    <ul className="mb-0 ps-3">
+                                        {warnings.map((w, i) => (
+                                            <li key={i}>{w}</li>
+                                        ))}
+                                    </ul>
+                                </div>
+                            ) : null}
+                        </Modal.Body>
+                        <Modal.Footer>
+                            <button
+                                type="button"
+                                className="btn btn-outline-secondary"
+                                onClick={this.closeConfirm}
+                                disabled={saving}>
+                                Cancel
+                            </button>
+                            <button
+                                type="button"
+                                className="btn btn-primary"
+                                onClick={this.handleSave}
+                                disabled={saving}>
+                                {saving ? 'Saving…' : 'Confirm'}
+                            </button>
+                        </Modal.Footer>
+                    </Modal>
+                ) : null}
+            </div>
+        );
+    }
+}

--- a/src/encoded/static/components/item-pages/components/user/UserAdminControls.js
+++ b/src/encoded/static/components/item-pages/components/user/UserAdminControls.js
@@ -6,9 +6,8 @@
  * @module item-pages/components/user/UserAdminControls
  */
 
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import _ from 'underscore';
 import Modal from 'react-bootstrap/esm/Modal';
 import Select from 'react-select';
 
@@ -68,6 +67,36 @@ const noSubmissionCenters = () => 'No submission centers found';
 const submissionCentersFailed = () => 'Failed to load submission centers';
 
 /**
+ * Derive the initial state synchronously from the embedded context so the
+ * controls render populated before the object-frame fetch returns.
+ */
+function getInitialState(user) {
+    const baseline = extractUserBaseline(user);
+    // Seed submits_for chip labels from the embedded context so chips show
+    // display titles immediately; the SubmissionCenter search fetch augments
+    // this with the full option list on mount.
+    const initialLabelMap = {};
+    const embeddedSubmits =
+        user && Array.isArray(user.submits_for) ? user.submits_for : [];
+    embeddedSubmits.forEach((sc) => {
+        if (sc && typeof sc === 'object' && sc['@id']) {
+            initialLabelMap[sc['@id']] =
+                sc.display_title || sc.identifier || sc['@id'];
+        }
+    });
+    return {
+        baselineStatus: LOAD.loading,
+        original: baseline,
+        draft: draftFromBaseline(baseline),
+        scOptions: [],
+        scLabelMap: initialLabelMap,
+        scStatus: LOAD.loading,
+        showConfirm: false,
+        saving: false,
+    };
+}
+
+/**
  * Admin-only right-side control panel on the User profile page. Renders three
  * searchable controls (status enum, groups multi-select, submits_for
  * SubmissionCenter multi-select), accumulates pending changes, confirms them in
@@ -81,98 +110,52 @@ const submissionCentersFailed = () => 'Failed to load submission centers';
  *
  * @memberof module:item-pages/components/user/UserAdminControls
  */
-export default class UserAdminControls extends React.Component {
-    static propTypes = {
-        user: PropTypes.object.isRequired,
-        schemas: PropTypes.object,
-        mayEdit: PropTypes.bool,
-        /** Called with the freshly re-fetched embedded user on save success. */
-        onUpdated: PropTypes.func,
-    };
+function UserAdminControls({
+    user,
+    schemas = null,
+    mayEdit = false,
+    onUpdated = null,
+}) {
+    const [state, setState] = useState(() => getInitialState(user));
+    const {
+        original,
+        draft,
+        scOptions,
+        scLabelMap,
+        scStatus,
+        baselineStatus,
+        showConfirm,
+        saving,
+    } = state;
 
-    static defaultProps = {
-        schemas: null,
-        mayEdit: false,
-        onUpdated: null,
-    };
-
-    constructor(props) {
-        super(props);
-        _.bindAll(
-            this,
-            'loadBaseline',
-            'loadSubmissionCenters',
-            'handleStatusChange',
-            'handleGroupsChange',
-            'handleSubmitsForChange',
-            'openConfirm',
-            'closeConfirm',
-            'handleSave',
-            'onPatchSuccess',
-            'onPatchError'
-        );
-
-        // Derive an initial baseline synchronously from the embedded context so
-        // the controls render populated before the object-frame fetch returns.
-        const baseline = extractUserBaseline(props.user);
-        // Seed submits_for chip labels from the embedded context so chips show
-        // display titles immediately; the SubmissionCenter search fetch
-        // augments this with the full option list on mount.
-        const initialLabelMap = {};
-        const embeddedSubmits =
-            props.user && Array.isArray(props.user.submits_for)
-                ? props.user.submits_for
-                : [];
-        embeddedSubmits.forEach((sc) => {
-            if (sc && typeof sc === 'object' && sc['@id']) {
-                initialLabelMap[sc['@id']] =
-                    sc.display_title || sc.identifier || sc['@id'];
-            }
-        });
-        this.state = {
-            baselineStatus: LOAD.loading,
-            original: baseline,
-            draft: draftFromBaseline(baseline),
-            scOptions: [],
-            scLabelMap: initialLabelMap,
-            scStatus: LOAD.loading,
-            showConfirm: false,
-            saving: false,
-        };
-    }
-
-    componentDidMount() {
-        this.loadBaseline();
-        this.loadSubmissionCenters();
-    }
+    const userId = user && user['@id'];
 
     /**
      * Fetch the object frame for clean scalar / `@id`-array baseline values to
      * diff and PATCH against (the embedded context nests linkTos as objects).
      */
-    loadBaseline() {
-        const { user } = this.props;
-        const atId = user && user['@id'];
-        if (!atId) {
-            this.setState({ baselineStatus: LOAD.failed });
+    const loadBaseline = useCallback(() => {
+        if (!userId) {
+            setState((prev) => {return { ...prev, baselineStatus: LOAD.failed };});
             return;
         }
         ajax.load(
-            atId + '?frame=object',
+            userId + '?frame=object',
             (resp) => {
-                const original = extractUserBaseline(resp);
-                this.setState((prev) => {
+                const nextOriginal = extractUserBaseline(resp);
+                setState((prev) => {
                     // Don't clobber selections the admin already made before
                     // this fetch returned: reset the draft only when nothing
                     // is pending.
                     const pending =
                         getChangedFields(prev.original, prev.draft).length > 0;
                     return {
+                        ...prev,
                         baselineStatus: LOAD.loaded,
-                        original,
+                        original: nextOriginal,
                         draft: pending
                             ? prev.draft
-                            : draftFromBaseline(original),
+                            : draftFromBaseline(nextOriginal),
                     };
                 });
             },
@@ -180,377 +163,385 @@ export default class UserAdminControls extends React.Component {
             () => {
                 // Keep the embedded-derived baseline already in state; just
                 // note the object-frame refresh failed (surfaced in render).
-                this.setState({ baselineStatus: LOAD.failed });
+                setState((prev) => {return {
+                    ...prev,
+                    baselineStatus: LOAD.failed,
+                };});
             }
         );
-    }
+    }, [userId]);
 
     /** Load the bounded set of SubmissionCenters for the submits_for options. */
-    loadSubmissionCenters() {
+    const loadSubmissionCenters = useCallback(() => {
         // `field=` restricts the returned _source; snovault always force-adds
         // `embedded.@id` and `embedded.@type` to the requested fields
         // (snovault/search/search.py `list_source_fields`), so each result
         // still carries the `@id` that computeSubmitsForOptions needs.
-        const { scStatus } = this.state;
-        if (scStatus !== LOAD.loading) {
-            this.setState({ scStatus: LOAD.loading });
-        }
+        setState((prev) => {
+            if (prev.scStatus === LOAD.loading) return prev;
+            return { ...prev, scStatus: LOAD.loading };
+        });
         ajax.load(
             '/search/?type=SubmissionCenter&limit=all&field=display_title&field=identifier',
             (resp) => {
                 const { options, labelMap } = computeSubmitsForOptions(
                     (resp && resp['@graph']) || []
                 );
-                this.setState(({ scLabelMap }) => {
-                    return {
-                        scOptions: options,
-                        // Retain embedded labels for centers absent from search;
-                        // prefer fresh labels for centers that were returned.
-                        scLabelMap: { ...scLabelMap, ...labelMap },
-                        scStatus: LOAD.loaded,
-                    };
-                });
+                setState((prev) => {return {
+                    ...prev,
+                    scOptions: options,
+                    // Retain embedded labels for centers absent from search;
+                    // prefer fresh labels for centers that were returned.
+                    scLabelMap: { ...prev.scLabelMap, ...labelMap },
+                    scStatus: LOAD.loaded,
+                };});
             },
             'GET',
             () => {
-                this.setState({ scStatus: LOAD.failed });
+                setState((prev) => {return { ...prev, scStatus: LOAD.failed };});
             }
         );
-    }
+    }, []);
 
-    handleStatusChange(option) {
+    useEffect(() => {
+        loadBaseline();
+        loadSubmissionCenters();
+    }, [loadBaseline, loadSubmissionCenters]);
+
+    const handleStatusChange = useCallback((option) => {
         const status = option ? option.value : '';
-        this.setState(({ draft }) => {
-            return { draft: { ...draft, status } };
-        });
-    }
+        setState((prev) => {return {
+            ...prev,
+            draft: { ...prev.draft, status },
+        };});
+    }, []);
 
-    handleGroupsChange(selected) {
+    const handleGroupsChange = useCallback((selected) => {
         const groups = (selected || []).map((o) => o.value);
-        this.setState(({ draft }) => {
-            return { draft: { ...draft, groups } };
-        });
-    }
+        setState((prev) => {return {
+            ...prev,
+            draft: { ...prev.draft, groups },
+        };});
+    }, []);
 
-    handleSubmitsForChange(selected) {
+    const handleSubmitsForChange = useCallback((selected) => {
         const submits_for = (selected || []).map((o) => o.value);
-        this.setState(({ draft }) => {
-            return { draft: { ...draft, submits_for } };
-        });
-    }
+        setState((prev) => {return {
+            ...prev,
+            draft: { ...prev.draft, submits_for },
+        };});
+    }, []);
 
-    openConfirm() {
-        this.setState({ showConfirm: true });
-    }
+    const openConfirm = useCallback(() => {
+        setState((prev) => {return { ...prev, showConfirm: true };});
+    }, []);
 
-    closeConfirm() {
-        const { saving } = this.state;
-        if (saving) return;
-        this.setState({ showConfirm: false });
-    }
-
-    handleSave() {
-        const { user } = this.props;
-        const { original, draft } = this.state;
-        const payload = buildUserPatchPayload(original, draft);
-        if (Object.keys(payload).length === 0) return;
-
-        this.setState({ saving: true });
-        ajax.load(
-            user['@id'],
-            this.onPatchSuccess,
-            'PATCH',
-            this.onPatchError,
-            JSON.stringify(payload)
+    const closeConfirm = useCallback(() => {
+        setState((prev) =>
+            prev.saving ? prev : { ...prev, showConfirm: false }
         );
-    }
+    }, []);
 
-    onPatchSuccess(resp) {
-        const { user, onUpdated } = this.props;
-        if (!resp || resp.status !== 'success') {
-            this.onPatchError(resp);
-            return;
-        }
-        // Do NOT dispatch the PATCH @graph[0] (object frame, no embeds).
-        // Re-GET the embedded frame to reconcile the on-page display, then
-        // reset the baseline so a subsequent save diffs against fresh values.
-        ajax.load(
-            user['@id'],
-            (embeddedResp) => {
-                if (typeof onUpdated === 'function') {
-                    onUpdated(embeddedResp);
-                }
-                const original = extractUserBaseline(embeddedResp);
-                this.setState({
-                    original,
-                    draft: draftFromBaseline(original),
-                    saving: false,
-                    showConfirm: false,
-                });
-                Alerts.queue({
-                    title: 'User updated',
-                    message: 'The user account was updated successfully.',
-                    style: 'success',
-                });
-            },
-            'GET',
-            () => {
-                // PATCH succeeded but the reconciling re-GET failed. Keep the
-                // panel usable; surface a soft warning and reset the baseline
-                // from the draft we just persisted.
-                this.setState(({ draft }) => {
-                    return {
-                        original: {
-                            status: draft.status,
-                            groups: draft.groups.slice(),
-                            submits_for: draft.submits_for.slice(),
-                        },
-                        saving: false,
-                        showConfirm: false,
-                    };
-                });
-                Alerts.queue({
-                    title: 'User updated',
-                    message:
-                        'Changes were saved, but the page could not be refreshed automatically. Reload to see the latest values.',
-                    style: 'warning',
-                });
-            }
-        );
-    }
-
-    onPatchError(errorResp) {
+    const onPatchError = useCallback((errorResp) => {
         // Keep pending draft intact so the admin can fix and retry.
-        this.setState({ saving: false, showConfirm: false });
+        setState((prev) => {return {
+            ...prev,
+            saving: false,
+            showConfirm: false,
+        };});
         Alerts.queue({
             title: 'Update failed',
             message: formatPatchError(errorResp),
             style: 'danger',
         });
+    }, []);
+
+    const onPatchSuccess = useCallback(
+        (resp) => {
+            if (!resp || resp.status !== 'success') {
+                onPatchError(resp);
+                return;
+            }
+            // Do NOT dispatch the PATCH @graph[0] (object frame, no embeds).
+            // Re-GET the embedded frame to reconcile the on-page display, then
+            // reset the baseline so a subsequent save diffs against fresh values.
+            ajax.load(
+                userId,
+                (embeddedResp) => {
+                    if (typeof onUpdated === 'function') {
+                        onUpdated(embeddedResp);
+                    }
+                    const nextOriginal = extractUserBaseline(embeddedResp);
+                    setState((prev) => {return {
+                        ...prev,
+                        original: nextOriginal,
+                        draft: draftFromBaseline(nextOriginal),
+                        saving: false,
+                        showConfirm: false,
+                    };});
+                    Alerts.queue({
+                        title: 'User updated',
+                        message: 'The user account was updated successfully.',
+                        style: 'success',
+                    });
+                },
+                'GET',
+                () => {
+                    // PATCH succeeded but the reconciling re-GET failed. Keep the
+                    // panel usable; surface a soft warning and reset the baseline
+                    // from the draft we just persisted.
+                    setState((prev) => {return {
+                        ...prev,
+                        original: {
+                            status: prev.draft.status,
+                            groups: prev.draft.groups.slice(),
+                            submits_for: prev.draft.submits_for.slice(),
+                        },
+                        saving: false,
+                        showConfirm: false,
+                    };});
+                    Alerts.queue({
+                        title: 'User updated',
+                        message:
+                            'Changes were saved, but the page could not be refreshed automatically. Reload to see the latest values.',
+                        style: 'warning',
+                    });
+                }
+            );
+        },
+        [onPatchError, onUpdated, userId]
+    );
+
+    const handleSave = useCallback(() => {
+        const payload = buildUserPatchPayload(original, draft);
+        if (Object.keys(payload).length === 0) return;
+
+        setState((prev) => {return { ...prev, saving: true };});
+        ajax.load(
+            userId,
+            onPatchSuccess,
+            'PATCH',
+            onPatchError,
+            JSON.stringify(payload)
+        );
+    }, [draft, onPatchError, onPatchSuccess, original, userId]);
+
+    const statusEnum = getStatusEnum(schemas);
+    const groupsEnum = getGroupsEnum(schemas);
+
+    const toOption = (v) => {
+        return { value: v, label: v };
+    };
+    const statusOptions = statusEnum.map(toOption);
+    const groupOptions = groupsEnum.map(toOption);
+
+    const selectedStatus =
+        statusOptions.find((o) => o.value === draft.status) || null;
+    const selectedGroups = (draft.groups || []).map(toOption);
+    const selectedSubmitsFor = (draft.submits_for || []).map((v) => {
+        return { value: v, label: scLabelMap[v] || v };
+    });
+
+    const changedFields = getChangedFields(original, draft);
+    const hasChanges = changedFields.length > 0;
+
+    // Defer modal-only work and JWT access during ordinary panel renders.
+    let diffRows;
+    let warnings;
+    if (showConfirm) {
+        const myDetails = JWT.getUserDetails() || {};
+        const isSelf =
+            !!myDetails.email &&
+            !!user.email &&
+            myDetails.email === user.email;
+        diffRows = diffUserFields(original, draft, scLabelMap);
+        warnings = computeChangeWarnings(original, draft, isSelf);
     }
 
-    render() {
-        const { user, schemas, mayEdit } = this.props;
-        const {
-            original,
-            draft,
-            scOptions,
-            scLabelMap,
-            scStatus,
-            baselineStatus,
-            showConfirm,
-            saving,
-        } = this.state;
-
-        const statusEnum = getStatusEnum(schemas);
-        const groupsEnum = getGroupsEnum(schemas);
-
-        const toOption = (v) => {
-            return { value: v, label: v };
-        };
-        const statusOptions = statusEnum.map(toOption);
-        const groupOptions = groupsEnum.map(toOption);
-
-        const selectedStatus =
-            statusOptions.find((o) => o.value === draft.status) || null;
-        const selectedGroups = (draft.groups || []).map(toOption);
-        const selectedSubmitsFor = (draft.submits_for || []).map((v) => {
-            return { value: v, label: scLabelMap[v] || v };
-        });
-
-        const changedFields = getChangedFields(original, draft);
-        const hasChanges = changedFields.length > 0;
-
-        // Defer modal-only work and JWT access during ordinary panel renders.
-        let diffRows;
-        let warnings;
-        if (showConfirm) {
-            const myDetails = JWT.getUserDetails() || {};
-            const isSelf =
-                !!myDetails.email &&
-                !!user.email &&
-                myDetails.email === user.email;
-            diffRows = diffUserFields(original, draft, scLabelMap);
-            warnings = computeChangeWarnings(original, draft, isSelf);
-        }
-
-        return (
-            <div
-                className="user-admin-controls card h-100"
-                data-testid="user-admin-controls">
-                <div className="card-header">
-                    <h3 className="block-title">
-                        <i className="icon icon-user-shield fas icon-fw me-12" />
-                        Admin Controls
-                    </h3>
-                </div>
-                <div className="card-body">
-                    {mayEdit ? (
-                        <div className="mb-3">
-                            <button
-                                type="button"
-                                className="btn btn-outline-secondary btn-sm w-100"
-                                onClick={() =>
-                                    navigate(
-                                        user['@id'] + '?currentAction=edit'
-                                    )
-                                }>
-                                <i className="icon icon-pencil-alt fas me-06" />
-                                Open full edit page
-                            </button>
-                        </div>
-                    ) : null}
-
-                    <div className="form-group mb-3">
-                        <label
-                            htmlFor="user-admin-status"
-                            className="text-500 mb-1">
-                            Status
-                        </label>
-                        <Select
-                            inputId="user-admin-status"
-                            aria-label="User status"
-                            styles={reactSelectStyles}
-                            options={statusOptions}
-                            value={selectedStatus}
-                            onChange={this.handleStatusChange}
-                            isDisabled={saving}
-                        />
-                    </div>
-
-                    <div className="form-group mb-3">
-                        <label
-                            htmlFor="user-admin-groups"
-                            className="text-500 mb-1">
-                            Groups
-                        </label>
-                        <Select
-                            inputId="user-admin-groups"
-                            aria-label="User groups"
-                            isMulti
-                            closeMenuOnSelect={false}
-                            styles={reactSelectStyles}
-                            options={groupOptions}
-                            value={selectedGroups}
-                            onChange={this.handleGroupsChange}
-                            placeholder="No groups"
-                            isDisabled={saving}
-                        />
-                    </div>
-
-                    <div className="form-group mb-3">
-                        <label
-                            htmlFor="user-admin-submits-for"
-                            className="text-500 mb-1">
-                            Submits for
-                        </label>
-                        <Select
-                            inputId="user-admin-submits-for"
-                            aria-label="Submits for submission centers"
-                            isMulti
-                            closeMenuOnSelect={false}
-                            styles={reactSelectStyles}
-                            options={scOptions}
-                            value={selectedSubmitsFor}
-                            onChange={this.handleSubmitsForChange}
-                            isLoading={scStatus === LOAD.loading}
-                            placeholder={
-                                scStatus === LOAD.failed
-                                    ? 'Failed to load submission centers'
-                                    : 'Select submission center(s)'
-                            }
-                            noOptionsMessage={
-                                scStatus === LOAD.failed
-                                    ? submissionCentersFailed
-                                    : noSubmissionCenters
-                            }
-                            isDisabled={saving}
-                        />
-                        {scStatus === LOAD.failed ? (
-                            <div className="text-danger small mt-1">
-                                Could not load submission centers.{' '}
-                                <button
-                                    type="button"
-                                    className="btn btn-link btn-sm p-0 align-baseline"
-                                    onClick={this.loadSubmissionCenters}>
-                                    Retry
-                                </button>
-                            </div>
-                        ) : null}
-                    </div>
-
-                    {baselineStatus === LOAD.failed ? (
-                        <div className="text-warning small mb-2">
-                            <i className="icon icon-exclamation-triangle fas me-06" />
-                            Could not refresh the latest values; editing against
-                            the values shown on the page.
-                        </div>
-                    ) : null}
-
-                    <div className="mt-3">
+    return (
+        <div
+            className="user-admin-controls card h-100"
+            data-testid="user-admin-controls">
+            <div className="card-header">
+                <h3 className="block-title">
+                    <i className="icon icon-user-shield fas icon-fw me-12" />
+                    Admin Controls
+                </h3>
+            </div>
+            <div className="card-body">
+                {mayEdit ? (
+                    <div className="mb-3">
                         <button
                             type="button"
-                            className="btn btn-primary w-100"
-                            disabled={!hasChanges || saving}
-                            onClick={this.openConfirm}>
-                            Save changes
+                            className="btn btn-outline-secondary btn-sm w-100"
+                            onClick={() =>
+                                navigate(user['@id'] + '?currentAction=edit')
+                            }>
+                            <i className="icon icon-pencil-alt fas me-06" />
+                            Open full edit page
                         </button>
                     </div>
+                ) : null}
+
+                <div className="form-group mb-3">
+                    <label
+                        htmlFor="user-admin-status"
+                        className="text-500 mb-1">
+                        Status
+                    </label>
+                    <Select
+                        inputId="user-admin-status"
+                        aria-label="User status"
+                        styles={reactSelectStyles}
+                        options={statusOptions}
+                        value={selectedStatus}
+                        onChange={handleStatusChange}
+                        isDisabled={saving}
+                    />
                 </div>
 
-                {showConfirm ? (
-                    <Modal show onHide={this.closeConfirm}>
-                        <Modal.Header closeButton>
-                            <Modal.Title className="text-400">
-                                Confirm user changes
-                            </Modal.Title>
-                        </Modal.Header>
-                        <Modal.Body>
-                            <p className="text-500">
-                                The following changes will be applied to{' '}
-                                <span className="text-600">{user.email}</span>:
-                            </p>
-                            <ul className="list-unstyled">
-                                {diffRows.map((row) => (
-                                    <li key={row.field} className="mb-1">
-                                        <span className="text-500">
-                                            {row.field}
-                                        </span>
-                                        : <code>{row.from}</code>
-                                        {' → '}
-                                        <code>{row.to}</code>
-                                    </li>
-                                ))}
-                            </ul>
-                            {warnings.length ? (
-                                <div className="alert alert-warning py-2 mb-0">
-                                    <ul className="mb-0 ps-3">
-                                        {warnings.map((w, i) => (
-                                            <li key={i}>{w}</li>
-                                        ))}
-                                    </ul>
-                                </div>
-                            ) : null}
-                        </Modal.Body>
-                        <Modal.Footer>
+                <div className="form-group mb-3">
+                    <label
+                        htmlFor="user-admin-groups"
+                        className="text-500 mb-1">
+                        Groups
+                    </label>
+                    <Select
+                        inputId="user-admin-groups"
+                        aria-label="User groups"
+                        isMulti
+                        closeMenuOnSelect={false}
+                        styles={reactSelectStyles}
+                        options={groupOptions}
+                        value={selectedGroups}
+                        onChange={handleGroupsChange}
+                        placeholder="No groups"
+                        isDisabled={saving}
+                    />
+                </div>
+
+                <div className="form-group mb-3">
+                    <label
+                        htmlFor="user-admin-submits-for"
+                        className="text-500 mb-1">
+                        Submits for
+                    </label>
+                    <Select
+                        inputId="user-admin-submits-for"
+                        aria-label="Submits for submission centers"
+                        isMulti
+                        closeMenuOnSelect={false}
+                        styles={reactSelectStyles}
+                        options={scOptions}
+                        value={selectedSubmitsFor}
+                        onChange={handleSubmitsForChange}
+                        isLoading={scStatus === LOAD.loading}
+                        placeholder={
+                            scStatus === LOAD.failed
+                                ? 'Failed to load submission centers'
+                                : 'Select submission center(s)'
+                        }
+                        noOptionsMessage={
+                            scStatus === LOAD.failed
+                                ? submissionCentersFailed
+                                : noSubmissionCenters
+                        }
+                        isDisabled={saving}
+                    />
+                    {scStatus === LOAD.failed ? (
+                        <div className="text-danger small mt-1">
+                            Could not load submission centers.{' '}
                             <button
                                 type="button"
-                                className="btn btn-outline-secondary"
-                                onClick={this.closeConfirm}
-                                disabled={saving}>
-                                Cancel
+                                className="btn btn-link btn-sm p-0 align-baseline"
+                                onClick={loadSubmissionCenters}>
+                                Retry
                             </button>
-                            <button
-                                type="button"
-                                className="btn btn-primary"
-                                onClick={this.handleSave}
-                                disabled={saving}>
-                                {saving ? 'Saving…' : 'Confirm'}
-                            </button>
-                        </Modal.Footer>
-                    </Modal>
+                        </div>
+                    ) : null}
+                </div>
+
+                {baselineStatus === LOAD.failed ? (
+                    <div className="text-warning small mb-2">
+                        <i className="icon icon-exclamation-triangle fas me-06" />
+                        Could not refresh the latest values; editing against
+                        the values shown on the page.
+                    </div>
                 ) : null}
+
+                <div className="mt-3">
+                    <button
+                        type="button"
+                        className="btn btn-primary w-100"
+                        disabled={!hasChanges || saving}
+                        onClick={openConfirm}>
+                        Save changes
+                    </button>
+                </div>
             </div>
-        );
-    }
+
+            {showConfirm ? (
+                <Modal show onHide={closeConfirm}>
+                    <Modal.Header closeButton>
+                        <Modal.Title className="text-400">
+                            Confirm user changes
+                        </Modal.Title>
+                    </Modal.Header>
+                    <Modal.Body>
+                        <p className="text-500">
+                            The following changes will be applied to{' '}
+                            <span className="text-600">{user.email}</span>:
+                        </p>
+                        <ul className="list-unstyled">
+                            {diffRows.map((row) => (
+                                <li key={row.field} className="mb-1">
+                                    <span className="text-500">
+                                        {row.field}
+                                    </span>
+                                    : <code>{row.from}</code>
+                                    {' → '}
+                                    <code>{row.to}</code>
+                                </li>
+                            ))}
+                        </ul>
+                        {warnings.length ? (
+                            <div className="alert alert-warning py-2 mb-0">
+                                <ul className="mb-0 ps-3">
+                                    {warnings.map((w, i) => (
+                                        <li key={i}>{w}</li>
+                                    ))}
+                                </ul>
+                            </div>
+                        ) : null}
+                    </Modal.Body>
+                    <Modal.Footer>
+                        <button
+                            type="button"
+                            className="btn btn-outline-secondary"
+                            onClick={closeConfirm}
+                            disabled={saving}>
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            className="btn btn-primary"
+                            onClick={handleSave}
+                            disabled={saving}>
+                            {saving ? 'Saving…' : 'Confirm'}
+                        </button>
+                    </Modal.Footer>
+                </Modal>
+            ) : null}
+        </div>
+    );
 }
+
+UserAdminControls.propTypes = {
+    user: PropTypes.object.isRequired,
+    schemas: PropTypes.object,
+    mayEdit: PropTypes.bool,
+    /** Called with the freshly re-fetched embedded user on save success. */
+    onUpdated: PropTypes.func,
+};
+
+export default UserAdminControls;

--- a/src/encoded/static/components/item-pages/components/user/UserAdminControls.js
+++ b/src/encoded/static/components/item-pages/components/user/UserAdminControls.js
@@ -63,6 +63,8 @@ const reactSelectStyles = {
 };
 
 const LOAD = { loading: 1, loaded: 2, failed: 3 };
+const noSubmissionCenters = () => 'No submission centers found';
+const submissionCentersFailed = () => 'Failed to load submission centers';
 
 /**
  * Admin-only right-side control panel on the User profile page. Renders three
@@ -196,32 +198,24 @@ export default class UserAdminControls extends React.Component {
         // `embedded.@id` and `embedded.@type` to the requested fields
         // (snovault/search/search.py `list_source_fields`), so each result
         // still carries the `@id` that computeSubmitsForOptions needs.
-        this.setState({ scStatus: LOAD.loading });
+        const { scStatus } = this.state;
+        if (scStatus !== LOAD.loading) {
+            this.setState({ scStatus: LOAD.loading });
+        }
         ajax.load(
             '/search/?type=SubmissionCenter&limit=all&field=display_title&field=identifier',
             (resp) => {
                 const { options, labelMap } = computeSubmitsForOptions(
                     (resp && resp['@graph']) || []
                 );
-                // Ensure any @ids already on the user (but absent from search,
-                // e.g. a deleted center) still have a chip label from the
-                // embedded context.
-                const { user } = this.props;
-                (user && Array.isArray(user.submits_for)
-                    ? user.submits_for
-                    : []
-                ).forEach((sc) => {
-                    if (sc && typeof sc === 'object' && sc['@id']) {
-                        if (!labelMap[sc['@id']]) {
-                            labelMap[sc['@id']] =
-                                sc.display_title || sc.identifier || sc['@id'];
-                        }
-                    }
-                });
-                this.setState({
-                    scOptions: options,
-                    scLabelMap: labelMap,
-                    scStatus: LOAD.loaded,
+                this.setState(({ scLabelMap }) => {
+                    return {
+                        scOptions: options,
+                        // Retain embedded labels for centers absent from search;
+                        // prefer fresh labels for centers that were returned.
+                        scLabelMap: { ...scLabelMap, ...labelMap },
+                        scStatus: LOAD.loaded,
+                    };
                 });
             },
             'GET',
@@ -378,11 +372,18 @@ export default class UserAdminControls extends React.Component {
         const changedFields = getChangedFields(original, draft);
         const hasChanges = changedFields.length > 0;
 
-        const myDetails = JWT.getUserDetails() || {};
-        const isSelf =
-            !!myDetails.email && !!user.email && myDetails.email === user.email;
-        const diffRows = diffUserFields(original, draft, scLabelMap);
-        const warnings = computeChangeWarnings(original, draft, isSelf);
+        // Defer modal-only work and JWT access during ordinary panel renders.
+        let diffRows;
+        let warnings;
+        if (showConfirm) {
+            const myDetails = JWT.getUserDetails() || {};
+            const isSelf =
+                !!myDetails.email &&
+                !!user.email &&
+                myDetails.email === user.email;
+            diffRows = diffUserFields(original, draft, scLabelMap);
+            warnings = computeChangeWarnings(original, draft, isSelf);
+        }
 
         return (
             <div
@@ -469,10 +470,10 @@ export default class UserAdminControls extends React.Component {
                                     ? 'Failed to load submission centers'
                                     : 'Select submission center(s)'
                             }
-                            noOptionsMessage={() =>
+                            noOptionsMessage={
                                 scStatus === LOAD.failed
-                                    ? 'Failed to load submission centers'
-                                    : 'No submission centers found'
+                                    ? submissionCentersFailed
+                                    : noSubmissionCenters
                             }
                             isDisabled={saving}
                         />

--- a/src/encoded/static/components/item-pages/components/user/UserAdminControls.js
+++ b/src/encoded/static/components/item-pages/components/user/UserAdminControls.js
@@ -23,6 +23,7 @@ import {
     getStatusEnum,
     getGroupsEnum,
     extractUserBaseline,
+    draftFromBaseline,
     buildUserPatchPayload,
     diffUserFields,
     getChangedFields,
@@ -131,11 +132,7 @@ export default class UserAdminControls extends React.Component {
         this.state = {
             baselineStatus: LOAD.loading,
             original: baseline,
-            draft: {
-                ...baseline,
-                groups: baseline.groups.slice(),
-                submits_for: baseline.submits_for.slice(),
-            },
+            draft: draftFromBaseline(baseline),
             scOptions: [],
             scLabelMap: initialLabelMap,
             scStatus: LOAD.loading,
@@ -175,11 +172,7 @@ export default class UserAdminControls extends React.Component {
                         original,
                         draft: pending
                             ? prev.draft
-                            : {
-                                ...original,
-                                groups: original.groups.slice(),
-                                submits_for: original.submits_for.slice(),
-                            },
+                            : draftFromBaseline(original),
                     };
                 });
             },
@@ -290,11 +283,7 @@ export default class UserAdminControls extends React.Component {
                 const original = extractUserBaseline(embeddedResp);
                 this.setState({
                     original,
-                    draft: {
-                        ...original,
-                        groups: original.groups.slice(),
-                        submits_for: original.submits_for.slice(),
-                    },
+                    draft: draftFromBaseline(original),
                     saving: false,
                     showConfirm: false,
                 });

--- a/src/encoded/static/components/item-pages/components/user/userAdminHelpers.js
+++ b/src/encoded/static/components/item-pages/components/user/userAdminHelpers.js
@@ -90,6 +90,25 @@ export function extractUserBaseline(source) {
 }
 
 /**
+ * Build an editable draft from a baseline, cloning the arrays so the draft and
+ * its baseline never share array references (edits replace, but a shared
+ * reference would still alias the two objects and break diffing). Single source
+ * of truth for the constructor / post-fetch / post-save seeding.
+ * @param {{status: string, groups: string[], submits_for: string[]}} baseline
+ * @returns {{status: string, groups: string[], submits_for: string[]}}
+ */
+export function draftFromBaseline(baseline) {
+    const base = baseline || {};
+    return {
+        ...base,
+        groups: Array.isArray(base.groups) ? base.groups.slice() : [],
+        submits_for: Array.isArray(base.submits_for)
+            ? base.submits_for.slice()
+            : [],
+    };
+}
+
+/**
  * Coerce a linkTo array (of `@id` strings and/or embedded objects) to a plain
  * array of `@id` strings, dropping anything without a resolvable `@id`.
  * @param {Array} arr

--- a/src/encoded/static/components/item-pages/components/user/userAdminHelpers.js
+++ b/src/encoded/static/components/item-pages/components/user/userAdminHelpers.js
@@ -174,8 +174,8 @@ export function diffUserFields(original, draft, labelMap = {}) {
         if (field === 'status') {
             return {
                 field,
-                from: (original.status || '(none)'),
-                to: (draft.status || '(none)'),
+                from: original.status || '(none)',
+                to: draft.status || '(none)',
             };
         }
         const toLabel = (id) => labelMap[id] || id;
@@ -221,7 +221,11 @@ export function formatPatchError(errorResp) {
             .map((e) => e.description || e.name || String(e))
             .join('; ');
     }
-    return errorResp.detail || errorResp.description || 'An unknown error occurred.';
+    return (
+        errorResp.detail ||
+        errorResp.description ||
+        'An unknown error occurred.'
+    );
 }
 
 /**
@@ -246,7 +250,9 @@ export function computeChangeWarnings(original, draft, isSelf) {
     const origGroups = new Set(original.groups || []);
     const nextGroups = new Set(draft.groups || []);
     if (!origGroups.has('admin') && nextGroups.has('admin')) {
-        warnings.push('Adding the "admin" group grants full administrative privileges.');
+        warnings.push(
+            'Adding the "admin" group grants full administrative privileges.'
+        );
     }
     if (
         !origGroups.has('read-only-admin') &&

--- a/src/encoded/static/components/item-pages/components/user/userAdminHelpers.js
+++ b/src/encoded/static/components/item-pages/components/user/userAdminHelpers.js
@@ -1,0 +1,263 @@
+'use strict';
+
+/**
+ * Pure, framework-free helpers backing the admin-only User control panel
+ * (see `UserAdminControls.js`). Keeping these free of React / SPC / react-select
+ * imports is what makes them unit-testable under the repo's default (node)
+ * Jest environment — no jsdom required.
+ *
+ * @module item-pages/components/user/userAdminHelpers
+ */
+
+/**
+ * Fallback enums, used only if the merged User schema fails to expose them.
+ * The served `/profiles/user.json` resolves the schema `$merge` refs at load
+ * time (snovault `schema_utils.fill_in_schema_merge_refs`), so at runtime
+ * `schemas.User.properties.status.enum` is populated; these mirror the
+ * authoritative values (`status`: snovault base `user.json`; `groups`: the
+ * SMaHT override in `src/encoded/schemas/user.json`).
+ */
+export const USER_STATUS_ENUM_FALLBACK = [
+    'current',
+    'deleted',
+    'inactive',
+    'revoked',
+];
+
+export const USER_GROUPS_ENUM_FALLBACK = [
+    'admin',
+    'read-only-admin',
+    'dbgap',
+    'public-dbgap',
+];
+
+/** The three admin-editable, `restricted_fields`-gated User properties. */
+export const ADMIN_EDITABLE_FIELDS = ['status', 'groups', 'submits_for'];
+
+/**
+ * Read the `status` enum out of the merged schemas prop, falling back to the
+ * hard-coded list if absent.
+ * @param {Object} schemas - App schemas object (keyed by type name).
+ * @returns {string[]}
+ */
+export function getStatusEnum(schemas) {
+    const enumVals =
+        schemas &&
+        schemas.User &&
+        schemas.User.properties &&
+        schemas.User.properties.status &&
+        schemas.User.properties.status.enum;
+    return Array.isArray(enumVals) && enumVals.length
+        ? enumVals
+        : USER_STATUS_ENUM_FALLBACK;
+}
+
+/**
+ * Read the `groups` item enum out of the merged schemas prop, falling back to
+ * the hard-coded list if absent.
+ * @param {Object} schemas - App schemas object (keyed by type name).
+ * @returns {string[]}
+ */
+export function getGroupsEnum(schemas) {
+    const enumVals =
+        schemas &&
+        schemas.User &&
+        schemas.User.properties &&
+        schemas.User.properties.groups &&
+        schemas.User.properties.groups.items &&
+        schemas.User.properties.groups.items.enum;
+    return Array.isArray(enumVals) && enumVals.length
+        ? enumVals
+        : USER_GROUPS_ENUM_FALLBACK;
+}
+
+/**
+ * Normalize an object-frame User response (or embedded context) into the clean
+ * scalar / `@id`-array shapes used both as the diff baseline and as PATCH
+ * payload values. `submits_for` may arrive as an array of `@id` strings
+ * (object frame) or of embedded objects (embedded frame); both are coerced to
+ * a plain `@id` array.
+ * @param {Object} source - object-frame or embedded User item.
+ * @returns {{status: string, groups: string[], submits_for: string[]}}
+ */
+export function extractUserBaseline(source) {
+    const src = source || {};
+    return {
+        status: typeof src.status === 'string' ? src.status : '',
+        groups: Array.isArray(src.groups) ? src.groups.slice() : [],
+        submits_for: normalizeLinkArray(src.submits_for),
+    };
+}
+
+/**
+ * Coerce a linkTo array (of `@id` strings and/or embedded objects) to a plain
+ * array of `@id` strings, dropping anything without a resolvable `@id`.
+ * @param {Array} arr
+ * @returns {string[]}
+ */
+export function normalizeLinkArray(arr) {
+    if (!Array.isArray(arr)) return [];
+    return arr
+        .map((entry) => {
+            if (typeof entry === 'string') return entry;
+            if (entry && typeof entry === 'object') {
+                return entry['@id'] || entry.atId || null;
+            }
+            return null;
+        })
+        .filter((v) => typeof v === 'string' && v.length > 0);
+}
+
+/** Set-equality for string arrays (order-insensitive). */
+export function sameStringSet(a, b) {
+    const arrA = Array.isArray(a) ? a : [];
+    const arrB = Array.isArray(b) ? b : [];
+    if (arrA.length !== arrB.length) return false;
+    const setB = new Set(arrB);
+    return arrA.every((v) => setB.has(v));
+}
+
+/** Whether a single field's draft value differs from the baseline. */
+export function isFieldChanged(field, original, draft) {
+    const orig = (original || {})[field];
+    const next = (draft || {})[field];
+    if (field === 'status') {
+        return (orig || '') !== (next || '');
+    }
+    // groups / submits_for are arrays compared as sets (PATCH replaces wholesale)
+    return !sameStringSet(orig, next);
+}
+
+/**
+ * Field names whose draft value differs from the baseline.
+ * @returns {string[]}
+ */
+export function getChangedFields(original, draft) {
+    return ADMIN_EDITABLE_FIELDS.filter((field) =>
+        isFieldChanged(field, original, draft)
+    );
+}
+
+/**
+ * Build the atomic PATCH payload: only changed fields, each carrying its full
+ * desired value. Arrays are sent in full (PATCH replaces arrays wholesale); an
+ * emptied array is sent as `[]`, which snovault applies as a clear
+ * (`validate_item_content_patch` does `data.update(request.json)` — an explicit
+ * `[]` replaces the stored value; verified against the resolved snovault
+ * source at `snovault/validators.py` `validate_item_content_patch`).
+ * @returns {Object} payload with 0..3 keys; `{}` when nothing changed.
+ */
+export function buildUserPatchPayload(original, draft) {
+    const payload = {};
+    getChangedFields(original, draft).forEach((field) => {
+        if (field === 'status') {
+            payload[field] = draft.status;
+        } else {
+            payload[field] = Array.isArray(draft[field])
+                ? draft[field].slice()
+                : [];
+        }
+    });
+    return payload;
+}
+
+/**
+ * Human-readable diff rows for the confirmation modal. `@id`s in `submits_for`
+ * are mapped to display labels via `labelMap` when available.
+ * @param {Object} original
+ * @param {Object} draft
+ * @param {Object} [labelMap] - map of `@id` -> display label for submits_for.
+ * @returns {Array<{field: string, from: string, to: string}>}
+ */
+export function diffUserFields(original, draft, labelMap = {}) {
+    return getChangedFields(original, draft).map((field) => {
+        if (field === 'status') {
+            return {
+                field,
+                from: (original.status || '(none)'),
+                to: (draft.status || '(none)'),
+            };
+        }
+        const toLabel = (id) => labelMap[id] || id;
+        const fromArr = (original[field] || []).map(toLabel);
+        const toArr = (draft[field] || []).map(toLabel);
+        return {
+            field,
+            from: fromArr.length ? fromArr.join(', ') : '(none)',
+            to: toArr.length ? toArr.join(', ') : '(none)',
+        };
+    });
+}
+
+/**
+ * Map a portal `/search/` result set of SubmissionCenters into react-select
+ * options and a companion `@id` -> label map.
+ * @param {Array} items - `@graph` array of SubmissionCenter items.
+ * @returns {{options: Array<{value: string, label: string}>, labelMap: Object}}
+ */
+export function computeSubmitsForOptions(items) {
+    const options = [];
+    const labelMap = {};
+    (Array.isArray(items) ? items : []).forEach((item) => {
+        const value = item && (item['@id'] || item.atId);
+        if (!value) return;
+        const label = item.display_title || item.identifier || value;
+        options.push({ value, label });
+        labelMap[value] = label;
+    });
+    options.sort((a, b) => a.label.localeCompare(b.label));
+    return { options, labelMap };
+}
+
+/**
+ * Extract a concise, user-facing error message from a snovault error response.
+ * @param {Object} errorResp - parsed error body from `ajax.load` error cb.
+ * @returns {string}
+ */
+export function formatPatchError(errorResp) {
+    if (!errorResp) return 'An unknown error occurred.';
+    if (Array.isArray(errorResp.errors) && errorResp.errors.length) {
+        return errorResp.errors
+            .map((e) => e.description || e.name || String(e))
+            .join('; ');
+    }
+    return errorResp.detail || errorResp.description || 'An unknown error occurred.';
+}
+
+/**
+ * Warnings to surface in the confirmation modal for high-impact changes.
+ * @param {Object} original
+ * @param {Object} draft
+ * @param {boolean} isSelf - whether the target user is the acting admin.
+ * @returns {string[]}
+ */
+export function computeChangeWarnings(original, draft, isSelf) {
+    const warnings = [];
+    if (
+        isFieldChanged('status', original, draft) &&
+        (draft.status === 'deleted' || draft.status === 'revoked')
+    ) {
+        warnings.push(
+            'Setting status to "' +
+                draft.status +
+                '" removes the user\'s access to their profile and data.'
+        );
+    }
+    const origGroups = new Set(original.groups || []);
+    const nextGroups = new Set(draft.groups || []);
+    if (!origGroups.has('admin') && nextGroups.has('admin')) {
+        warnings.push('Adding the "admin" group grants full administrative privileges.');
+    }
+    if (
+        !origGroups.has('read-only-admin') &&
+        nextGroups.has('read-only-admin')
+    ) {
+        warnings.push(
+            'Adding the "read-only-admin" group grants elevated read access.'
+        );
+    }
+    if (isSelf && getChangedFields(original, draft).length > 0) {
+        warnings.push('You are modifying your own account.');
+    }
+    return warnings;
+}

--- a/src/encoded/static/scss/encoded/modules/_item-pages.scss
+++ b/src/encoded/static/scss/encoded/modules/_item-pages.scss
@@ -1034,7 +1034,8 @@ body[data-pathname^="/users/"] {
 			.card {
 				box-shadow: none;
 				&.access-keys-container,
-				&.organizations {
+				&.organizations,
+				&.user-admin-controls {
 					.card-header {
 						height: 95px;
 						display: flex;


### PR DESCRIPTION
## Intent

Implement an admin-only control panel on the SMaHT Portal User profile page, frontend-only. Goal: administrators viewing any User page get a right-side panel to edit three restricted fields — status, groups, and submits_for — without a new backend endpoint.

Captain-approved decisions: expose the FULL status enum (current/deleted/inactive/revoked); expose ALL schema groups including admin and read-only-admin; NO self-target guardrails (warn-only in modal); authorization stays on the backend restricted_fields validator (client admin gate is cosmetic only).

Frontend-only was verified against snovault source. Admin gate resolves in componentDidMount to avoid SSR hydration mismatch while keeping the non-admin tree byte-identical. Single atomic PATCH of only changed fields; arrays sent as full replacements; empty array [] clears a field (verified via snovault validate_item_content_patch data.update). On success re-fetch embedded frame and reconcile store; on failure retain pending changes. submits_for options from /search/?type=SubmissionCenter (field= still returns @id per snovault list_source_fields). react-select styles inlined to keep d3 out of the chunk.

Pipeline history on this branch: review finding (loading-state on retry) already fixed; changelog entry + pyproject.toml version bump to 2.7.0 (minor, new feature) already added per maintainer decision. The prior run failed only on a TRANSIENT GitHub GraphQL error during PR creation (gh pr create server-side glitch), not a code issue — this re-run retries PR creation and CI. Tests: pure-helper unit tests, props-seeded renderToStaticMarkup tests, and non-admin source-invariant guards (node-env Jest, no jsdom).

## What Changed

- Added an admin-only control panel to the User profile page (`UserView.js`, new `UserAdminControls.js` and `userAdminHelpers.js`) that lets administrators edit a User's `status`, `groups`, and `submits_for` from a right-side panel, gated cosmetically on the client with authorization still enforced by the backend `restricted_fields` validator. The admin gate resolves in `componentDidMount` to avoid SSR hydration mismatch and keep the non-admin tree byte-identical.
- Edits produce a single atomic PATCH of only changed fields (arrays sent as full replacements, empty array clears a field); on success the embedded frame is re-fetched and reconciled into the store, and pending changes are retained on failure. `submits_for` options are loaded from `/search/?type=SubmissionCenter`, and react-select styles are inlined to keep d3 out of the chunk. The submission-center retry path now sets its loading state correctly.
- Added Jest coverage in `UserAdminControls.test.js` (pure helpers, `renderToStaticMarkup` rendering, non-admin source-invariant gating) and recorded the feature with a 2.7.0 CHANGELOG entry and `pyproject.toml` version bump.

## Risk Assessment

✅ Low: Well-bounded, frontend-only feature with a cosmetic client admin gate (real authorization stays on the backend restricted_fields validator), correct reuse of established ajax/JWT/Alerts patterns, coherent state/reconcile logic, solid pure-helper and render tests, and full conformance to every stated intent criterion.

## Testing

Baseline had no node_modules, so I ran `npm ci`, then executed the change's Jest suite (`UserAdminControls.test.js`): all 28 tests pass, exercising the atomic-PATCH payload builder (only-changed fields, `[]` clears), order-insensitive diffing, full status/groups enum extraction with fallbacks, warn-only change warnings, submits_for option mapping, and the non-admin byte-identical column/admin-gating source invariants on UserView.js. Unit-passing alone isn't sufficient for a UI feature, so I rendered the real UserAdminControls component with the real react-select to HTML, loaded it in Chrome with Bootstrap CSS, and screenshotted the actual surface — showing the Status/Groups/Submits-for controls, the mayEdit-only full-edit link, Save changes, and the confirmation modal with the from→to diff of only changed fields plus warn-only guardrails (revoked/admin). Evidence artifacts written to the evidence directory. Overall: change satisfies the stated intent and all tests pass with no findings.

- Evidence: Admin Controls panel + confirmation modal (real component, Chrome screenshot) (local file: <code>/var/folders/b0/frc2r_1s5l77zdf6_xrlqfdw0000gn/T/no-mistakes-evidence/01KYAT8R8RAM71HMHA1WZ2B0R1/user-admin-controls.png</code>)
<details>
<summary>Evidence: Rendered HTML of the real UserAdminControls (react-select markup + confirm modal)</summary>

```text
<!doctype html>
<html><head><meta charset="utf-8">
<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
<link href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css" rel="stylesheet">
<style>
  body { background:#f5f6f8; padding:32px; font-family: system-ui, sans-serif; }
  .grid { display:flex; gap:24px; align-items:flex-start; flex-wrap:wrap; }
  .card-header .block-title, .card-header h3 { font-size:1.05rem; margin:0; }
  .user-admin-controls { width:360px; }
  .fas.icon-user-shield::before { content:"\f505"; }
  .icon-pencil-alt::before { content:"\f303"; }
  .icon-exclamation-triangle::before { content:"\f071"; }
  .panel-label { font-weight:600; color:#444; margin:0 0 8px; }
  .modal-wrap { width:520px; background:#fff; border-radius:6px; box-shadow:0 8px 30px rgba(0,0,0,.2); }
  .modal-header,.modal-footer{ padding:12px 16px; } .modal-body{ padding:16px; }
  .modal-footer{ display:flex; gap:8px; justify-content:flex-end; border-top:1px solid #eee; }
  .modal-header{ border-bottom:1px solid #eee; }
</style></head>
<body>
<h2 class="mb-4">Admin Controls panel — User profile page (admin viewer)</h2>
<div class="grid">
  <div>
    <p class="panel-label">Right-side panel (as rendered in the User page third column)</p>
    <div class="user-admin-controls card h-100" data-testid="user-admin-controls"><div class="card-header"><h3 class="block-title"><i class="icon icon-user-shield fas icon-fw me-12"></i>Admin Controls</h3></div><div class="card-body"><div class="mb-3"><button type="button" class="btn btn-outline-secondary btn-sm w-100"><i class="icon icon-pencil-alt fas me-06"></i>Open full edit page</button></div><div class="form-group mb-3"><label for="user-admin-status" class="text-500 mb-1">Status</label><style data-emotion="css b62m3t-container">.css-b62m3t-container{position:relative;box-sizing:border-box;}</style><div class="css-b62m3t-container"><style data-emotion="css 1f43avz-a11yText-A11yText">.css-1f43avz-a11yText-A11yText{z-index:9999;border:0;clip:rect(1px, 1px, 1px, 1px);height:1px;width:1px;position:absolute;overflow:hidden;padding:0;white-space:nowrap;}</style><span id="react-select-2-live-region" class="css-1f43avz-a11yText-A11yText"></span><span aria-live="polite" aria-atomic="false" aria-relevant="additions text" role="log" class="css-1f43avz-a11yText-A11yText"></span><style data-emotion="css 1ddmdm3-control">.css-1ddmdm3-control{-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;cursor:default;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-box-flex-wrap:wrap;-webkit-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;-webkit-box-pack:justify;-webkit-justify-content:space-between;justify-content:space-between;min-height:38px;outline:0!important;position:relative;-webkit-transition:all 100ms;transition:all 100ms;background-color:hsl(0, 0%, 100%);border-color:#dee2e6;border-radius:4px;border-style:solid;border-width:1px;box-shadow:none;box-sizing:border-box;font-size:0.875rem;}.css-1ddmdm3-control:hover{border-color:hsl(0, 0%, 70%);}</style><div class="css-1ddmdm3-control"><style data-emotion="css 1boa47a">.css-1boa47a{-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;display:grid;-webkit-flex:1;-ms-flex:1;flex:1;-webkit-box-flex-wrap:wrap;-webkit-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;-webkit-overflow-scrolling:touch;position:relative;overflow:hidden;padding:0 6px;box-sizing:border-box;}</style><div class="css-1boa47a"><style data-emotion="css 1dimb5e-singleValue">.css-1dimb5e-singleValue{grid-area:1/1/2/3;max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:hsl(0, 0%, 20%);margin-left:2px;margin-right:2px;box-sizing:border-box;}</style><div class="css-1dimb5e-singleValue">current</div><style data-emotion="css 1lx7dxn">.css-1lx7dxn{visibility:visible;-webkit-flex:1 1 auto;-ms-flex:1 1 auto;flex:1 1 auto;display:inline-grid;grid-area:1/1/2/3;grid-template-columns:0 min-content;margin:0;padding-bottom:2px;padding-top:2px;color:hsl(0, 0%, 20%);box-sizing:border-box;padding:0;}.css-1lx7dxn:after{content:attr(data-value) " ";visibility:hidden;white-space:pre;grid-area:1/2;font:inherit;min-width:2px;border:0;margin:0;outline:0;padding:0;}</style><div class="css-1lx7dxn" data-value=""><input class="" style="label:input;color:inherit;background:0;opacity:1;width:100%;grid-area:1 / 2;font:inherit;min-width:2px;border:0;margin:0;outline:0;padding:0" autoCapitalize="none" autoComplete="off" autoCorrect="off" id="user-admin-status" spellcheck="false" tabindex="0" type="text" aria-autocomplete="list" aria-expanded="false" aria-haspopup="true" aria-label="User status" role="combobox" aria-activedescendant="" value=""/></div></div><style data-emotion="css 1wy0on6">.css-1wy0on6{-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;-webkit-align-self:stretch;-ms-flex-item-align:stretch;align-self:stretch;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex-shrink:0;-ms-flex-negative:0;flex-shrink:0;box-sizing:border-box;}</style><div class="css-1wy0on6"><style data-emotion="css 1u9des2-indicatorSeparator">.css-1u9des2-indicatorSeparator{-webkit-align-self:stretch;-ms-flex-item-align:stretch;align-self:stretch;width:1px;background-color:hsl(0, 0%, 80%);margin-bottom:8px;margin-top:8px;box-sizing:border-box;}</style><span class="css-1u9des2-indicatorSeparator"></span><style data-emotion="css 1xc3v61-indicatorContainer">.css-1xc3v61-indicatorContainer{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-transition:color 150ms;transition:color 150ms;color:hsl(0, 0%, 80%);padding:8px;box-sizing:border-box;}.css-1xc3v61-indicatorContainer:hover{color:hsl(0, 0%, 60%);}</style><div class="css-1xc3v61-indicatorContainer" aria-hidden="true"><style data-emotion="css tj5bde-Svg">.css-tj5bde-Svg{display:inline-block;fill:currentColor;line-height:1;stroke:currentColor;stroke-width:0;}</style><svg height="20" width="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" class="css-tj5bde-Svg"><path d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"></path></svg></div></div></div></div></div><div class="form-group mb-3"><label for="user-admin-groups" class="text-500 mb-1">Groups</label><style data-emotion="css b62m3t-container">.css-b62m3t-container{position:relative;box-sizing:border-box;}</style><div class="css-b62m3t-container"><style data-emotion="css 1f43avz-a11yText-A11yText">.css-1f43avz-a11yText-A11yText{z-index:9999;border:0;clip:rect(1px, 1px, 1px, 1px);height:1px;width:1px;position:absolute;overflow:hidden;padding:0;white-space:nowrap;}</style><span id="react-select-3-live-region" class="css-1f43avz-a11yText-A11yText"></span><span aria-live="polite" aria-atomic="false" aria-relevant="additions text" role="log" class="css-1f43avz-a11yText-A11yText"></span><style data-emotion="css 1ddmdm3-control">.css-1ddmdm3-control{-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;cursor:default;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-box-flex-wrap:wrap;-webkit-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;-webkit-box-pack:justify;-webkit-justify-content:space-between;justify-content:space-between;min-height:38px;outline:0!important;position:relative;-webkit-transition:all 100ms;transition:all 100ms;background-color:hsl(0, 0%, 100%);border-color:#dee2e6;border-radius:4px;border-style:solid;border-width:1px;box-shadow:none;box-sizing:border-box;font-size:0.875rem;}.css-1ddmdm3-control:hover{border-color:hsl(0, 0%, 70%);}</style><div class="css-1ddmdm3-control"><style data-emotion="css 16r0gbz">.css-16r0gbz{-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;display:

... [27619 bytes truncated] ...

flex-wrap:wrap;flex-wrap:wrap;-webkit-overflow-scrolling:touch;position:relative;overflow:hidden;padding:0 6px;box-sizing:border-box;}</style><div class="css-16r0gbz"><style data-emotion="css 1qk2bvw-multiValue">.css-1qk2bvw-multiValue{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;min-width:0;background-color:#f2f2f2;border-radius:2px;margin:2px;box-sizing:border-box;}</style><div class="css-1qk2bvw-multiValue"><style data-emotion="css 9jq23d">.css-9jq23d{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;border-radius:2px;color:hsl(0, 0%, 20%);font-size:85%;padding:3px;padding-left:6px;box-sizing:border-box;}</style><div class="css-9jq23d">Broad GCC</div><style data-emotion="css v7duua">.css-v7duua{-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;border-radius:2px;padding-left:4px;padding-right:4px;box-sizing:border-box;}.css-v7duua:hover{background-color:#FFBDAD;color:#DE350B;}</style><div role="button" class="css-v7duua" aria-label="Remove Broad GCC"><style data-emotion="css tj5bde-Svg">.css-tj5bde-Svg{display:inline-block;fill:currentColor;line-height:1;stroke:currentColor;stroke-width:0;}</style><svg height="14" width="14" viewBox="0 0 20 20" aria-hidden="true" focusable="false" class="css-tj5bde-Svg"><path d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"></path></svg></div></div><div class="css-1qk2bvw-multiValue"><div class="css-9jq23d">WashU GCC</div><div role="button" class="css-v7duua" aria-label="Remove WashU GCC"><svg height="14" width="14" viewBox="0 0 20 20" aria-hidden="true" focusable="false" class="css-tj5bde-Svg"><path d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"></path></svg></div></div><style data-emotion="css 1lx7dxn">.css-1lx7dxn{visibility:visible;-webkit-flex:1 1 auto;-ms-flex:1 1 auto;flex:1 1 auto;display:inline-grid;grid-area:1/1/2/3;grid-template-columns:0 min-content;margin:0;padding-bottom:2px;padding-top:2px;color:hsl(0, 0%, 20%);box-sizing:border-box;padding:0;}.css-1lx7dxn:after{content:attr(data-value) " ";visibility:hidden;white-space:pre;grid-area:1/2;font:inherit;min-width:2px;border:0;margin:0;outline:0;padding:0;}</style><div class="css-1lx7dxn" data-value=""><input class="" style="label:input;color:inherit;background:0;opacity:1;width:100%;grid-area:1 / 2;font:inherit;min-width:2px;border:0;margin:0;outline:0;padding:0" autoCapitalize="none" autoComplete="off" autoCorrect="off" id="user-admin-submits-for" spellcheck="false" tabindex="0" type="text" aria-autocomplete="list" aria-expanded="false" aria-haspopup="true" aria-label="Submits for submission centers" role="combobox" aria-activedescendant="" value=""/></div></div><style data-emotion="css 1wy0on6">.css-1wy0on6{-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;-webkit-align-self:stretch;-ms-flex-item-align:stretch;align-self:stretch;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex-shrink:0;-ms-flex-negative:0;flex-shrink:0;box-sizing:border-box;}</style><div class="css-1wy0on6"><style data-emotion="css pogzpp-loadingIndicator">.css-pogzpp-loadingIndicator{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-transition:color 150ms;transition:color 150ms;-webkit-align-self:center;-ms-flex-item-align:center;align-self:center;font-size:4px;line-height:1;margin-right:4px;text-align:center;vertical-align:middle;color:hsl(0, 0%, 80%);padding:8px;box-sizing:border-box;}</style><div class="css-pogzpp-loadingIndicator" aria-hidden="true"><style data-emotion="css 1icxkl9-LoadingDot animation-stj4i2">.css-1icxkl9-LoadingDot{-webkit-animation:animation-stj4i2 1s ease-in-out 0ms infinite;animation:animation-stj4i2 1s ease-in-out 0ms infinite;background-color:currentColor;border-radius:1em;display:inline-block;height:1em;vertical-align:top;width:1em;}@-webkit-keyframes animation-stj4i2{0%,80%,100%{opacity:0;}40%{opacity:1;}}@keyframes animation-stj4i2{0%,80%,100%{opacity:0;}40%{opacity:1;}}</style><span class="css-1icxkl9-LoadingDot"></span><style data-emotion="css 1oazjx7-LoadingDot animation-stj4i2">.css-1oazjx7-LoadingDot{-webkit-animation:animation-stj4i2 1s ease-in-out 160ms infinite;animation:animation-stj4i2 1s ease-in-out 160ms infinite;background-color:currentColor;border-radius:1em;display:inline-block;margin-left:1em;height:1em;vertical-align:top;width:1em;}@-webkit-keyframes animation-stj4i2{0%,80%,100%{opacity:0;}40%{opacity:1;}}@keyframes animation-stj4i2{0%,80%,100%{opacity:0;}40%{opacity:1;}}</style><span class="css-1oazjx7-LoadingDot"></span><style data-emotion="css 1wonz24-LoadingDot animation-stj4i2">.css-1wonz24-LoadingDot{-webkit-animation:animation-stj4i2 1s ease-in-out 320ms infinite;animation:animation-stj4i2 1s ease-in-out 320ms infinite;background-color:currentColor;border-radius:1em;display:inline-block;margin-left:1em;height:1em;vertical-align:top;width:1em;}@-webkit-keyframes animation-stj4i2{0%,80%,100%{opacity:0;}40%{opacity:1;}}@keyframes animation-stj4i2{0%,80%,100%{opacity:0;}40%{opacity:1;}}</style><span class="css-1wonz24-LoadingDot"></span></div><style data-emotion="css 1u9des2-indicatorSeparator">.css-1u9des2-indicatorSeparator{-webkit-align-self:stretch;-ms-flex-item-align:stretch;align-self:stretch;width:1px;background-color:hsl(0, 0%, 80%);margin-bottom:8px;margin-top:8px;box-sizing:border-box;}</style><span class="css-1u9des2-indicatorSeparator"></span><style data-emotion="css 1xc3v61-indicatorContainer">.css-1xc3v61-indicatorContainer{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-transition:color 150ms;transition:color 150ms;color:hsl(0, 0%, 80%);padding:8px;box-sizing:border-box;}.css-1xc3v61-indicatorContainer:hover{color:hsl(0, 0%, 60%);}</style><div class="css-1xc3v61-indicatorContainer" aria-hidden="true"><svg height="20" width="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false" class="css-tj5bde-Svg"><path d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"></path></svg></div></div></div></div></div><div class="mt-3"><button type="button" class="btn btn-primary w-100">Save changes</button></div></div><div class="modal-dialog-faux"><div class="modal-header"><h4 class="modal-title">Confirm user changes</h4></div><div class="modal-body"><p class="text-500">The following changes will be applied to <span class="text-600">jane.smith@example.org</span>:</p><ul class="list-unstyled"><li class="mb-1"><span class="text-500">status</span>: <code>current</code> → <code>revoked</code></li><li class="mb-1"><span class="text-500">groups</span>: <code>dbgap</code> → <code>dbgap, admin</code></li><li class="mb-1"><span class="text-500">submits_for</span>: <code>Broad GCC</code> → <code>Broad GCC, WashU GCC</code></li></ul><div class="alert alert-warning py-2 mb-0"><ul class="mb-0 ps-3"><li>Setting status to &quot;revoked&quot; removes the user&#x27;s access to their profile and data.</li><li>Adding the &quot;admin&quot; group grants full administrative privileges.</li></ul></div></div><div class="modal-footer"><button type="button" class="btn btn-outline-secondary">Cancel</button><button type="button" class="btn btn-primary">Confirm</button></div></div></div></div>
  </div>
</div>
</body></html>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npx jest src/encoded/static/components/__tests__/UserAdminControls.test.js` — 28/28 pass (pure helpers, renderToStaticMarkup render, UserView source-invariant admin gating)</code>
- `Rendered the real UserAdminControls component (real react-select, emotion styles inlined) to static HTML and captured it in Chrome via chrome-devtools-axi (panel + confirmation modal)`
- `Verified worktree has no tracked changes after removing the transient evidence-gen test; node_modules is gitignored`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
