### PR TITLE
fix: 500 on self-registration when no Auth0 email was established

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,19 @@ Change Log
 ----------
 
 
+2.6.5
+=====
+
+`PR 735: fix 500 on self-registration when no Auth0 email was established <https://github.com/smaht-dac/smaht-portal/pull/735>`_
+
+* Fixes an HTTP 500 (``IndexError``) on ``POST /create-unauthorized-user``: the restricted-email
+  check ran ahead of the Auth0 email-match check, so the internal "no auth0 authenticated e-mail
+  supplied" placeholder was passed to ``email_is_not_restricted`` and failed to parse. Callers with
+  no established Auth0 email now get the intended 401.
+* ``email_is_not_restricted`` now refuses an address whose domain cannot be determined with
+  ``HTTPForbidden`` instead of raising ``IndexError``.
+* Restricted domain/email semantics and self-registration privilege stripping are unchanged.
+
 2.6.4
 =====
 

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/willronchetti/.cache/firstmate/node-deps/smaht-portal/470c6be7794b29c89e83bea040be8df6337d88da2beb5e6c30be4297d08e64be/node_modules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "2.6.4"
+version = "2.6.5"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/authentication.py
+++ b/src/encoded/authentication.py
@@ -122,7 +122,13 @@ def email_is_not_restricted(registry, jwt_info, email=None):
             email = jwt_info['email'].lower()
         else:
             raise HTTPForbidden(title="Cannot determine email address - jwt_info is None and no email arg")
-    email_domain = email.split('@')[1]
+    # An address we cannot split into exactly one local part and one domain cannot be evaluated
+    # against the restricted domain/email lists, so it is refused rather than allowed through.
+    # Previously this raised IndexError (surfacing as an HTTP 500) for any value lacking an '@'.
+    email_parts = email.split('@')
+    if len(email_parts) != 2 or not all(email_parts):
+        raise HTTPForbidden(title=f"Cannot determine email domain from {email}")
+    email_domain = email_parts[1]
     if (email_matches_blocked_country(email) or
             email in restricted_emails or email_domain in restricted_emails or
             email_domain in restricted_domains):
@@ -223,13 +229,18 @@ def smaht_create_unauthorized_user(context, request):
 
     user_props = request.json
     user_props_email = user_props.get("email", "<no e-mail supplied>").lower()
-    email_is_not_restricted(request.registry, None, email)
+    # This check must come first: when no Auth0 email could be established above, `email` is a
+    # placeholder string (e.g. "<no auth0 authenticated e-mail supplied>") that this comparison
+    # is designed to reject with a 401. Running the restriction check ahead of it fed that
+    # placeholder to email_is_not_restricted instead. Once this passes, email == user_props_email,
+    # so the restriction check below evaluates exactly the same address either way.
     if user_props_email != email:
         raise HTTPUnauthorized(
             title="Provided email {} not validated with Auth0. Try logging in again.".format(user_props_email),
             headers={
                 'WWW-Authenticate': "Bearer realm=\"{}\"; Basic realm=\"{}\"".format(request.domain, request.domain)}
         )
+    email_is_not_restricted(request.registry, None, email)
 
     # set user insert props
     del user_props['g-recaptcha-response']

--- a/src/encoded/tests/test_authentication.py
+++ b/src/encoded/tests/test_authentication.py
@@ -7,7 +7,7 @@ from pyramid.interfaces import IAuthenticationPolicy
 from pyramid.security import Authenticated, Everyone
 from pyramid.testing import DummyRequest
 from pyramid.threadlocal import manager
-from pyramid.httpexceptions import HTTPForbidden
+from pyramid.httpexceptions import HTTPForbidden, HTTPUnauthorized
 from snovault import COLLECTIONS
 from zope.interface.verify import verifyClass, verifyObject
 from ..authentication import (
@@ -126,6 +126,53 @@ def test_restricted_emails(testapp, email):
         })
 
 
+# email_is_not_restricted only reads these two keys off the registry, so a plain dict is
+# sufficient (this is exactly how encoded.commands.prune_restricted_users calls it) and lets
+# these cases run without the server fixture stack.
+EMPTY_RESTRICTION_REGISTRY = {
+    'RESTRICTED_DOMAINS': set(),
+    'RESTRICTED_EMAILS': set(),
+}
+
+
+@pytest.mark.parametrize('email', [
+    'leon.schuetz@med.uni-tuebingen.de',  # reported address - multi-label domain, not restricted
+    'person@example.org',
+])
+def test_unrestricted_emails_are_allowed(email):
+    """ Valid, unrestricted addresses must pass through the check without raising. """
+    email_is_not_restricted(EMPTY_RESTRICTION_REGISTRY, None, email)
+
+
+@pytest.mark.parametrize('email', [
+    '',  # empty string
+    '<no auth0 authenticated e-mail supplied>',  # placeholder used when Auth0 login is absent
+    '<no e-mail supplied>',  # placeholder used when no email is on the JWT
+    'nodomain',  # no '@' at all
+    'user@',  # no domain part
+    '@example.com',  # no local part
+    'user@one@two.com',  # ambiguous domain
+])
+def test_unparseable_emails_are_forbidden_not_500(email):
+    """ Regression: any value whose domain cannot be determined must be refused via the
+        established HTTPForbidden contract rather than raising IndexError (an HTTP 500).
+    """
+    with pytest.raises(HTTPForbidden):
+        email_is_not_restricted(EMPTY_RESTRICTION_REGISTRY, None, email)
+
+
+def test_restricted_email_still_forbidden_without_fixtures():
+    """ The restriction semantics themselves are unchanged by the parsing hardening. """
+    registry = {
+        'RESTRICTED_DOMAINS': {'restricted.org'},
+        'RESTRICTED_EMAILS': {'blocked@example.com'},
+    }
+    email_is_not_restricted(registry, None, 'fine@example.com')
+    for restricted in ['blocked@example.com', 'anyone@restricted.org', 'person@org.cn']:
+        with pytest.raises(HTTPForbidden):
+            email_is_not_restricted(registry, None, restricted)
+
+
 ATTACKER_EMAIL = 'attacker-self-registration@example.com'
 
 
@@ -187,3 +234,64 @@ def test_create_unauthorized_user_cannot_self_grant_privileges(mock_recaptcha, d
     assert new_user.properties.get('submits_for', []) == []
     assert new_user.properties.get('was_unauthorized') is True
     assert new_user.properties.get('email') == ATTACKER_EMAIL
+
+
+REPORTED_EMAIL = 'leon.schuetz@med.uni-tuebingen.de'
+
+
+@patch('encoded.authentication.redis_is_active', return_value=False)
+@patch('encoded.authentication.app_project')
+def test_create_unauthorized_user_without_auth0_email_is_401_not_500(mock_app_project, mock_redis_active):
+    """ Regression test for an HTTP 500 (IndexError: list index out of range) on
+        POST /create-unauthorized-user.
+
+        When no Auth0 email can be established for the request, the handler falls back to the
+        placeholder string "<no auth0 authenticated e-mail supplied>". That placeholder is meant
+        to be rejected by the `user_props_email != email` comparison with a 401, but the
+        restricted-email check ran ahead of that comparison and tried `placeholder.split('@')[1]`,
+        raising IndexError. The submitted address itself is perfectly valid and never reaches the
+        crash, which is why a report like this one looks like an address-parsing problem.
+
+        This case stops well before any database write, so it is mocked rather than
+        fixture-backed and runs without the server fixture stack.
+    """
+    mock_app_project.return_value.env_allows_auto_registration.return_value = True
+    request = MagicMock()
+    request.json = {
+        'g-recaptcha-response': 'fake-recaptcha-token',
+        'email': REPORTED_EMAIL,
+        'first_name': 'Leon',
+        'last_name': 'Schuetz',
+    }
+    # A MagicMock answers hasattr() for anything, so the attribute is explicitly removed to
+    # reproduce the request shape that produced the 500: no Auth0-authenticated email.
+    del request._auth0_authenticated
+    assert not hasattr(request, '_auth0_authenticated')
+
+    with pytest.raises(HTTPUnauthorized):
+        smaht_create_unauthorized_user(None, request)
+
+
+@patch('encoded.authentication.requests.get')
+def test_create_unauthorized_user_accepts_multi_label_domain(mock_recaptcha, dummy_request):
+    """ The reported (valid, unrestricted) address must reach the normal registration flow. """
+    mock_recaptcha.return_value = MagicMock(json=lambda: {'success': True})
+
+    dummy_request.json = {
+        'g-recaptcha-response': 'fake-recaptcha-token',
+        'email': REPORTED_EMAIL,
+        'first_name': 'Leon',
+        'last_name': 'Schuetz',
+    }
+    dummy_request._auth0_authenticated = REPORTED_EMAIL
+    dummy_request.context = dummy_request.root
+
+    manager.push({'request': dummy_request, 'registry': dummy_request.registry})
+    try:
+        smaht_create_unauthorized_user(None, dummy_request)
+    finally:
+        manager.pop()
+
+    new_user = dummy_request.registry[COLLECTIONS]['User'][REPORTED_EMAIL]
+    assert new_user.properties.get('email') == REPORTED_EMAIL
+    assert new_user.properties.get('was_unauthorized') is True

--- a/src/encoded/tests/test_authentication.py
+++ b/src/encoded/tests/test_authentication.py
@@ -136,7 +136,7 @@ EMPTY_RESTRICTION_REGISTRY = {
 
 
 @pytest.mark.parametrize('email', [
-    'leon.schuetz@med.uni-tuebingen.de',  # reported address - multi-label domain, not restricted
+    'user@dept.example.org',  # multi-label domain, not restricted
     'person@example.org',
 ])
 def test_unrestricted_emails_are_allowed(email):
@@ -236,7 +236,7 @@ def test_create_unauthorized_user_cannot_self_grant_privileges(mock_recaptcha, d
     assert new_user.properties.get('email') == ATTACKER_EMAIL
 
 
-REPORTED_EMAIL = 'leon.schuetz@med.uni-tuebingen.de'
+REPORTED_EMAIL = 'user@dept.example.org'
 
 
 @patch('encoded.authentication.redis_is_active', return_value=False)
@@ -260,8 +260,8 @@ def test_create_unauthorized_user_without_auth0_email_is_401_not_500(mock_app_pr
     request.json = {
         'g-recaptcha-response': 'fake-recaptcha-token',
         'email': REPORTED_EMAIL,
-        'first_name': 'Leon',
-        'last_name': 'Schuetz',
+        'first_name': 'Jane',
+        'last_name': 'Doe',
     }
     # A MagicMock answers hasattr() for anything, so the attribute is explicitly removed to
     # reproduce the request shape that produced the 500: no Auth0-authenticated email.
@@ -280,8 +280,8 @@ def test_create_unauthorized_user_accepts_multi_label_domain(mock_recaptcha, dum
     dummy_request.json = {
         'g-recaptcha-response': 'fake-recaptcha-token',
         'email': REPORTED_EMAIL,
-        'first_name': 'Leon',
-        'last_name': 'Schuetz',
+        'first_name': 'Jane',
+        'last_name': 'Doe',
     }
     dummy_request._auth0_authenticated = REPORTED_EMAIL
     dummy_request.context = dummy_request.root


### PR DESCRIPTION
## Diagnosis

`POST /create-unauthorized-user` returned **HTTP 500 — `IndexError: list index out of range`** from `email_is_not_restricted` at `email.split('@')[1]`.

**The reported address is a red herring.** `user@example.org` splits fine and never reaches the crash. The value being split is the *Auth0-derived* email, not the submitted one.

| | |
|---|---|
| **Trigger** | A request reaches the endpoint with no established Auth0 email. In the non-redis branch the handler falls back to the placeholder `"<no auth0 authenticated e-mail supplied>"` (`authentication.py:191`), which contains no `@`. |
| **Masking condition** | That placeholder is *designed* to be caught by the `user_props_email != email` comparison and answered with a 401. The SMaHT override runs `email_is_not_restricted(...)` **one line ahead** of that comparison, so the placeholder is fed to the splitter first. |
| **Symptom** | `IndexError` → 500, before any domain/email-restriction decision is ever produced. |

### Diagnosis by elimination

`IndexError` at that line requires a non-empty string with no `@`. Walking every way `email` is bound in the handler:

- redis-active branch, missing/None JWT email → `None.lower()` → `AttributeError`, not `IndexError`.
- redis-active branch, dead session token → `None.decode_jwt` → `AttributeError`, not `IndexError`.
- `_auth0_authenticated` explicitly `None` → `email=None`, `jwt_info=None` → the pre-existing `HTTPForbidden` at `authentication.py:124`.
- **`not redis_is_active(request)` with `_auth0_authenticated` unset → the placeholder → `IndexError`.** Only this branch produces the reported symptom.

### Comparison against the proven working path

`smaht_create_unauthorized_user` is an override of `snovault.authentication.create_unauthorized_user`. Upstream (`snovault` as resolved in `poetry.lock`) has the identical placeholder fallback, and immediately follows it with the mismatch check that consumes it:

```python
user_props_email = user_props.get("email", "<no e-mail supplied>").lower()
if user_props_email != email:
    raise HTTPUnauthorized(title="Provided email {} not validated with Auth0. ...")
```

`git log -L 220,235:src/encoded/authentication.py` shows the SMaHT override (`fd843b46 re-implement registration`) copied that upstream body and inserted `email_is_not_restricted(request.registry, None, email)` in front of the mismatch check. That insertion is the regression: it broke upstream's sentinel contract. The recent self-registration security hardening (`0c55bfb8`) touched the field-stripping below this point and is not implicated.

## Fix

Two changes, both in `src/encoded/authentication.py`:

1. **Restore the ordering.** The Auth0 email-match check runs before the restriction check. Once it passes, `email == user_props_email`, so the restriction check evaluates *exactly the same address* as before — restricted emails and domains are rejected identically. The only behavioral delta is for a caller with both a restricted Auth0 email *and* a mismatched body email: 403 → 401. Either way registration is refused. It also stops echoing the internal placeholder string back to the client.

2. **Harden `email_is_not_restricted`.** An address that does not split into exactly one non-empty local part and one non-empty domain is now refused with `HTTPForbidden` — the helper's own existing "cannot determine email address" contract, one line above — rather than raising `IndexError`. This is a deny, not an accept: malformed addresses are never silently allowed through.

Nothing else changed. Domain and explicit-email restriction semantics, the blocked-TLD check, and the self-registration privilege-stripping protections from `0c55bfb8` are untouched.

### Blast radius of change 2

`email_is_not_restricted` has three other callers:

- `session_properties` and `SMAHTAuth0AuthenticationPolicy.unauthenticated_userid` — a malformed email goes from 500 to 403. Strictly better.
- `commands/prune_restricted_users.py` treats `HTTPForbidden` as "restricted → patch status to deleted". A malformed stored email goes from *crashing the entire prune run* to being classified restricted. Stored `User.email` is schema-constrained to `format: email`, so this should be unreachable; the conservative classification is the right default if it ever is not.

## Test evidence

New coverage in `src/encoded/tests/test_authentication.py`. `email_is_not_restricted` only reads two keys off the registry (exactly as `prune_restricted_users` calls it), so the helper cases use a plain dict and need no fixture stack.

**Before the fix** — the new tests reproduce the reported failure:

```
E       IndexError: list index out of range
src/encoded/authentication.py:125: IndexError
  (test_unparseable_emails_are_forbidden_not_500[<no auth0 authenticated e-mail supplied>])

src/encoded/authentication.py:226: in smaht_create_unauthorized_user
E       IndexError: list index out of range
  (test_create_unauthorized_user_without_auth0_email_is_401_not_500)

7 failed, 3 passed
```

**After the fix:**

```
$ pytest src/encoded/tests/test_authentication.py
24 passed, 7 errors     # 7 errors = pre-existing fixture-backed tests, see below
```

Tests added:

| Test | Asserts |
|---|---|
| `test_unrestricted_emails_are_allowed` | `user@example.org` reaches the normal decision and does not raise |
| `test_unparseable_emails_are_forbidden_not_500` | `''`, both placeholder strings, `nodomain`, `user@`, `@example.com`, `user@one@two.com` → `HTTPForbidden`, never `IndexError` |
| `test_restricted_email_still_forbidden_without_fixtures` | restricted email, restricted domain, and blocked-TLD entries still raise; an unrestricted one still passes |
| `test_create_unauthorized_user_without_auth0_email_is_401_not_500` | the endpoint, with no Auth0 email, raises `HTTPUnauthorized` (401) instead of 500 |
| `test_create_unauthorized_user_accepts_multi_label_domain` | the reported address completes normal registration end to end |

`flake8` clean on both files.

**Limitation:** the fixture-backed tests (`test_restricted_emails`, `test_create_unauthorized_user_cannot_self_grant_privileges`, and the new `..._accepts_multi_label_domain`) could not run in this environment — the session fixtures need PostgreSQL/OpenSearch and abort on an expired local AWS SSO token, and `NO_SERVER_FIXTURES=true` makes them error in `conftest.py:93`. They run in CI on this PR. Every case reported as before/after evidence above is fixture-free and was run locally.

## Not fixed here (flagged, out of scope)

`authentication.py:222`, redis-active branch: `jwt_info.get('email', '<no e-mail supplied>').lower()` returns `None` — and then raises `AttributeError` — when the key is present with a `None` value, which lines 220–221 can produce if `redis_session_token.get_email()` returns `None`. That is a separate 500 with a different symptom and a different fix.

Also note: this fix routes an unauthenticated caller to the established 401. It does **not** on its own guarantee the reporter can now register — that still requires a working Auth0 session on the deployment. If `_auth0_authenticated` is systematically unset there, registration will remain blocked, but behind a correct 401 rather than a 500.