### PR TITLE
fix: remove symlink node_modules

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,14 @@ Change Log
 ----------
 
 
+2.6.6
+=====
+
+`PR 738: fix: remove symlink node_modules <https://github.com/smaht-dac/smaht-portal/pull/738>`_
+
+* Remove node_modules symlink
+
+
 2.6.5
 =====
 

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/willronchetti/.cache/firstmate/node-deps/smaht-portal/470c6be7794b29c89e83bea040be8df6337d88da2beb5e6c30be4297d08e64be/node_modules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "2.6.5"
+version = "2.6.6"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
### Summary
`node_modules` was accidentally committed as a symlink in #735 (`git ls-files -s node_modules` showed
mode `120000`, pointing at a local cache path on another machine. `.gitignore`'s `/node_modules/`
pattern only matches directories, not symlinks, so it wasn't caught before merge.

This PR untracks it via `git rm --cached node_modules` - it only removes it from git's index, it does
not touch anyone's local `node_modules` on disk. Anyone who pulls this should end up with a normal,
gitignored `node_modules/` directory instead of the dangling symlink.