### PR TITLE
260728 upd cr don man 89

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,14 @@ Change Log
 ----------
 
 
+2.6.4
+=====
+
+`PR 733: update bulk donor manifest script to represent 89 as '89+' <https://github.com/smaht-dac/smaht-portal/pull/733>`_
+
+* Handles the case where donor age is 89 and represents it as "89+" in the bulk donor manifest
+* Ensures no newline characters are present in the bulk donor manifest output
+
 2.6.3
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "2.6.3"
+version = "2.6.4"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/commands/create_bulk_donor_manifest.py
+++ b/src/encoded/commands/create_bulk_donor_manifest.py
@@ -166,6 +166,19 @@ CHANGED_COLUMNS = {
 }
 
 
+def _format_capped_age(value: Any) -> Any:
+    """Represent the de-identification age cap (89) as '89+' in manifests."""
+    if value == 89:
+        return "89+"
+    return value
+
+
+VALUE_TRANSFORMS = {
+    "Donor.age": _format_capped_age,
+    "ProtectedDonor.age": _format_capped_age,
+}
+
+
 def create_bulk_donor_manifest(
     output: str,
     auth_key: Dict[str, str],
@@ -440,7 +453,8 @@ def format_value_from_properties(
     ]
     if len(results) > 1:  # multiple items returned from search
         for sub in subcolumns:
-            col = f"{item_type}.{sub}"
+            orig_col = f"{item_type}.{sub}"
+            col = orig_col
             if col in CHANGED_COLUMNS.keys():
                 col = CHANGED_COLUMNS[col]
             values = []
@@ -449,6 +463,8 @@ def format_value_from_properties(
                     value = hit[sub]
                     if type(value) is list:
                         value = ";".join(value)
+                    if orig_col in VALUE_TRANSFORMS:
+                        value = VALUE_TRANSFORMS[orig_col](value)
                     if value or value == 0:
                         values.append(str(value))
                     else:
@@ -458,13 +474,16 @@ def format_value_from_properties(
             donor_manifest.at[idx, col] = "|".join(values)
     elif len(results) == 1:
         for sub in subcolumns:
-            col = f"{item_type}.{sub}"
+            orig_col = f"{item_type}.{sub}"
+            col = orig_col
             if col in CHANGED_COLUMNS.keys():
                 col = CHANGED_COLUMNS[col]
             if sub in results[0]:
                 value = results[0][sub]
                 if type(value) is list:
                     value = ";".join(value)
+                if orig_col in VALUE_TRANSFORMS:
+                    value = VALUE_TRANSFORMS[orig_col](value)
                 if value or value == 0:
                     donor_manifest.at[idx, col] = value
                 else:

--- a/src/encoded/commands/create_bulk_donor_manifest.py
+++ b/src/encoded/commands/create_bulk_donor_manifest.py
@@ -179,6 +179,13 @@ VALUE_TRANSFORMS = {
 }
 
 
+def _sanitize_text_value(value: Any) -> Any:
+    """Collapse embedded newlines so each manifest record stays on one line."""
+    if isinstance(value, str):
+        return value.replace("\r\n", " ").replace("\r", " ").replace("\n", " ")
+    return value
+
+
 def create_bulk_donor_manifest(
     output: str,
     auth_key: Dict[str, str],
@@ -463,6 +470,7 @@ def format_value_from_properties(
                     value = hit[sub]
                     if type(value) is list:
                         value = ";".join(value)
+                    value = _sanitize_text_value(value)
                     if orig_col in VALUE_TRANSFORMS:
                         value = VALUE_TRANSFORMS[orig_col](value)
                     if value or value == 0:
@@ -482,6 +490,7 @@ def format_value_from_properties(
                 value = results[0][sub]
                 if type(value) is list:
                     value = ";".join(value)
+                value = _sanitize_text_value(value)
                 if orig_col in VALUE_TRANSFORMS:
                     value = VALUE_TRANSFORMS[orig_col](value)
                 if value or value == 0:

--- a/src/encoded/tests/test_commands_create_bulk_donor_manifest.py
+++ b/src/encoded/tests/test_commands_create_bulk_donor_manifest.py
@@ -31,3 +31,37 @@ def test_uncapped_age_passed_through_unchanged():
         donor_manifest, 0, "ProtectedDonor", ["ProtectedDonor.age"], [{"age": 65}]
     )
     assert result.at[0, "ProtectedDonor.age"] == 65
+
+
+def test_embedded_newline_replaced_with_space_single_result():
+    donor_manifest = _manifest_with_column("Diagnosis.comments")
+    result = format_value_from_properties(
+        donor_manifest,
+        0,
+        "Diagnosis",
+        ["Diagnosis.comments"],
+        [{"comments": "Family reports patient\nwas previously treating it as an infection"}],
+    )
+    assert result.at[0, "Diagnosis.comments"] == (
+        "Family reports patient was previously treating it as an infection"
+    )
+
+
+def test_embedded_crlf_and_cr_replaced_with_space():
+    donor_manifest = _manifest_with_column("Diagnosis.comments")
+    result = format_value_from_properties(
+        donor_manifest, 0, "Diagnosis", ["Diagnosis.comments"], [{"comments": "line1\r\nline2\rline3"}]
+    )
+    assert result.at[0, "Diagnosis.comments"] == "line1 line2 line3"
+
+
+def test_embedded_newline_replaced_in_multi_result_join():
+    donor_manifest = _manifest_with_column("Diagnosis.comments")
+    result = format_value_from_properties(
+        donor_manifest,
+        0,
+        "Diagnosis",
+        ["Diagnosis.comments"],
+        [{"comments": "first\ncomment"}, {"comments": "second comment"}],
+    )
+    assert result.at[0, "Diagnosis.comments"] == "first comment|second comment"

--- a/src/encoded/tests/test_commands_create_bulk_donor_manifest.py
+++ b/src/encoded/tests/test_commands_create_bulk_donor_manifest.py
@@ -1,0 +1,33 @@
+import pandas as pd
+
+from encoded.commands.create_bulk_donor_manifest import (
+    format_value_from_properties,
+)
+
+
+def _manifest_with_column(column: str) -> pd.DataFrame:
+    return pd.DataFrame(columns=[column], index=[0])
+
+
+def test_capped_age_displayed_as_89_plus_for_protected_donor():
+    donor_manifest = _manifest_with_column("ProtectedDonor.age")
+    result = format_value_from_properties(
+        donor_manifest, 0, "ProtectedDonor", ["ProtectedDonor.age"], [{"age": 89}]
+    )
+    assert result.at[0, "ProtectedDonor.age"] == "89+"
+
+
+def test_capped_age_displayed_as_89_plus_for_public_donor():
+    donor_manifest = _manifest_with_column("Donor.age")
+    result = format_value_from_properties(
+        donor_manifest, 0, "Donor", ["Donor.age"], [{"age": 89}]
+    )
+    assert result.at[0, "Donor.age"] == "89+"
+
+
+def test_uncapped_age_passed_through_unchanged():
+    donor_manifest = _manifest_with_column("ProtectedDonor.age")
+    result = format_value_from_properties(
+        donor_manifest, 0, "ProtectedDonor", ["ProtectedDonor.age"], [{"age": 65}]
+    )
+    assert result.at[0, "ProtectedDonor.age"] == 65


### PR DESCRIPTION
In bulk donor manifest creation script change the value in the age column for those donors who are 89 plus and have their age property set to the integer 89 as per schema constraints to '89+'.

Also add a function to strip newlines out of 'comments' (or any other field) - manifested as a bug when testing - a truncated line and an extra malformatted line were added.

A couple of simple tests for these updates. 