### PR TITLE
Fix: Donor x Tissue matrix cells don't dim on click

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,17 @@ Change Log
 ----------
 
 
+2.6.7
+=====
+
+`PR 740: Fix: Donor x Tissue matrix cells don't dim on click <https://github.com/smaht-dac/smaht-portal/pull/740>`_
+
+* Fixes the Data Matrix's Donor x Tissue tab so clicking a cell dims the other cells, matching the
+  existing Donor x Assay / Tissue x Assay behavior.
+* Removes the ``disableBlockOpen`` flag that was preventing ``openBlock`` state from ever being set
+  in Donor x Tissue mode, and the now-dead early-return branch in ``StackedBlockVisual``'s
+  ``handleBlockClick``.
+
 2.6.6
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,19 @@ smaht-portal
 Change Log
 ----------
 
+
+2.7.1
+=====
+
+`PR 740: Fix: Donor x Tissue matrix cells don't dim on click <https://github.com/smaht-dac/smaht-portal/pull/740>`_
+
+* Fixes the Data Matrix's Donor x Tissue tab so clicking a cell dims the other cells, matching the
+  existing Donor x Assay / Tissue x Assay behavior.
+* Removes the ``disableBlockOpen`` flag that was preventing ``openBlock`` state from ever being set
+  in Donor x Tissue mode, and the now-dead early-return branch in ``StackedBlockVisual``'s
+  ``handleBlockClick``.
+
+
 2.7.0
 =====
 
@@ -19,17 +32,6 @@ Change Log
   ``restricted_fields`` permission, and the client-side admin gate is cosmetic. The panel is
   client-rendered only (never in server-rendered output).
 
-
-2.6.7
-=====
-
-`PR 740: Fix: Donor x Tissue matrix cells don't dim on click <https://github.com/smaht-dac/smaht-portal/pull/740>`_
-
-* Fixes the Data Matrix's Donor x Tissue tab so clicking a cell dims the other cells, matching the
-  existing Donor x Assay / Tissue x Assay behavior.
-* Removes the ``disableBlockOpen`` flag that was preventing ``openBlock`` state from ever being set
-  in Donor x Tissue mode, and the now-dead early-return branch in ``StackedBlockVisual``'s
-  ``handleBlockClick``.
 
 2.6.6
 =====

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "2.7.0"
+version = "2.7.1"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encoded"
-version = "2.6.6"
+version = "2.6.7"
 description = "SMaHT Data Analysis Portal"
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/src/encoded/static/components/viz/Matrix/DataMatrix.js
+++ b/src/encoded/static/components/viz/Matrix/DataMatrix.js
@@ -2130,8 +2130,6 @@ export default class DataMatrix extends React.PureComponent {
             showCoverageSummaries: matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE,
             // Donor x Tissue should not expose expand controls.
             disableRowExpand: matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE,
-            // Donor x Tissue blocks are informational; disable click-to-open highlighting/popover selection.
-            disableBlockOpen: matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE,
             isGridRefreshing: isCountToggleRefreshing,
             // Avoid showing the fallback N/A germ-layer band while a donor/tissue refresh is in flight.
             hideFallbackColumnGroupHeader: matrixMode === DataMatrix.MATRIX_MODES.DONOR_TISSUE && isRefreshing,

--- a/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
+++ b/src/encoded/static/components/viz/Matrix/StackedBlockVisual.js
@@ -1721,13 +1721,6 @@ export class StackedBlockVisual extends React.PureComponent {
     };
 
     handleBlockClick = (columnIdx, rowIdx, rowKey, rowGroupKey, summaryRowType = null) => {
-        // Donor x Tissue view keeps blocks non-interactive to avoid accidental "open" white-state styling.
-        if (this.props.disableBlockOpen) {
-            if (this.state.openBlock !== null) {
-                this.setState({ openBlock: null });
-            }
-            return;
-        }
         const openBlock = (columnIdx !== null || rowIdx !== null) ? { columnIdx, rowIdx, rowKey, rowGroupKey, summaryRowType } : null;
         if (openBlock) {
             setTimeout(() => {


### PR DESCRIPTION
## Summary
- Donor x Tissue tab in the Data Matrix didn't dim other cells when a cell was clicked, unlike Donor x Assay and Tissue x Assay. The `disableBlockOpen` flag on `DataMatrix`/`StackedBlockVisual` was preventing `openBlock` state from ever being set for this mode, which is the only thing that triggers the `.has-open-block` dimming CSS.
- The flag was added in a83abb6b1 alongside the fix for the "open cell renders as a blank white box" issue, but that fix (filling the open cell with its real color instead of forcing white) is mode-agnostic and already works correctly for the other two tabs — `disableBlockOpen` for Donor x Tissue was an unnecessary extra guard added in the same commit, not an intentional design choice.
- Removed the flag and the now-dead early-return branch in `handleBlockClick`, so Donor x Tissue now goes through the same click → dim path as the other matrix modes. Popover behavior is unaffected (it's managed independently by `OverlayTrigger`, not by `openBlock`).

## Test plan
- [ ] In Donor x Tissue mode, click a cell and confirm all other cells dim to 30% opacity while the clicked cell (and its row/column labels) stay fully opaque, matching Donor x Assay / Tissue x Assay behavior.
- [ ] Confirm the popover still opens/closes correctly on click in Donor x Tissue mode.
- [ ] Spot-check Donor x Assay and Tissue x Assay tabs to confirm no regression in their existing dim/highlight behavior.
