### PR TITLE
initial commit of protected donor safeguards

### DIFF
--- a/src/encoded/tests/test_types_protected_donor.py
+++ b/src/encoded/tests/test_types_protected_donor.py
@@ -120,17 +120,36 @@ def test_protected_metadata_accepts_protected_donor(
 
 
 @pytest.mark.workbook
-def test_protected_metadata_donor_check_skips_when_links_are_skipped(
+def test_protected_metadata_donor_check_skips_for_check_only_skip_links(
     es_testapp: TestApp,
     workbook: None,
 ) -> None:
-    """Server validation-only paths use skip_links=true for submitr upgrade compatibility."""
+    """Server validation-only paths use check_only + skip_links for compatibility."""
     body = _protected_metadata_body(
         "DEMOGRAPHIC",
-        "SKIP-LINKS-UNPROTECTED",
+        "CHECK-ONLY-SKIP-LINKS-UNPROTECTED",
         "TEST_DONOR_MALE",
     )
-    es_testapp.post_json("/Demographic?skip_links=true", body, status=201)
+    es_testapp.post_json(
+        "/Demographic?check_only=true&skip_links=true",
+        body,
+        status=200,
+    )
+
+
+@pytest.mark.workbook
+def test_protected_metadata_donor_check_does_not_skip_for_skip_links_write(
+    es_testapp: TestApp,
+    workbook: None,
+) -> None:
+    """skip_links=true alone must not bypass this validator on DB-writing requests."""
+    body = _protected_metadata_body(
+        "DEMOGRAPHIC",
+        "SKIP-LINKS-WRITE-UNPROTECTED",
+        "TEST_DONOR_MALE",
+    )
+    response = es_testapp.post_json("/Demographic?skip_links=true", body, status=422)
+    assert "ProtectedDonor" in str(response.json)
 
 
 @pytest.mark.workbook
@@ -145,7 +164,7 @@ def test_existing_bad_protected_metadata_fails_on_edit_without_skip_links(
         "TEST_DONOR_MALE",
     )
     posted = es_testapp.post_json(
-        "/Demographic?skip_links=true", body, status=201
+        "/Demographic?validate=false", body, status=201
     ).json["@graph"][0]
     response = es_testapp.patch_json(
         posted["@id"],

--- a/src/encoded/tests/test_types_protected_donor.py
+++ b/src/encoded/tests/test_types_protected_donor.py
@@ -6,6 +6,30 @@ from .utils import (
     get_search
 )
 
+
+PROTECTED_METADATA_TYPES = [
+    ("Demographic", "DEMOGRAPHIC", {}),
+    ("DeathCircumstances", "DEATH-CIRCUMSTANCES", {}),
+    (
+        "FamilyHistory",
+        "FAMILY-HISTORY",
+        {"disease": "Pulmonary Fibrosis", "relatives": ["Father"]},
+    ),
+    ("MedicalHistory", "MEDICAL-HISTORY", {}),
+    ("TissueCollection", "TISSUE-COLLECTION", {}),
+]
+
+
+def _protected_metadata_body(item_code, suffix, donor, extra_properties=None):
+    body = {
+        "submitted_id": f"TEST_{item_code}_{suffix}",
+        "submission_centers": ["smaht"],
+        "donor": donor,
+    }
+    if extra_properties:
+        body.update(extra_properties)
+    return body
+
 @pytest.mark.workbook
 def test_medical_history_rev_link(es_testapp: TestApp, workbook: None) -> None:
     """Ensure medical_history rev link works."""
@@ -54,3 +78,84 @@ def test_tissue_collection_rev_link(es_testapp: TestApp, workbook: None) -> None
         "?type=ProtectedDonor&tissue_collection!=No+value"
     )
     assert donor_search
+
+
+@pytest.mark.workbook
+@pytest.mark.parametrize("item_type,item_code,extra_properties", PROTECTED_METADATA_TYPES)
+def test_protected_metadata_rejects_unprotected_donor(
+    es_testapp: TestApp,
+    workbook: None,
+    item_type: str,
+    item_code: str,
+    extra_properties: dict,
+) -> None:
+    """Protected metadata items must not link their donor field to plain Donor."""
+    body = _protected_metadata_body(
+        item_code,
+        f"UNPROTECTED-{item_code}",
+        "TEST_DONOR_MALE",
+        extra_properties,
+    )
+    response = es_testapp.post_json(f"/{item_type}", body, status=422)
+    assert "ProtectedDonor" in str(response.json)
+
+
+@pytest.mark.workbook
+@pytest.mark.parametrize("item_type,item_code,extra_properties", PROTECTED_METADATA_TYPES)
+def test_protected_metadata_accepts_protected_donor(
+    es_testapp: TestApp,
+    workbook: None,
+    item_type: str,
+    item_code: str,
+    extra_properties: dict,
+) -> None:
+    """Protected metadata items can link their donor field to ProtectedDonor."""
+    body = _protected_metadata_body(
+        item_code,
+        f"PROTECTED-{item_code}",
+        "TEST_PROTECTED-DONOR_MALE",
+        extra_properties,
+    )
+    es_testapp.post_json(f"/{item_type}", body, status=201)
+
+
+@pytest.mark.workbook
+def test_protected_metadata_donor_check_skips_when_links_are_skipped(
+    es_testapp: TestApp,
+    workbook: None,
+) -> None:
+    """Server validation-only paths use skip_links=true for submitr upgrade compatibility."""
+    body = _protected_metadata_body(
+        "DEMOGRAPHIC",
+        "SKIP-LINKS-UNPROTECTED",
+        "TEST_DONOR_MALE",
+    )
+    es_testapp.post_json("/Demographic?skip_links=true", body, status=201)
+
+
+@pytest.mark.workbook
+def test_existing_bad_protected_metadata_fails_on_edit_without_skip_links(
+    es_testapp: TestApp,
+    workbook: None,
+) -> None:
+    """Existing protected metadata linked to plain Donor should fail future edits."""
+    body = _protected_metadata_body(
+        "DEMOGRAPHIC",
+        "BAD-EDIT-UNPROTECTED",
+        "TEST_DONOR_MALE",
+    )
+    posted = es_testapp.post_json(
+        "/Demographic?skip_links=true", body, status=201
+    ).json["@graph"][0]
+    response = es_testapp.patch_json(
+        posted["@id"],
+        {"military_association": "Unknown"},
+        status=422,
+    )
+    assert "ProtectedDonor" in str(response.json)
+
+    es_testapp.patch_json(
+        posted["@id"],
+        {"donor": "TEST_PROTECTED-DONOR_MALE"},
+        status=200,
+    )

--- a/src/encoded/types/death_circumstances.py
+++ b/src/encoded/types/death_circumstances.py
@@ -1,7 +1,16 @@
 from snovault import collection, load_schema
+from snovault.util import debug_log
+from pyramid.view import view_config
 from copy import deepcopy
 
-from .submitted_item import SubmittedItem
+from .base import collection_add, item_edit
+from .protected_metadata import validate_donor_is_protected_donor
+from .submitted_item import (
+    SubmittedItem,
+    SUBMITTED_ITEM_ADD_VALIDATORS,
+    SUBMITTED_ITEM_EDIT_PATCH_VALIDATORS,
+    SUBMITTED_ITEM_EDIT_PUT_VALIDATORS,
+)
 from .acl import ONLY_DBGAP_VIEW_ACL, ONLY_PUBLIC_DBGAP_VIEW_ACL
 
 
@@ -33,3 +42,48 @@ class DeathCircumstances(SubmittedItem):
         'protected-network': ONLY_DBGAP_VIEW_ACL,
         'protected': ONLY_PUBLIC_DBGAP_VIEW_ACL
     })
+
+
+validate_death_circumstances_donor_is_protected_donor = validate_donor_is_protected_donor(
+    "DeathCircumstances"
+)
+
+DEATH_CIRCUMSTANCES_ADD_VALIDATORS = SUBMITTED_ITEM_ADD_VALIDATORS + [
+    validate_death_circumstances_donor_is_protected_donor,
+]
+
+DEATH_CIRCUMSTANCES_EDIT_PATCH_VALIDATORS = SUBMITTED_ITEM_EDIT_PATCH_VALIDATORS + [
+    validate_death_circumstances_donor_is_protected_donor,
+]
+
+DEATH_CIRCUMSTANCES_EDIT_PUT_VALIDATORS = SUBMITTED_ITEM_EDIT_PUT_VALIDATORS + [
+    validate_death_circumstances_donor_is_protected_donor,
+]
+
+
+@view_config(
+    context=DeathCircumstances.Collection,
+    permission="add",
+    request_method="POST",
+    validators=DEATH_CIRCUMSTANCES_ADD_VALIDATORS,
+)
+@debug_log
+def death_circumstances_add(context, request, render=None):
+    return collection_add(context, request, render)
+
+
+@view_config(
+    context=DeathCircumstances,
+    permission="edit",
+    request_method="PUT",
+    validators=DEATH_CIRCUMSTANCES_EDIT_PUT_VALIDATORS,
+)
+@view_config(
+    context=DeathCircumstances,
+    permission="edit",
+    request_method="PATCH",
+    validators=DEATH_CIRCUMSTANCES_EDIT_PATCH_VALIDATORS,
+)
+@debug_log
+def death_circumstances_edit(context, request, render=None):
+    return item_edit(context, request, render)

--- a/src/encoded/types/demographic.py
+++ b/src/encoded/types/demographic.py
@@ -1,7 +1,16 @@
 from snovault import collection, load_schema
+from snovault.util import debug_log
+from pyramid.view import view_config
 from copy import deepcopy
 
-from .submitted_item import SubmittedItem
+from .base import collection_add, item_edit
+from .protected_metadata import validate_donor_is_protected_donor
+from .submitted_item import (
+    SubmittedItem,
+    SUBMITTED_ITEM_ADD_VALIDATORS,
+    SUBMITTED_ITEM_EDIT_PATCH_VALIDATORS,
+    SUBMITTED_ITEM_EDIT_PUT_VALIDATORS,
+)
 from .acl import ONLY_DBGAP_VIEW_ACL, ONLY_PUBLIC_DBGAP_VIEW_ACL
 
 
@@ -33,5 +42,50 @@ class Demographic(SubmittedItem):
         'protected-network': ONLY_DBGAP_VIEW_ACL,
         'protected': ONLY_PUBLIC_DBGAP_VIEW_ACL
     })
+
+
+validate_demographic_donor_is_protected_donor = validate_donor_is_protected_donor(
+    "Demographic"
+)
+
+DEMOGRAPHIC_ADD_VALIDATORS = SUBMITTED_ITEM_ADD_VALIDATORS + [
+    validate_demographic_donor_is_protected_donor,
+]
+
+DEMOGRAPHIC_EDIT_PATCH_VALIDATORS = SUBMITTED_ITEM_EDIT_PATCH_VALIDATORS + [
+    validate_demographic_donor_is_protected_donor,
+]
+
+DEMOGRAPHIC_EDIT_PUT_VALIDATORS = SUBMITTED_ITEM_EDIT_PUT_VALIDATORS + [
+    validate_demographic_donor_is_protected_donor,
+]
+
+
+@view_config(
+    context=Demographic.Collection,
+    permission="add",
+    request_method="POST",
+    validators=DEMOGRAPHIC_ADD_VALIDATORS,
+)
+@debug_log
+def demographic_add(context, request, render=None):
+    return collection_add(context, request, render)
+
+
+@view_config(
+    context=Demographic,
+    permission="edit",
+    request_method="PUT",
+    validators=DEMOGRAPHIC_EDIT_PUT_VALIDATORS,
+)
+@view_config(
+    context=Demographic,
+    permission="edit",
+    request_method="PATCH",
+    validators=DEMOGRAPHIC_EDIT_PATCH_VALIDATORS,
+)
+@debug_log
+def demographic_edit(context, request, render=None):
+    return item_edit(context, request, render)
 
 

--- a/src/encoded/types/family_history.py
+++ b/src/encoded/types/family_history.py
@@ -1,7 +1,16 @@
 from snovault import collection, load_schema
+from snovault.util import debug_log
+from pyramid.view import view_config
 from copy import deepcopy
 
-from .submitted_item import SubmittedItem
+from .base import collection_add, item_edit
+from .protected_metadata import validate_donor_is_protected_donor
+from .submitted_item import (
+    SubmittedItem,
+    SUBMITTED_ITEM_ADD_VALIDATORS,
+    SUBMITTED_ITEM_EDIT_PATCH_VALIDATORS,
+    SUBMITTED_ITEM_EDIT_PUT_VALIDATORS,
+)
 from .acl import ONLY_DBGAP_VIEW_ACL, ONLY_PUBLIC_DBGAP_VIEW_ACL
 
 
@@ -33,3 +42,46 @@ class FamilyHistory(SubmittedItem):
         'protected-network': ONLY_DBGAP_VIEW_ACL,
         'protected': ONLY_PUBLIC_DBGAP_VIEW_ACL
     })
+
+
+validate_family_history_donor_is_protected_donor = validate_donor_is_protected_donor("FamilyHistory")
+
+FAMILY_HISTORY_ADD_VALIDATORS = SUBMITTED_ITEM_ADD_VALIDATORS + [
+    validate_family_history_donor_is_protected_donor,
+]
+
+FAMILY_HISTORY_EDIT_PATCH_VALIDATORS = SUBMITTED_ITEM_EDIT_PATCH_VALIDATORS + [
+    validate_family_history_donor_is_protected_donor,
+]
+
+FAMILY_HISTORY_EDIT_PUT_VALIDATORS = SUBMITTED_ITEM_EDIT_PUT_VALIDATORS + [
+    validate_family_history_donor_is_protected_donor,
+]
+
+
+@view_config(
+    context=FamilyHistory.Collection,
+    permission="add",
+    request_method="POST",
+    validators=FAMILY_HISTORY_ADD_VALIDATORS,
+)
+@debug_log
+def family_history_add(context, request, render=None):
+    return collection_add(context, request, render)
+
+
+@view_config(
+    context=FamilyHistory,
+    permission="edit",
+    request_method="PUT",
+    validators=FAMILY_HISTORY_EDIT_PUT_VALIDATORS,
+)
+@view_config(
+    context=FamilyHistory,
+    permission="edit",
+    request_method="PATCH",
+    validators=FAMILY_HISTORY_EDIT_PATCH_VALIDATORS,
+)
+@debug_log
+def family_history_edit(context, request, render=None):
+    return item_edit(context, request, render)

--- a/src/encoded/types/medical_history.py
+++ b/src/encoded/types/medical_history.py
@@ -2,9 +2,18 @@ from typing import List, Union
 from copy import deepcopy
 
 from snovault import collection, load_schema, calculated_property
+from snovault.util import debug_log
 from pyramid.request import Request
+from pyramid.view import view_config
 
-from .submitted_item import SubmittedItem
+from .base import collection_add, item_edit
+from .protected_metadata import validate_donor_is_protected_donor
+from .submitted_item import (
+    SubmittedItem,
+    SUBMITTED_ITEM_ADD_VALIDATORS,
+    SUBMITTED_ITEM_EDIT_PATCH_VALIDATORS,
+    SUBMITTED_ITEM_EDIT_PUT_VALIDATORS,
+)
 from .acl import ONLY_DBGAP_VIEW_ACL, ONLY_PUBLIC_DBGAP_VIEW_ACL
 from ..item_utils.utils import (
     get_property_value_from_identifier,
@@ -94,3 +103,46 @@ class MedicalHistory(SubmittedItem):
     def medical_treatments(self, request: Request) -> Union[List[str], None]:
         result = self.rev_link_atids(request, "medical_treatments")
         return result or None
+
+
+validate_medical_history_donor_is_protected_donor = validate_donor_is_protected_donor("MedicalHistory")
+
+MEDICAL_HISTORY_ADD_VALIDATORS = SUBMITTED_ITEM_ADD_VALIDATORS + [
+    validate_medical_history_donor_is_protected_donor,
+]
+
+MEDICAL_HISTORY_EDIT_PATCH_VALIDATORS = SUBMITTED_ITEM_EDIT_PATCH_VALIDATORS + [
+    validate_medical_history_donor_is_protected_donor,
+]
+
+MEDICAL_HISTORY_EDIT_PUT_VALIDATORS = SUBMITTED_ITEM_EDIT_PUT_VALIDATORS + [
+    validate_medical_history_donor_is_protected_donor,
+]
+
+
+@view_config(
+    context=MedicalHistory.Collection,
+    permission="add",
+    request_method="POST",
+    validators=MEDICAL_HISTORY_ADD_VALIDATORS,
+)
+@debug_log
+def medical_history_add(context, request, render=None):
+    return collection_add(context, request, render)
+
+
+@view_config(
+    context=MedicalHistory,
+    permission="edit",
+    request_method="PUT",
+    validators=MEDICAL_HISTORY_EDIT_PUT_VALIDATORS,
+)
+@view_config(
+    context=MedicalHistory,
+    permission="edit",
+    request_method="PATCH",
+    validators=MEDICAL_HISTORY_EDIT_PATCH_VALIDATORS,
+)
+@debug_log
+def medical_history_edit(context, request, render=None):
+    return item_edit(context, request, render)

--- a/src/encoded/types/protected_metadata.py
+++ b/src/encoded/types/protected_metadata.py
@@ -1,0 +1,70 @@
+from typing import Any, Dict, Optional
+
+from pyramid.request import Request
+from pyramid.settings import asbool
+from snovault import Item
+from snovault.util import get_item_or_none
+
+from .utils import get_properties, get_property_for_validation
+from ..item_utils import item as item_utils
+
+
+PROTECTED_METADATA_DONOR_ERROR = (
+    "Protected metadata items must link their donor field to a ProtectedDonor, "
+    "not an unprotected Donor."
+)
+
+
+def _should_skip_protected_donor_validation(request: Request) -> bool:
+    """Allow submitr/loadxl validation-only paths to defer this link check.
+
+    Server-side workbook validation uses skip_links=true so older submitr clients can
+    validate workbooks before transforming Donor sheets to ProtectedDonor sheets. Actual
+    ingestion does not use skip_links=true and should enforce this privacy invariant.
+    """
+    return asbool(request.params.get("skip_links", False))
+
+
+def _get_donor_identifier_for_validation(context: Item, request: Request) -> Optional[str]:
+    """Get the effective donor identifier for POST/PUT/PATCH validation."""
+    properties_to_update = get_properties(request)
+    if request.method == "POST":
+        return properties_to_update.get("donor")
+    existing_properties = get_properties(context)
+    return get_property_for_validation("donor", existing_properties, properties_to_update)
+
+
+def _get_abstract_donor_item(request: Request, donor_identifier: str) -> Dict[str, Any]:
+    """Resolve a donor identifier to either Donor or ProtectedDonor properties.
+
+    Specific collections are checked before the abstract collection so the resolved
+    item has the concrete @type needed for this validation.
+    """
+    for item_type in ("protected-donors", "donors", "abstract-donors"):
+        donor_item = get_item_or_none(request, donor_identifier, item_type)
+        if donor_item:
+            return donor_item
+    return {}
+
+
+def validate_donor_is_protected_donor(item_type_name: str):
+    """Return a validator requiring protected metadata donor links to ProtectedDonor."""
+
+    def validator(context, request):
+        if _should_skip_protected_donor_validation(request):
+            return
+        donor_identifier = _get_donor_identifier_for_validation(context, request)
+        if not donor_identifier:
+            return
+        donor_item = _get_abstract_donor_item(request, donor_identifier)
+        if not donor_item:
+            return  # Let standard link validation handle missing or invalid references.
+        if item_utils.get_type(donor_item) != "ProtectedDonor":
+            return request.errors.add(
+                "body",
+                f"{item_type_name}: invalid link",
+                PROTECTED_METADATA_DONOR_ERROR,
+            )
+        return request.validated.update({})
+
+    return validator

--- a/src/encoded/types/protected_metadata.py
+++ b/src/encoded/types/protected_metadata.py
@@ -16,13 +16,17 @@ PROTECTED_METADATA_DONOR_ERROR = (
 
 
 def _should_skip_protected_donor_validation(request: Request) -> bool:
-    """Allow submitr/loadxl validation-only paths to defer this link check.
+    """Allow only check-only submitr/loadxl validation to defer this link check.
 
-    Server-side workbook validation uses skip_links=true so older submitr clients can
-    validate workbooks before transforming Donor sheets to ProtectedDonor sheets. Actual
-    ingestion does not use skip_links=true and should enforce this privacy invariant.
+    Server-side workbook validation uses check_only=true with skip_links=true so older
+    submitr clients can validate workbooks before transforming Donor sheets to
+    ProtectedDonor sheets. Actual ingestion must enforce this privacy invariant, even
+    if a caller supplies skip_links=true.
     """
-    return asbool(request.params.get("skip_links", False))
+    return (
+        asbool(request.params.get("skip_links", False))
+        and asbool(request.params.get("check_only", False))
+    )
 
 
 def _get_donor_identifier_for_validation(context: Item, request: Request) -> Optional[str]:

--- a/src/encoded/types/tissue_collection.py
+++ b/src/encoded/types/tissue_collection.py
@@ -1,7 +1,16 @@
 from snovault import collection, load_schema
+from snovault.util import debug_log
+from pyramid.view import view_config
 from copy import deepcopy
 
-from .submitted_item import SubmittedItem
+from .base import collection_add, item_edit
+from .protected_metadata import validate_donor_is_protected_donor
+from .submitted_item import (
+    SubmittedItem,
+    SUBMITTED_ITEM_ADD_VALIDATORS,
+    SUBMITTED_ITEM_EDIT_PATCH_VALIDATORS,
+    SUBMITTED_ITEM_EDIT_PUT_VALIDATORS,
+)
 from .acl import ONLY_DBGAP_VIEW_ACL, ONLY_PUBLIC_DBGAP_VIEW_ACL
 
 
@@ -33,3 +42,46 @@ class TissueCollection(SubmittedItem):
         'protected-network': ONLY_DBGAP_VIEW_ACL,
         'protected': ONLY_PUBLIC_DBGAP_VIEW_ACL
     })
+
+
+validate_tissue_collection_donor_is_protected_donor = validate_donor_is_protected_donor("TissueCollection")
+
+TISSUE_COLLECTION_ADD_VALIDATORS = SUBMITTED_ITEM_ADD_VALIDATORS + [
+    validate_tissue_collection_donor_is_protected_donor,
+]
+
+TISSUE_COLLECTION_EDIT_PATCH_VALIDATORS = SUBMITTED_ITEM_EDIT_PATCH_VALIDATORS + [
+    validate_tissue_collection_donor_is_protected_donor,
+]
+
+TISSUE_COLLECTION_EDIT_PUT_VALIDATORS = SUBMITTED_ITEM_EDIT_PUT_VALIDATORS + [
+    validate_tissue_collection_donor_is_protected_donor,
+]
+
+
+@view_config(
+    context=TissueCollection.Collection,
+    permission="add",
+    request_method="POST",
+    validators=TISSUE_COLLECTION_ADD_VALIDATORS,
+)
+@debug_log
+def tissue_collection_add(context, request, render=None):
+    return collection_add(context, request, render)
+
+
+@view_config(
+    context=TissueCollection,
+    permission="edit",
+    request_method="PUT",
+    validators=TISSUE_COLLECTION_EDIT_PUT_VALIDATORS,
+)
+@view_config(
+    context=TissueCollection,
+    permission="edit",
+    request_method="PATCH",
+    validators=TISSUE_COLLECTION_EDIT_PATCH_VALIDATORS,
+)
+@debug_log
+def tissue_collection_edit(context, request, render=None):
+    return item_edit(context, request, render)


### PR DESCRIPTION
Currently there is nothing safeguarding protected data items from being linked to unprotected Donors.
This PR adds validators for each of the protected item types to ensure that they are linked to ProtectedDonor items upon submission.