### PR TITLE
fix: serialize Poetry dependency installation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,8 @@ authoritative files over copied details; use `README.rst` for the longer macOS s
 - `make build` installs frontend dependencies with `npm ci`, builds assets, installs Poetry 1.8.5
   and Python dependencies, and generates local INI files. It also downloads AWS IP ranges and
   restricted-domain data, so it requires network access.
+- `poetry.toml` keeps Poetry's installer serial because Poetry 1.8.5 can race `packaging` while
+  building legacy sdists such as `future`; revisit this when the Poetry bootstrap is upgraded.
 - Start PostgreSQL/OpenSearch/nginx and load local data with `make deploy1`, then serve Pyramid in a
   second terminal with `make deploy2`; the portal is proxied at `http://localhost:8000`. Variants
   `deploy1a`/`deploy1b` separate the ingestion listener for debugging. These commands clear the local

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,2 +1,7 @@
 [virtualenvs]
 create = false
+
+[installer]
+# Poetry 1.8.5 probes the bootstrap environment while building legacy sdists.
+# Serial installs prevent a packaging downgrade from racing that probe.
+parallel = false


### PR DESCRIPTION
## Summary

- Serialize Poetry 1.8.5 dependency installation to avoid the legacy-sdist bootstrap race.
- Keep the existing lockfile, setuptools runtime pin, Poetry version, and supported Python policy unchanged.

## Diagnosis

CI run [31108682450](https://github.com/smaht-dac/smaht-portal/actions/runs/31108682450) failed in `make build` on `ubuntu-22.04` with CPython 3.11.15. Poetry's isolated build for `future` resolved `setuptools 83.0.0`, while its generated tag probe referenced `packaging/tags.py` from the bootstrap environment during a concurrent packaging replacement. The prior run [31107138427](https://github.com/smaht-dac/smaht-portal/actions/runs/31107138427) passed on the same runner and Python version.

Direct builds of `future 0.18.3` succeed with both setuptools 76.1.0 and 83.0.0, so 83.0.0 is not intrinsically incompatible with the package. The lockfile's setuptools dependency cannot constrain `future`'s isolated build-system resolver; `poetry.toml` is the ownership point for serializing Poetry 1.8.5's installer. The setting should be revisited when the Poetry bootstrap is upgraded.

## Validation

- `poetry check --lock`
- `poetry install --no-cache --no-root --only main` after removing `future`, with Poetry 1.8.5 and Python 3.11.9
- Direct `future 0.18.3` builds with setuptools 76.1.0 and 83.0.0
- `git diff --check`
- `make -n build`
